### PR TITLE
fix(mypy): exclude scripts/ + annotate pubsub_service return

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,13 @@ exclude = [
     "debug_generation\\.py",
     "migrations/",
     "workflow_runs/",
+    # `scripts/` is a top-level helpers folder without an __init__.py.
+    # Without exclusion, mypy walks `scripts/backfill_slugs.py` from two
+    # different roots and errors with "Source file found twice under
+    # different module names" because it can't decide whether to treat
+    # the file as `backfill_slugs` or `scripts.backfill_slugs`. The same
+    # exclusion already exists in `.flake8` for the same reason.
+    "scripts/",
 ]
 
 [tool.uv]

--- a/services/pubsub_service.py
+++ b/services/pubsub_service.py
@@ -27,7 +27,7 @@ def publish_message(topic_name: str, data: dict) -> str:
     
     try:
         future = publisher.publish(topic_path, data=data_bytes)
-        message_id = future.result()
+        message_id: str = future.result()
         logger.info(f"Published message {message_id} to {topic_name}")
         return message_id
     except Exception as e:


### PR DESCRIPTION
## Summary

Two issues blocking the **Type Check (mypy)** job on `dev` → `main`:

1. **`scripts/backfill_slugs.py` source-file-found-twice error.** mypy walks the file from two roots (Backend root and `scripts/`) because there's no `__init__.py`, and errors with `Source file found twice under different module names: "backfill_slugs" and "scripts.backfill_slugs"`. Adding `scripts/` to `[tool.mypy].exclude` matches what `.flake8` already does and is the canonical workaround per the [mypy docs](https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules). `scripts/` is a top-level helpers folder (init-DB, backfill, etc.) — not part of the application package — so excluding is correct.

2. **`pubsub_service.publish_message()` `no-any-return`.** Declared `-> str` but returns `future.result()`, which the google-cloud-pubsub stubs type as `Any`. Annotating the local `message_id: str` records the runtime contract without a behavior change (Pub/Sub publish futures resolve to message ID strings).

## Verification

```
$ uv run mypy . --ignore-missing-imports
Success: no issues found in 58 source files
```

## Stack

- `chore(lint): black-format repo, drop unused imports, document the step` (#125) — sibling, no overlap with this PR
- This PR: `fix(mypy): exclude scripts/ + annotate pubsub_service return` ← you are here
- Next: `fix(test): test_backfill_slugs_retry_loop fixture issue` (#118)
- After all three land: re-target #120 and the `Lint`, `Type Check`, `Test` checks pass

## Conflict note

Both this PR and #125 touch `services/pubsub_service.py`, but on different lines (this PR: line 30 type annotation; #125: blank-line whitespace + E302). They should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

