### PR TITLE
fix(tests): bind SQLAlchemy URI before init via create_app overrides (#118)

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,9 +39,17 @@ from utils.session_utils import get_or_create_session_id
 logger = setup_logging()
 
 
-def create_app():
+def create_app(**config_overrides):
     """
     Application factory for creating the Flask app.
+
+    Args:
+        **config_overrides: Flask config values to apply after the default
+            environment-driven config has loaded but before extensions are
+            initialized. Tests use this to bind the SQLAlchemy engine to
+            ``sqlite:///:memory:`` from the start, avoiding a brief window
+            where the engine would otherwise pick up the file-based dev DB
+            from ``config.py`` (issue #118).
 
     Returns:
         Flask: Configured Flask application
@@ -83,6 +91,11 @@ def create_app():
 
     app.config["SQLALCHEMY_DATABASE_URI"] = SQLALCHEMY_DATABASE_URI
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = SQLALCHEMY_TRACK_MODIFICATIONS
+
+    # Apply caller-supplied overrides (e.g. test fixtures binding to
+    # sqlite:///:memory:) before extensions latch on to the URI.
+    if config_overrides:
+        app.config.update(config_overrides)
 
     # Initialize extensions
     from extensions import db, migrate

--- a/tests/test_migration_backfill_slug.py
+++ b/tests/test_migration_backfill_slug.py
@@ -12,12 +12,11 @@ from scripts.backfill_slugs import generate_slug, run_backfill
 
 @pytest.fixture
 def app():
-    app = create_app()
-    app.config.update({
-        "TESTING": True,
-        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"
-    })
-    
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+
     with app.app_context():
         db.create_all()
         yield app

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -25,13 +25,10 @@ from models.user import User  # noqa: E402
 
 @pytest.fixture
 def app():
-    app = create_app()
-    app.config.update(
-        {
-            "TESTING": True,
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
-            "WTF_CSRF_ENABLED": False,
-        }
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
     )
     with app.app_context():
         db.create_all()


### PR DESCRIPTION
## Summary

Resolves #118 — `tests/test_migration_backfill_slug.py::test_backfill_slugs_retry_loop` fails on CI with `table recipe has no column named status`.

The fixture was calling `create_app()` first and *then* updating `SQLALCHEMY_DATABASE_URI` on `app.config`. That leaves a window where Flask-SQLAlchemy can latch onto the file-based dev DB defaulted from `config.py` before the `:memory:` override is visible — once an engine is bound, the later config update is silently ignored, and `db.create_all()` runs against whatever schema that on-disk file already had.

This PR adopts the canonical Flask app-factory pattern:

```python
def create_app(**config_overrides):
    ...
    app.config["SQLALCHEMY_DATABASE_URI"] = SQLALCHEMY_DATABASE_URI
    if config_overrides:
        app.config.update(config_overrides)
    db.init_app(app)
```

The override is applied **before** extension init, so the engine sees `sqlite:///:memory:` from the start. Both test fixtures are updated to use the new signature, so the project converges on one pattern.

## Test plan

- [x] `uv run pytest tests/test_migration_backfill_slug.py::test_backfill_slugs_retry_loop -xvs` — passes locally
- [x] Full `uv run pytest` suite — 109 passed, 0 failed
- [ ] CI Backend pytest job (PR-gate, Python 3.12 + uv) goes green on this PR
- [ ] No regression in `test_public_ssr.py` (also migrated to the new pattern)

## Notes

- `test_public_ssr.py` already worked before this change, but I migrated its fixture too so we don't have two slightly-different fixture patterns floating around.
- `create_app()` keeps its zero-arg behavior, so production entrypoints (`app.py:205` `app = create_app()`, gunicorn, the migrate Job) are unaffected.

Refs: #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)