### PR TITLE
Add pantry-aware multi-agent generator and cookbook scaffolding

### DIFF
--- a/agents/cookbook_agents.py
+++ b/agents/cookbook_agents.py
@@ -1,0 +1,197 @@
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List
+
+from openai import OpenAI
+try:
+    from openai.agents import Agent, Handoff, Session
+except ImportError:  # pragma: no cover - fallback for environments without Agents SDK
+    class Agent:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Handoff:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Session:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def run(self, *args, **kwargs):
+            raise RuntimeError("OpenAI Agents SDK not available")
+
+from .tools import (
+    consolidate_shopping_delta,
+    generate_run_id,
+    normalize_ingredient,
+    nutrition_estimate,
+    parse_pantry_input,
+    unit_convert,
+    validate_recipe_json,
+)
+
+OPENAI_KEY = os.getenv("OPENAI_API_KEY")
+client = OpenAI(api_key=OPENAI_KEY) if OPENAI_KEY else None
+
+FAST_MODEL = os.getenv("AGENT_FAST_MODEL", "gpt-4.1-mini")
+REASON_MODEL = os.getenv("AGENT_REASONING_MODEL", "gpt-4.1")
+
+
+router = Agent(
+    name="Cookbook Orchestrator",
+    model=FAST_MODEL,
+    instructions="""
+You coordinate Pantry Parser → Pantry Matcher → Recipe Generator → Substitutions → Nutritionist → QA.
+All dishes are plant-based by default; do not add 'vegan/mock/substitute' prefixes unless requested.
+Emit compact, structured steps; keep titles creative.
+""",
+    tools=[parse_pantry_input, normalize_ingredient, unit_convert],
+    handoffs=[
+        Handoff("PantryParser"),
+        Handoff("PantryMatcher"),
+        Handoff("RecipeGenerator"),
+        Handoff("Substitutions"),
+        Handoff("Nutritionist"),
+        Handoff("QA"),
+    ],
+)
+
+pantry_parser = Agent(
+    name="PantryParser",
+    model=FAST_MODEL,
+    instructions="Parse free-text pantry into normalized items with qty/unit/confidence.",
+    tools=[parse_pantry_input, normalize_ingredient, unit_convert],
+)
+
+pantry_matcher = Agent(
+    name="PantryMatcher",
+    model=FAST_MODEL,
+    instructions="Classify pantry into matches/stretchables/missing; propose 2-3 recipe archetypes.",
+)
+
+recipe_generator = Agent(
+    name="RecipeGenerator",
+    model=REASON_MODEL,
+    instructions="Generate full recipe JSON matching schema; titles are creative; steps concise.",
+    tools=[unit_convert],
+)
+
+substitutions = Agent(
+    name="Substitutions",
+    model=FAST_MODEL,
+    instructions="Suggest functional substitutions only when required; update shopping_delta.",
+)
+
+nutritionist = Agent(
+    name="Nutritionist",
+    model=FAST_MODEL,
+    instructions="Estimate per-serving and total nutrition fields.",
+    tools=[nutrition_estimate],
+)
+
+qa = Agent(
+    name="QA",
+    model=FAST_MODEL,
+    instructions="Validate/repair against JSON Schema and normalize units.",
+    tools=[validate_recipe_json, consolidate_shopping_delta],
+)
+
+AGENTS = {
+    "Router": router,
+    "PantryParser": pantry_parser,
+    "PantryMatcher": pantry_matcher,
+    "RecipeGenerator": recipe_generator,
+    "Substitutions": substitutions,
+    "Nutritionist": nutritionist,
+    "QA": qa,
+}
+
+
+@dataclass
+class SSEEvent:
+    type: str
+    run_id: str
+    stage: str | None = None
+    payload: Dict[str, Any] | None = None
+
+    def to_json(self) -> str:
+        data = {"type": self.type, "run_id": self.run_id}
+        if self.stage:
+            data["stage"] = self.stage
+        if self.payload is not None:
+            data.update(self.payload)
+        return json.dumps(data)
+
+
+def _local_fallback_recipe(user_input: Dict[str, Any]) -> Dict[str, Any]:
+    pantry = parse_pantry_input(user_input.get("pantry", ""))
+    name = "Pantry Skillet Supper"
+    ingredients = {
+        "wet": [{"name": "olive oil", "amount": 2, "units": "tbsp"}],
+        "dry": [{"name": "smoked paprika", "amount": 1, "units": "tsp"}],
+        "other": [{"name": i["name"], "amount": 1, "units": "cup"} for i in pantry[:2]],
+    }
+    instructions = [
+        "Warm oil in a skillet.",
+        "Toss pantry stars with spices.",
+        "Simmer until tender and serve hot.",
+    ]
+    return {
+        "name": name,
+        "description": "Quick plant-based dinner led by your pantry finds.",
+        "prepTime": 10,
+        "cookTime": 20,
+        "servings": 2,
+        "ingredients": ingredients,
+        "instructions": instructions,
+        "notes": "Auto-generated locally because no OpenAI key was present.",
+        "tags": ["pantry", "weeknight"],
+    }
+
+
+def run_pantry_session(user_input: Dict[str, Any], schema: Dict[str, Any] | None = None) -> Iterable[str]:
+    """Yield SSE-ready JSON event strings as the multi-agent run progresses."""
+    run_id = user_input.get("run_id") or generate_run_id()
+    yield SSEEvent(type="status", run_id=run_id, stage="start").to_json()
+    if not OPENAI_KEY or not client:
+        recipe = _local_fallback_recipe(user_input)
+        matches = parse_pantry_input(user_input.get("pantry", ""))
+        recipe.update(
+            {
+                "pantry_matches": matches,
+                "pantry_stretchables": [],
+                "missing_items": [],
+                "shopping_delta": [],
+                "tools_equipment": ["skillet", "knife"],
+                "difficulty": "easy",
+                "prep_time_minutes": 10,
+                "cook_time_minutes": 20,
+                "total_time_minutes": 30,
+                "nutrition": nutrition_estimate([], recipe.get("servings", 2)),
+                "agents_involved": list(AGENTS.keys()),
+                "run_id": run_id,
+                "agent_trace": [{"stage": "local-fallback", "timestamp": time.time()}],
+                "rating": None,
+                "collections": [],
+                "tags": recipe.get("tags", []),
+                "variant_of": None,
+                "version": "1.0",
+            }
+        )
+        if schema:
+            validate_recipe_json(recipe, schema)
+        yield SSEEvent(type="status", run_id=run_id, stage="complete").to_json()
+        yield SSEEvent(type="final", run_id=run_id, payload={"recipe": recipe}).to_json()
+        return
+
+    session = Session(agents=list(AGENTS.values()), metadata={"run_id": run_id})
+    orchestrated = session.run(AGENTS["Router"], input=user_input)
+    for step in orchestrated.stream():
+        yield json.dumps(step)
+    final_recipe = orchestrated.final()
+    if schema:
+        validate_recipe_json(final_recipe, schema)
+    yield SSEEvent(type="final", run_id=run_id, payload={"recipe": final_recipe}).to_json()

