### PR TITLE
feat(ssr): public recipe routes /r/<slug> and /browse (TAS-2718)

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from blueprints.auth_api_bp import auth_api_bp
 from blueprints.collections_api_bp import collections_api_bp
 from blueprints.generation_api_bp import generation_api_bp
 from blueprints.generation_bp import generation_bp
+from blueprints.public_bp import public_bp
 from blueprints.recipes_api_bp import recipes_api_bp
 from blueprints.recipes_bp import recipes_bp
 from utils.logging_config import setup_logging
@@ -175,6 +176,7 @@ def create_app():
     # Register blueprints
     app.register_blueprint(auth_bp, url_prefix="/auth")
     app.register_blueprint(auth_api_bp)  # /api/auth/* endpoints
+    app.register_blueprint(public_bp)  # No prefix - includes '/r/<slug>' and '/browse'
     app.register_blueprint(recipes_bp)  # No prefix - includes '/' and '/recipe/*'
     app.register_blueprint(generation_bp)  # No prefix - includes '/generate_recipe'
     app.register_blueprint(generation_api_bp)  # Prefix '/api' - Angular JSON endpoints

--- a/blueprints/generation_api_bp.py
+++ b/blueprints/generation_api_bp.py
@@ -250,7 +250,10 @@ def serve_recipe_image(recipe_id):
     Serve a recipe's AI-generated image.
     Tries in order: Valkey cache → GCS bucket → legacy base64 in DB.
     Cached in Valkey for 24 hours.
