### PR TITLE
fix(TAS-8): decouple image_service from Flask request context

### DIFF
--- a/services/image_service.py
+++ b/services/image_service.py
@@ -16,10 +16,31 @@ import json
 import os
 import traceback
 
-from flask import session, url_for
+from flask import has_request_context, session, url_for
 
 from services.gemini_service import get_genai_client
 from utils.session_utils import get_user_metadata
+
+
+def _safe_session_get(key, default=None):
+    """Return a value from Flask's session only when a request context is active.
+
+    This lets the service run in contexts without Flask (unit tests, CLI jobs)
+    without triggering ``RuntimeError: Working outside of request context``.
+    """
+    if not has_request_context():
+        return default
+    return session.get(key, default)
+
+
+def _anonymous_user_metadata():
+    """Default metadata used when no Flask request context is available."""
+    return {
+        "user_id": None,
+        "display_name": None,
+        "is_authenticated": False,
+        "session_id": None,
+    }
 
 
 def generate_ai_image(filepath, recipe_data, filename, force_regenerate=False):
@@ -48,16 +69,21 @@ def generate_ai_image(filepath, recipe_data, filename, force_regenerate=False):
     if force_regenerate and "ai_image_url" in recipe_data:
         del recipe_data["ai_image_url"]
 
-    # Get authenticated client
-    session_credentials = session.get("credentials") if session else None
+    # Get authenticated client (session is only available inside request context)
+    session_credentials = _safe_session_get("credentials")
     client = get_genai_client(session_credentials)
 
     if not client:
         return None, {"error": "No credentials available", "status": 500}
 
     try:
-        # Get comprehensive user metadata
-        user_metadata = get_user_metadata()
+        # Get comprehensive user metadata when available; fall back to
+        # anonymous metadata when called outside of a Flask request context
+        # (e.g. from unit tests or background/CLI jobs).
+        if has_request_context():
+            user_metadata = get_user_metadata()
+        else:
+            user_metadata = _anonymous_user_metadata()
         _ = user_metadata["user_id"]  # noqa: F841
 
         model_to_use = "imagen-4.0-generate-001"

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -42,9 +42,8 @@ class TestImageService(unittest.TestCase):
         self.assertEqual(url, "/static/images/existing.png")
         self.assertIsNone(err)
 
-    @patch("services.image_service.session")
     @patch("services.image_service.get_genai_client")
-    def test_generate_fails_without_client(self, mock_get_client, mock_session):
+    def test_generate_fails_without_client(self, mock_get_client):
         """Should return an error if no Gemini client can be created (no auth)."""
         mock_get_client.return_value = None
 
@@ -54,14 +53,13 @@ class TestImageService(unittest.TestCase):
         self.assertEqual(err["status"], 500)
         self.assertIn("credentials", err["error"].lower())
 
-    @patch("services.image_service.session")
     @patch("services.image_service.get_genai_client")
     @patch("services.image_service.get_user_metadata", return_value=MOCK_USER_METADATA)
     @patch("services.image_service.save_image_file")
     @patch("services.image_service.update_recipe_with_image")
     @patch("builtins.open", new_callable=mock_open)
     def test_successful_generation(
-        self, mock_file_open, mock_update, mock_save, mock_meta, mock_client, mock_session
+        self, mock_file_open, mock_update, mock_save, mock_meta, mock_client
     ):
         """Should complete the entire generation pipeline and save the JSON."""
         # Setup mock client and response
@@ -87,13 +85,10 @@ class TestImageService(unittest.TestCase):
         # Verify file write for the JSON was called
         mock_file_open().write.assert_called()
 
-    @patch("services.image_service.session")
     @patch("services.image_service.get_genai_client")
     @patch("services.image_service.get_user_metadata", side_effect=Exception("Simulated API Crash"))
     @patch("builtins.open", new_callable=mock_open)
-    def test_generation_exception_handling(
-        self, mock_file_open, mock_meta, mock_client, mock_session
-    ):
+    def test_generation_exception_handling(self, mock_file_open, mock_meta, mock_client):
         """Should catch unexpected exceptions, log them, and return a clean 500 error."""
         mock_client.return_value = MagicMock()
 


### PR DESCRIPTION
Assignee: @adamtasteslikegood ([adamschoen3](https://linear.app/tasteslikegood/profiles/adamschoen3))

## Summary

Fixes the three pytest failures in `tests/test_image_service.py` that were reported in [TAS-8](https://linear.app/tasteslikegood/issue/TAS-8/pytest-failing-for-pr67):

- `test_generate_fails_without_client`
- `test_generation_exception_handling`
- `test_successful_generation`

All three failed with `RuntimeError: Working outside of request context.`

## Root cause

`services.image_service.generate_ai_image` touched Flask's request-bound `session` LocalProxy (`session.get("credentials") if session else None`) and called `utils.session_utils.get_user_metadata()` unconditionally. Both require a live request context.

Compounding the bug, the tests tried to neutralise the `session` access with `@patch("services.image_service.session")`, but `unittest.mock`'s `_is_async_obj` calls `hasattr(session, '__func__')` while setting up the patch, which triggers the LocalProxy and raises **before the test body runs** — i.e. the patch decorator itself was the source of the `RuntimeError`.

## Fix (in application code, per the Linear issue)

Decoupled the service from Flask request context instead of pushing a `test_request_context()` around tests:

- Added `_safe_session_get(key, default)` — only reads `session` when `has_request_context()` is true.
- Guarded the `get_user_metadata()` call with `has_request_context()`, falling back to `_anonymous_user_metadata()` (all `None` fields) when invoked outside a request.
- Removed `@patch("services.image_service.session")` from the three tests — no longer needed now that session access is guarded (and was itself the source of the CI failure).

The service now runs cleanly from unit tests, CLI jobs, or background workers without a live request, while still reading real session credentials + metadata in production requests.

## Verification

- Reproduced all three originally failing tests locally (`RuntimeError: Working outside of request context`).
- After the fix: `uv run pytest tests/test_image_service.py -v` — 5/5 pass.
- Full suite: `uv run pytest` — 99/99 pass.
- Manual smoke test: imported and called `generate_ai_image(...)` with no Flask app context at all; returned the expected `(None, {"error": "No credentials available", "status": 500})`.
- `uv run flake8` clean; `uv run black --check` clean; `uv run mypy services/image_service.py --ignore-missing-imports` clean.

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->