--- a/agents/cookbook_agents.py
+++ b/agents/cookbook_agents.py
@@ -2,7 +2,7 @@ import json
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable
 
 from openai import OpenAI
 try:

--- a/agents/tools.py
+++ b/agents/tools.py
@@ -1,0 +1,85 @@
+import json
+import re
+import uuid
+from decimal import Decimal
+from typing import Any, Dict, List
+
+from jsonschema import validate as js_validate
+
+
+def parse_pantry_input(text: str) -> List[Dict[str, Any]]:
+    """Parse free-text pantry into normalized items with qty/unit/confidence."""
+    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    items = []
+    for line in lines:
+        m = re.match(r"(?P<qty>\\d+(\\.\\d+)?)\\s*(?P<unit>[a-zA-Z]+)?\\s+(?P<name>.+)", line)
+        if m:
+            items.append(
+                {
+                    "name": m.group("name"),
+                    "normalized_name": normalize_ingredient(m.group("name")),
+                    "qty": m.group("qty"),
+                    "unit": (m.group("unit") or "").lower(),
+                    "confidence": 0.72,
+                }
+            )
+        else:
+            items.append(
+                {
+                    "name": line,
+                    "normalized_name": normalize_ingredient(line),
+                    "qty": "",
+                    "unit": "",
+                    "confidence": 0.5,
+                }
+            )
+    return items
+
+
+def normalize_ingredient(name: str) -> str:
+    return re.sub(r"\\s+", " ", name.lower()).strip()
+
+
+def unit_convert(qty: float, unit: str, target_unit: str) -> Dict[str, str]:
+    factor = 1.0 if unit == target_unit else 1.0
+    return {"qty": str(qty * factor), "unit": target_unit}
+
+
+def nutrition_estimate(ingredients: List[Dict[str, Any]], servings: int = 2) -> Dict[str, Any]:
+    total = {
+        "calories": 500,
+        "protein_g": 18,
+        "carbs_g": 70,
+        "fat_g": 14,
+        "fiber_g": 12,
+        "sugar_g": 10,
+        "sodium_mg": 800,
+    }
+    per = {k: (v / max(servings, 1)) for k, v in total.items()}
+    return {"per_serving": per, "total": total}
+
+
+def consolidate_shopping_delta(pantry_matches, missing_items) -> List[Dict[str, Any]]:
+    out, idx = [], {}
+    for item in missing_items or []:
+        key = item.get("name", "").lower().strip()
+        if not key:
+            continue
+        if key in idx:
+            try:
+                out[idx[key]]["qty"] = str(Decimal(out[idx[key]]["qty"]) + Decimal(item.get("qty") or "0"))
+            except Exception:
+                pass
+        else:
+            idx[key] = len(out)
+            out.append({"name": item.get("name", ""), "qty": item.get("qty", ""), "unit": item.get("unit", "")})
+    return out
+
+
+def validate_recipe_json(recipe: Dict[str, Any], schema: Dict[str, Any]) -> Dict[str, Any]:
+    js_validate(instance=recipe, schema=schema)
+    return {"valid": True}
+
+
+def generate_run_id() -> str:
+    return str(uuid.uuid4())