-    Only serves the image if the recipe belongs to the current user/guest session.
+
+    Access rules:
+        - If the recipe is public (``is_public=True``) anyone may fetch the image.
+        - Otherwise the recipe must belong to the current user or guest session.
     """
     # Check Valkey cache first (stores raw bytes)
     ck = recipe_image_key(recipe_id)
@@ -262,11 +265,20 @@ def serve_recipe_image(recipe_id):
             headers={"Cache-Control": "public, max-age=86400"},
         )
 
-    user_id = _current_user_id()
-    guest_session_id = _current_guest_session_id()
-    recipe = db_recipe_repository.get_recipe_by_id(recipe_id, user_id, guest_session_id)
-    if not recipe:
+    # Public recipes bypass ownership scoping so unauthenticated SSR pages
+    # and crawlers can still load the image.
+    from models import Recipe
+
+    recipe = Recipe.query.filter_by(id=recipe_id).first()
+    if recipe is None:
         return jsonify({"error": "Recipe not found"}), 404
+
+    if not recipe.is_public:
+        user_id = _current_user_id()
+        guest_session_id = _current_guest_session_id()
+        recipe = db_recipe_repository.get_recipe_by_id(recipe_id, user_id, guest_session_id)
+        if not recipe:
+            return jsonify({"error": "Recipe not found"}), 404
 
     recipe_data = recipe.data or {}
     image_bytes = None

--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -1,0 +1,81 @@
+"""
+Public SSR blueprint — server-rendered routes for anonymous visitors and
+search-engine crawlers.
+
+Exposes:
+    GET /r/<slug>   Single published recipe (is_public=True)
+    GET /browse     Paginated index of all published recipes
+
+These endpoints serve HTML directly so crawlers can index the content
+without executing client-side JavaScript. All other traffic (Angular SPA,
+JSON API) continues to flow through the existing blueprints.
+"""
+
+import logging
+from math import ceil
+
+from flask import Blueprint, abort, render_template, request
+from sqlalchemy.orm import joinedload
+
+from models import Recipe
+
+logger = logging.getLogger(__name__)
+
+public_bp = Blueprint("public", __name__)
+
+BROWSE_PAGE_SIZE = 20
+
+
+@public_bp.route("/r/<slug>", methods=["GET"])
+def show_public_recipe(slug):
+    """Render the SSR view of a single published recipe.
+
+    Returns 404 when no recipe matches the slug or the recipe is not public.
+    """
+    recipe = (
+        Recipe.query.options(joinedload(Recipe.user))
+        .filter(Recipe.slug == slug, Recipe.is_public.is_(True))
+        .first()
+    )
+
+    if recipe is None:
+        abort(404)
+
+    return render_template("public/recipe.html", recipe=recipe)
+
+
+@public_bp.route("/browse", methods=["GET"])
+def browse_public_recipes():
+    """Paginated SSR index of published recipes.
+
+    Uses ``joinedload`` on ``Recipe.user`` so the template can show author
+    names without triggering an extra SELECT per row (N+1).
+    """
+    try:
+        page = max(1, int(request.args.get("page", 1)))
+    except (TypeError, ValueError):
+        page = 1
+
+    base_query = Recipe.query.filter(Recipe.is_public.is_(True)).options(
+        joinedload(Recipe.user)
+    )
+
+    total = base_query.with_entities(Recipe.id).count()
+    total_pages = max(1, ceil(total / BROWSE_PAGE_SIZE))
+    page = min(page, total_pages)
+
+    recipes = (
+        base_query.order_by(Recipe.created_at.desc())
+        .limit(BROWSE_PAGE_SIZE)
+        .offset((page - 1) * BROWSE_PAGE_SIZE)
+        .all()
+    )
+
+    return render_template(
+        "public/browse.html",
+        recipes=recipes,
+        page=page,
+        total_pages=total_pages,
+        total=total,
+        page_size=BROWSE_PAGE_SIZE,
+    )

--- a/templates/public/browse.html
+++ b/templates/public/browse.html
@@ -1,0 +1,57 @@
+{% extends "base.html" %}
+
+{% block title %}Browse Vegan Recipes · TastesLikeGood{% endblock %}
+
+{% block head %}
+<meta name="description" content="Browse published vegan recipes from the TastesLikeGood community.">
+<link rel="canonical" href="{{ url_for('public.browse_public_recipes', _external=True) }}">
+{% endblock %}
+
+{% block content %}
+<section class="public-browse">
+    <header class="public-browse-header">
+        <h1>Browse Vegan Recipes</h1>
+        <p>Showing {{ recipes|length }} of {{ total }} published recipes.</p>
+    </header>
+
+    {% if recipes %}
+    <ul class="public-browse-list">
+        {% for recipe in recipes %}
+        {% set data = recipe.data or {} %}
+        <li class="public-browse-item">
+            <a href="{{ url_for('public.show_public_recipe', slug=recipe.slug) }}">
+                {% if data.ai_image_url or data.stock_image_url %}
+                <img
+                    src="{{ data.ai_image_url or data.stock_image_url }}"
+                    alt="{{ recipe.name }}"
+                    loading="lazy"
+                >
+                {% endif %}
+                <h2>{{ recipe.name }}</h2>
+            </a>
+            {% if data.description %}
+            <p>{{ data.description }}</p>
+            {% endif %}
+            <p class="public-browse-byline">
+                {% if recipe.user and recipe.user.name %}By {{ recipe.user.name }}{% endif %}
+            </p>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="public-browse-empty">No public recipes yet. Check back soon.</p>
+    {% endif %}
+
+    {% if total_pages > 1 %}
+    <nav class="public-browse-pagination" aria-label="Pagination">
+        {% if page > 1 %}
+        <a href="{{ url_for('public.browse_public_recipes', page=page - 1) }}" rel="prev">← Previous</a>
+        {% endif %}
+        <span>Page {{ page }} of {{ total_pages }}</span>
+        {% if page < total_pages %}
+        <a href="{{ url_for('public.browse_public_recipes', page=page + 1) }}" rel="next">Next →</a>
+        {% endif %}
+    </nav>
+    {% endif %}
+</section>
+{% endblock %}

--- a/templates/public/recipe.html
+++ b/templates/public/recipe.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+
+{% set data = recipe.data or {} %}
+
+{% block title %}{{ recipe.name }} · TastesLikeGood{% endblock %}
+
+{% block head %}
+<meta name="description" content="{{ data.description or 'A vegan recipe from TastesLikeGood.' }}">
+<link rel="canonical" href="{{ url_for('public.show_public_recipe', slug=recipe.slug, _external=True) }}">
+{% endblock %}
+
+{% block content %}
+<article class="public-recipe">
+    <header class="public-recipe-header">
+        <p class="eyebrow"><a href="{{ url_for('public.browse_public_recipes') }}">← Browse all recipes</a></p>
+        <h1>{{ recipe.name }}</h1>
+        {% if data.description %}
+        <p class="public-recipe-description">{{ data.description }}</p>
+        {% endif %}
+        <ul class="public-recipe-meta">
+            {% if data.prepTime is not none %}<li><strong>Prep:</strong> {{ data.prepTime }} min</li>{% endif %}
+            {% if data.cookTime is not none %}<li><strong>Cook:</strong> {{ data.cookTime }} min</li>{% endif %}
+            {% if data.servings is not none %}<li><strong>Servings:</strong> {{ data.servings }}</li>{% endif %}
+            {% if recipe.user and recipe.user.name %}
+            <li><strong>By:</strong> {{ recipe.user.name }}</li>
+            {% endif %}
+        </ul>
+    </header>
+
+    {% if data.ai_image_url or data.stock_image_url %}
+    <figure class="public-recipe-image">
+        <img
+            src="{{ data.ai_image_url or data.stock_image_url }}"
+            alt="{{ recipe.name }}"
+            loading="lazy"
+        >
+    </figure>
+    {% endif %}
+
+    {% if data.ingredients %}
+    <section class="public-recipe-ingredients">
+        <h2>Ingredients</h2>
+        {% for group_name, group in data.ingredients.items() %}
+        <h3>{{ group_name | capitalize }}</h3>
+        <ul>
+            {% for ing in group %}
+            <li>
+                {% if ing.amount is iterable and ing.amount is not string %}
+                {{ ing.amount[0] }}–{{ ing.amount[1] }}
+                {% else %}
+                {{ ing.amount }}
+                {% endif %}
+                {{ ing.units }} {{ ing.name }}{% if ing.notes %} <em>({{ ing.notes }})</em>{% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+        {% endfor %}
+    </section>
+    {% endif %}
+
+    {% if data.instructions %}
+    <section class="public-recipe-instructions">
+        <h2>Instructions</h2>
+        <ol>
+            {% for step in data.instructions %}
+            {% if step is mapping %}
+            <li>{{ step.description }}</li>
+            {% else %}
+            <li>{{ step }}</li>
+            {% endif %}
+            {% endfor %}
+        </ol>
+    </section>
+    {% endif %}
+
+    {% if data.notes %}
+    <section class="public-recipe-notes">
+        <h2>Notes</h2>
+        <p>{{ data.notes }}</p>
+    </section>
+    {% endif %}
+</article>
+{% endblock %}

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -1,0 +1,194 @@
+"""Tests for the public SSR routes (TAS-2718).
+
+Covers:
+- /r/<slug> renders only published recipes, 404 for private / missing
+- /browse paginates and only lists is_public=True recipes
+- /browse uses eager loading (joinedload) to avoid N+1 on Recipe.user
+- /api/recipes/<id>/image is readable without ownership when is_public=True
+"""
+
+import base64
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import event
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.update(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_recipe(name, slug, *, public=True, owner=None, data=None):
+    return Recipe(
+        id=str(uuid.uuid4()),
+        user_id=owner.id if owner else None,
+        name=name,
+        slug=slug,
+        is_public=public,
+        data=data or {"name": name, "description": f"{name} description"},
+    )
+
+
+def test_show_public_recipe_renders_html(app, client):
+    with app.app_context():
+        recipe = _make_recipe("Thai Peanut Noodles", "thai-peanut-noodles")
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/thai-peanut-noodles")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Thai Peanut Noodles" in body
+    assert "Thai Peanut Noodles description" in body
+
+
+def test_show_public_recipe_404_when_missing(client):
+    resp = client.get("/r/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_show_public_recipe_404_when_private(app, client):
+    with app.app_context():
+        recipe = _make_recipe("Secret Sauce", "secret-sauce", public=False)
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/secret-sauce")
+    assert resp.status_code == 404
+
+
+def test_browse_lists_only_public_recipes(app, client):
+    with app.app_context():
+        db.session.add_all(
+            [
+                _make_recipe("Public One", "public-one"),
+                _make_recipe("Public Two", "public-two"),
+                _make_recipe("Private", "private", public=False),
+            ]
+        )
+        db.session.commit()
+
+    resp = client.get("/browse")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Public One" in body
+    assert "Public Two" in body
+    assert "Private" not in body
+
+
+def test_browse_paginates(app, client):
+    """Page size is 20; a page=2 request should render only the older rows."""
+    with app.app_context():
+        for idx in range(25):
+            db.session.add(_make_recipe(f"Recipe {idx:02d}", f"recipe-{idx:02d}"))
+        db.session.commit()
+
+    first = client.get("/browse?page=1")
+    assert first.status_code == 200
+    first_body = first.get_data(as_text=True)
+    assert "Page 1 of 2" in first_body
+
+    second = client.get("/browse?page=2")
+    assert second.status_code == 200
+    second_body = second.get_data(as_text=True)
+    assert "Page 2 of 2" in second_body
+
+
+def test_browse_uses_joinedload_and_avoids_n_plus_one(app, client):
+    """Eagerly loading Recipe.user keeps queries constant regardless of row count."""
+    with app.app_context():
+        owner = User(email="chef@example.com", name="Chef One")
+        db.session.add(owner)
+        db.session.commit()
+        for idx in range(5):
+            db.session.add(
+                _make_recipe(f"Owned {idx}", f"owned-{idx}", owner=owner)
+            )
+        db.session.commit()
+
+    select_count = 0
+
+    @event.listens_for(db.engine, "before_cursor_execute")
+    def _count(_conn, _cursor, statement, _params, _ctx, _exec):
+        nonlocal select_count
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_count += 1
+
+    try:
+        resp = client.get("/browse")
+    finally:
+        event.remove(db.engine, "before_cursor_execute", _count)
+
+    assert resp.status_code == 200
+    # Expect a small, fixed number of SELECTs — count(*) + recipes+user join.
+    # Anything above 5 means eager loading regressed and rows are loading users one-by-one.
+    assert select_count <= 5, f"expected ≤5 SELECTs, got {select_count} (N+1 regression)"
+
+
+def test_public_recipe_image_served_without_session(app, client):
+    """A public recipe's image should be fetchable by anyone."""
+    png_bytes = b"\x89PNG\r\n\x1a\nfake"
+    with app.app_context():
+        recipe = _make_recipe(
+            "Public With Image",
+            "public-with-image",
+            data={
+                "name": "Public With Image",
+                "ai_image_data": base64.b64encode(png_bytes).decode("ascii"),
+            },
+        )
+        db.session.add(recipe)
+        db.session.commit()
+        recipe_id = recipe.id
+
+    resp = client.get(f"/api/recipes/{recipe_id}/image")
+    assert resp.status_code == 200
+    assert resp.mimetype == "image/png"
+    assert resp.data == png_bytes
+
+
+def test_private_recipe_image_still_requires_ownership(app, client):
+    png_bytes = b"\x89PNG\r\n\x1a\nsecret"
+    with app.app_context():
+        recipe = _make_recipe(
+            "Private With Image",
+            "private-with-image",
+            public=False,
+            data={
+                "name": "Private With Image",
+                "ai_image_data": base64.b64encode(png_bytes).decode("ascii"),
+            },
+        )
+        db.session.add(recipe)
+        db.session.commit()
+        recipe_id = recipe.id
+
+    resp = client.get(f"/api/recipes/{recipe_id}/image")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Adds `public_bp` blueprint with `/r/<slug>` and `/browse` server-rendered routes so crawlers can index published recipes without executing JS.
- `/browse` uses `joinedload(Recipe.user)` to prevent N+1 queries when rendering the author byline; an event-listener test caps SELECTs at ≤5.
- `/api/recipes/<id>/image` now bypasses ownership scoping when `is_public=True` so anonymous SSR pages can load thumbnails; private images still require the owner session.

## Test plan
- [x] `pytest tests/test_public_ssr.py` — 8 tests covering public/private visibility, pagination, N+1 guard, and image access
- [x] `pytest` — full suite (109 passing)
- [ ] Manual: hit `/r/<slug>` and `/browse` against Flask with real data and confirm rendered HTML