--- a/app.py
+++ b/app.py
@@ -58,7 +58,8 @@ os.makedirs(RECIPES_DIR, exist_ok=True)
 # Simple cache for recipe list to avoid reading all files on every request
 _recipes_cache = {'data': None, 'timestamp': 0}
 # Cache TTL (in seconds) for the recipes list. Default is 60s, which balances
-# avoiding frequent disk reads with keeping the list reasonably fresh.
+# TODO: Replace this with a more scalable solution like a database or Redis.
+RUN_PAYLOADS: dict[str, dict] = {}
 _RECIPES_CACHE_TTL = int(os.getenv("RECIPES_CACHE_TTL", "60"))
 RUN_PAYLOADS: dict[str, dict] = {}
 

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import datetime
 import re
 import csv
 import requests
+import uuid
 
 from dotenv import load_dotenv
 from flask import Flask, render_template, abort, request, redirect, url_for, Response, session, jsonify
@@ -14,6 +15,15 @@ import google.oauth2.credentials
 from jsonschema import Draft7Validator, ValidationError
 from auth import auth_bp
 from utils import normalize_recipe_data
+from agents.cookbook_agents import run_pantry_session
+from services.cookbook_service import (
+    attach_recipe_to_cookbook,
+    delete_recipe,
+    list_cookbooks,
+    patch_recipe,
+    save_cookbook,
+    save_recipe,
+)
 
 load_dotenv()
 
@@ -50,6 +60,7 @@ _recipes_cache = {'data': None, 'timestamp': 0}
 # Cache TTL (in seconds) for the recipes list. Default is 60s, which balances
 # avoiding frequent disk reads with keeping the list reasonably fresh.
 _RECIPES_CACHE_TTL = int(os.getenv("RECIPES_CACHE_TTL", "60"))
+RUN_PAYLOADS: dict[str, dict] = {}
 
 
 def _load_recipe_schema():
@@ -965,6 +976,94 @@ def get_jokes():
     except Exception as e:
         print(f"Error loading jokes from {joke_file}: {e}")
         return jsonify([])
+
+
+# Pantry-aware multi-agent workflow
+def _rate_limited(session_id: str, window_seconds: int = 5) -> bool:
+    now = time.time()
+    last = session.get("last_pantry_ts")
+    if last and now - last < window_seconds:
+        return True
+    session["last_pantry_ts"] = now
+    return False
+
+
+def _store_run(run_id: str, payload: dict):
+    RUN_PAYLOADS[run_id] = payload | {"run_id": run_id}
+
+
+def _load_run(run_id: str) -> dict | None:
+    return RUN_PAYLOADS.get(run_id)
+
+
+@app.route("/pantry", methods=["GET"])
+def pantry_page():
+    return render_template("pantry.html")
+
+
+@app.route("/api/pantry/generate", methods=["POST"])
+def pantry_generate():
+    if _rate_limited(session.get("user_id", "anon")):
+        return jsonify({"error": "Too many requests"}), 429
+    payload = request.get_json(force=True) or {}
+    pantry = payload.get("pantry", "").strip()
+    if not pantry:
+        return jsonify({"error": "pantry is required"}), 400
+    run_id = str(uuid.uuid4())
+    _store_run(run_id, {"pantry": pantry, "constraints": payload.get("constraints")})
+    return jsonify({"run_id": run_id, "session_id": session.get("user_id", "anon")})
+
+
+@app.route("/api/pantry/stream/<run_id>")
+def pantry_stream(run_id: str):
+    stored = _load_run(run_id)
+    if not stored:
+        return Response("not found", status=404)
+
+    def event_stream():
+        for evt in run_pantry_session(stored, schema=RECIPE_SCHEMA):
+            yield f"data: {evt}\n\n"
+
+    headers = {
+        "Cache-Control": "no-cache",
+        "Content-Type": "text/event-stream",
+        "Connection": "keep-alive",
+    }
+    return Response(event_stream(), headers=headers)
+
+
+@app.route("/api/cookbook", methods=["GET"])
+def api_cookbook_list():
+    return jsonify(list_cookbooks())
+
+
+@app.route("/cookbook", methods=["GET"])
+def cookbook_page():
+    return render_template("json_viewer.html", recipe={"name": "Cookbooks", "filename": ""}, recipe_json_str=json.dumps(list_cookbooks(), indent=2))
+
+
+@app.route("/api/cookbook/recipes", methods=["POST"])
+def api_cookbook_save_recipe():
+    payload = request.get_json(force=True) or {}
+    recipe = payload.get("recipe")
+    if not recipe:
+        return jsonify({"error": "recipe is required"}), 400
+    saved = save_recipe(recipe)
+    cookbook_id = payload.get("cookbook_id") or "default"
+    attach_recipe_to_cookbook(cookbook_id, saved["id"])
+    return jsonify(saved)
+
+
+@app.route("/api/cookbook/recipes/<recipe_id>", methods=["PATCH", "DELETE"])
+def api_cookbook_modify_recipe(recipe_id: str):
+    if request.method == "DELETE":
+        ok = delete_recipe(recipe_id)
+        return jsonify({"deleted": ok})
+    updates = request.get_json(force=True) or {}
+    updated = patch_recipe(recipe_id, updates)
+    if not updated:
+        return jsonify({"error": "not found"}), 404
+    return jsonify(updated)
 
 
 # --- NEW: Route for generating recipes ---

--- a/cookbook_schema.json
+++ b/cookbook_schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Cookbook",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "title": { "type": "string" },
+    "owner_session_id": { "type": "string" },
+    "collections": { "type": "array", "items": { "type": "string" } },
+    "tags": { "type": "array", "items": { "type": "string" } },
+    "default_preferences": { "type": "object" },
+    "recipes": { "type": "array", "items": { "type": "string" } }
+  },
+  "required": ["id", "title", "owner_session_id"]
+}

--- a/recipe_schema.json
+++ b/recipe_schema.json
@@ -105,8 +105,11 @@
       }
     },
     "notes": {
-      "type": "string",
-      "description": "Optional notes, tips, or variations"
+      "type": ["string", "array"],
+      "description": "Optional notes, tips, or variations",
+      "items": {
+        "type": "string"
+      }
     },
     "tags": {
       "type": "array",
@@ -189,6 +192,66 @@
           "description": "Whether images are currently working/valid"
         }
       }
+    }
+    ,
+    "pantry_matches": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "pantry_stretchables": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "missing_items": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "shopping_delta": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "tools_equipment": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "difficulty": {
+      "type": "string"
+    },
+    "prep_time_minutes": {
+      "type": "integer"
+    },
+    "cook_time_minutes": {
+      "type": "integer"
+    },
+    "total_time_minutes": {
+      "type": "integer"
+    },
+    "nutrition": {
+      "type": "object"
+    },
+    "agents_involved": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "agent_trace": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "rating": {
+      "type": ["number", "null"]
+    },
+    "collections": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "variant_of": {
+      "type": ["string", "null"]
+    },
+    "version": {
+      "type": ["string", "number"]
     }
   },
   "required": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ googleapis-common-protos==1.70.0
 
 # Validation and Data
 jsonschema==4.25.1
+openai==1.59.5
 pydantic==2.12.5
 pydantic-core==2.41.5
 python-dotenv==1.2.1

--- a/services/cookbook_service.py
+++ b/services/cookbook_service.py
@@ -1,0 +1,103 @@
+import json
+import os
+import uuid
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional
+
+COOKBOOK_DIR = "cookbooks"
+RECIPES_DIR = "recipes"
+os.makedirs(COOKBOOK_DIR, exist_ok=True)
+os.makedirs(RECIPES_DIR, exist_ok=True)
+
+
+def _read_json(path: str) -> Dict[str, Any]:
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+        return data
+
+
+def _write_json(path: str, data: Dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def generate_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+@dataclass
+class Cookbook:
+    id: str
+    title: str
+    owner_session_id: str = "anonymous"
+    collections: List[str] | None = None
+    tags: List[str] | None = None
+    default_preferences: Dict[str, Any] | None = None
+    recipes: List[str] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def load_cookbook(cookbook_id: str) -> Optional[Dict[str, Any]]:
+    path = os.path.join(COOKBOOK_DIR, f"{cookbook_id}.json")
+    if not os.path.exists(path):
+        return None
+    return _read_json(path)
+
+
+def list_cookbooks() -> List[Dict[str, Any]]:
+    books = []
+    for fname in os.listdir(COOKBOOK_DIR):
+        if not fname.endswith(".json"):
+            continue
+        books.append(_read_json(os.path.join(COOKBOOK_DIR, fname)))
+    return books
+
+
+def save_cookbook(cookbook: Dict[str, Any]) -> Dict[str, Any]:
+    cid = cookbook.get("id") or generate_id("cookbook")
+    cookbook["id"] = cid
+    path = os.path.join(COOKBOOK_DIR, f"{cid}.json")
+    _write_json(path, cookbook)
+    return cookbook
+
+
+def save_recipe(recipe: Dict[str, Any]) -> Dict[str, Any]:
+    rid = recipe.get("id") or generate_id("recipe")
+    recipe["id"] = rid
+    path = os.path.join(RECIPES_DIR, f"{rid}.json")
+    _write_json(path, recipe)
+    return recipe
+
+
+def delete_recipe(recipe_id: str) -> bool:
+    path = os.path.join(RECIPES_DIR, f"{recipe_id}.json")
+    if os.path.exists(path):
+        os.remove(path)
+        return True
+    return False
+
+
+def patch_recipe(recipe_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    path = os.path.join(RECIPES_DIR, f"{recipe_id}.json")
+    if not os.path.exists(path):
+        return None
+    data = _read_json(path)
+    data.update(updates)
+    _write_json(path, data)
+    return data
+
+
+def attach_recipe_to_cookbook(cookbook_id: str, recipe_id: str) -> None:
+    cb = load_cookbook(cookbook_id)
+    if not cb:
+        cb = Cookbook(id=cookbook_id, title="Untitled").to_dict()
+    recipes = cb.get("recipes") or []
+    if recipe_id not in recipes:
+        recipes.append(recipe_id)
+    cb["recipes"] = recipes
+    save_cookbook(cb)

--- a/static/js/pantry.js
+++ b/static/js/pantry.js
@@ -1,0 +1,50 @@
+(() => {
+  const form = document.getElementById("pantry-form");
+  const logEl = document.getElementById("progress-log");
+  const recipeCard = document.getElementById("recipe-card");
+  const recipeJson = document.getElementById("recipe-json");
+  const saveBtn = document.getElementById("save-recipe-btn");
+  let currentRun = null;
+  let session = null;
+
+  function appendLog(obj) {
+    logEl.textContent += JSON.stringify(obj, null, 2) + "\n";
+  }
+
+  form?.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    logEl.textContent = "";
+    recipeCard.style.display = "none";
+    const pantry = document.getElementById("pantry-text").value;
+    const constraints = document.getElementById("constraints").value;
+    const res = await fetch("/api/pantry/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pantry, constraints }),
+    });
+    const payload = await res.json();
+    currentRun = payload.run_id;
+    session = payload.session_id;
+    const es = new EventSource(`/api/pantry/stream/${currentRun}`);
+    es.onmessage = (ev) => {
+      const data = JSON.parse(ev.data);
+      appendLog(data);
+      if (data.type === "final" && data.recipe) {
+        recipeJson.textContent = JSON.stringify(data.recipe, null, 2);
+        recipeCard.style.display = "block";
+        saveBtn.onclick = () => saveRecipe(data.recipe);
+        es.close();
+      }
+    };
+  });
+
+  async function saveRecipe(recipe) {
+    const res = await fetch("/api/cookbook/recipes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recipe }),
+    });
+    const payload = await res.json();
+    appendLog({ saved: payload.id });
+  }
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,8 @@
 <body>
     <nav class="top-nav">
         <a href="{{ url_for('index') }}">Home</a> | 
-        <a href="{{ url_for('generate_recipe') }}">Generate Recipe</a>
+        <a href="{{ url_for('pantry_page') }}">Pantry-Aware</a> | 
+        <a href="{{ url_for('generate_recipe') }}">Quick Vegan Generator (Legacy)</a>
         {% if session.get('credentials') %}
              | <a href="{{ url_for('auth.profile') }}">Profile</a>
              | <a href="{{ url_for('auth.logout') }}">Logout ({{ session['user_info'].get('name', 'User') }})</a>
@@ -27,7 +28,8 @@
     <hr>
     <nav class="bottom-nav">
         <a href="{{ url_for('index') }}">Home</a> | 
-        <a href="{{ url_for('generate_recipe') }}">Generate Recipe</a>
+        <a href="{{ url_for('pantry_page') }}">Pantry-Aware</a> | 
+        <a href="{{ url_for('generate_recipe') }}">Quick Vegan Generator (Legacy)</a>
     </nav>
 </body>
 </html>

--- a/templates/generate_recipe.html
+++ b/templates/generate_recipe.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Generate a New Recipe{% endblock %}
+{% block title %}Quick Vegan Generator (Legacy){% endblock %}
 
 {% block head %}
 <style>
@@ -114,8 +114,8 @@
 {% endblock %}
 
 {% block content %}
-    <h1>Generate a New Recipe with AI</h1>
-    <p>Enter a description of the recipe you want to create. For example, "a vegan gluten-free chocolate chip cookie recipe."</p>
+    <h1>Quick Vegan Generator (Legacy)</h1>
+    <p>Legacy one-shot generator. All dishes are plant-based by default.</p>
 
     <form id="generate-form" action="{{ url_for('generate_recipe') }}" method="post">
         <div class="model-controls">

--- a/templates/pantry.html
+++ b/templates/pantry.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Pantry-Aware Generator{% endblock %}
+
+{% block content %}
+<h1>Pantry-Aware Multi-Agent Generator</h1>
+<p>All dishes are plant-powered by default. Provide your pantry and constraints to craft a recipe that respects what you have.</p>
+
+<form id="pantry-form">
+  <label for="pantry-text">Pantry items</label><br>
+  <textarea id="pantry-text" name="pantry" rows="6" cols="60" placeholder="e.g., 2 cans chickpeas, 1 tbsp paprika, half onion"></textarea><br>
+  <label for="constraints">Constraints (diet, time, tools)</label><br>
+  <input type="text" id="constraints" name="constraints" placeholder="gluten-free, 30 minutes, one-pot"><br>
+  <button type="submit">Generate</button>
+</form>
+
+<section>
+  <h2>Progress</h2>
+  <pre id="progress-log"></pre>
+</section>
+
+<section id="recipe-card" style="display:none;">
+  <h2>Generated Recipe</h2>
+  <pre id="recipe-json"></pre>
+  <button id="save-recipe-btn">Save to Cookbook</button>
+</section>
+
+<script src="{{ url_for('static', filename='js/pantry.js') }}"></script>
+{% endblock %}

--- a/tests/test_cookbook_service.py
+++ b/tests/test_cookbook_service.py
@@ -1,0 +1,44 @@
+import json
+import os
+import tempfile
+import unittest
+
+from services import cookbook_service as service
+
+
+class TestCookbookService(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        service.COOKBOOK_DIR = os.path.join(self.tmpdir.name, "cookbooks")
+        service.RECIPES_DIR = os.path.join(self.tmpdir.name, "recipes")
+        os.makedirs(service.COOKBOOK_DIR, exist_ok=True)
+        os.makedirs(service.RECIPES_DIR, exist_ok=True)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_save_and_list_cookbook(self):
+        book = {"title": "Weeknight", "owner_session_id": "anon"}
+        saved = service.save_cookbook(book)
+        self.assertIn("id", saved)
+        listed = service.list_cookbooks()
+        self.assertEqual(len(listed), 1)
+
+    def test_save_recipe_and_attach(self):
+        recipe = {"name": "Soup", "prepTime": 1, "cookTime": 1, "servings": 1, "ingredients": {"wet": [], "dry": []}, "instructions": []}
+        saved = service.save_recipe(recipe)
+        service.attach_recipe_to_cookbook("default", saved["id"])
+        cookbook = service.load_cookbook("default")
+        self.assertIn(saved["id"], cookbook["recipes"])
+
+    def test_patch_and_delete(self):
+        recipe = {"name": "Stew", "prepTime": 1, "cookTime": 1, "servings": 1, "ingredients": {"wet": [], "dry": []}, "instructions": []}
+        saved = service.save_recipe(recipe)
+        updated = service.patch_recipe(saved["id"], {"name": "Bright Stew"})
+        self.assertEqual(updated["name"], "Bright Stew")
+        ok = service.delete_recipe(saved["id"])
+        self.assertTrue(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pantry_agents.py
+++ b/tests/test_pantry_agents.py
@@ -1,0 +1,27 @@
+import json
+import unittest
+
+from agents.cookbook_agents import run_pantry_session
+
+
+class TestPantryAgents(unittest.TestCase):
+    def test_local_fallback_stream(self):
+        payload = {"pantry": "1 cup oats\n2 tbsp tahini"}
+        events = list(run_pantry_session(payload))
+        self.assertGreaterEqual(len(events), 2)
+        final = json.loads(events[-1])
+        self.assertEqual(final["type"], "final")
+        self.assertIn("recipe", final)
+        self.assertEqual(final["recipe"]["ingredients"]["wet"][0]["name"], "olive oil")
+
+    def test_schema_fields_present(self):
+        payload = {"pantry": "can tomatoes"}
+        final = json.loads(list(run_pantry_session(payload))[-1])
+        recipe = final["recipe"]
+        self.assertIn("pantry_matches", recipe)
+        self.assertIn("nutrition", recipe)
+        self.assertEqual(recipe["difficulty"], "easy")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add pantry-aware multi-agent pipeline with SSE streaming and cookbook endpoints
- introduce agents/tools scaffolds plus cookbook/recipe persistence schemas and services
- update UI with Pantry-Aware page, navigation rename, and coverage tests for agents and services

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694bddab2c8c83318f11a7e1813bdddc)