### PR TITLE
fix(auth): tolerate Google's scope bundling for returning users

### DIFF
--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -21,13 +21,18 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-# Allow OAuth over HTTP for local development
-os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
+# Allow OAuth over HTTP for local development only. In production the request
+# is HTTPS at the edge (Cloud Run) and ProxyFix forwards the scheme, so this
+# flag should never be needed. Use setdefault so an operator can still pin
+# the value explicitly via the runtime environment if needed.
+if os.environ.get("FLASK_ENV") != "production":
+    os.environ.setdefault("OAUTHLIB_INSECURE_TRANSPORT", "1")
 # Tolerate scope set/order differences in Google's token response. Google may
 # bundle previously-granted scopes (e.g. cloud-platform from an earlier consent)
 # into the response and reorder the list; oauthlib raises on any mismatch by
 # default, which fails the callback for returning users with stale grants.
-os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
+# setdefault preserves any explicit value an operator sets in the environment.
+os.environ.setdefault("OAUTHLIB_RELAX_TOKEN_SCOPE", "1")
 
 auth_api_bp = Blueprint("auth_api", __name__, url_prefix="/api/auth")
 

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -23,6 +23,11 @@ logger = logging.getLogger(__name__)
 
 # Allow OAuth over HTTP for local development
 os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
+# Tolerate scope set/order differences in Google's token response. Google may
+# bundle previously-granted scopes (e.g. cloud-platform from an earlier consent)
+# into the response and reorder the list; oauthlib raises on any mismatch by
+# default, which fails the callback for returning users with stale grants.
+os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
 
 auth_api_bp = Blueprint("auth_api", __name__, url_prefix="/api/auth")
 
@@ -96,9 +101,10 @@ def api_login():
         redirect_uri = url_for("auth_api.api_callback", _external=True)
         flow.redirect_uri = redirect_uri
 
-        authorization_url, state = flow.authorization_url(
-            access_type="offline", include_granted_scopes="true"
-        )
+        # Do NOT pass include_granted_scopes="true". We ask for the full scope
+        # set up front (no incremental auth). Bundling previously-granted
+        # scopes into the response trips oauthlib's scope-mismatch check.
+        authorization_url, state = flow.authorization_url(access_type="offline")
         session["state"] = state
         # google-auth-oauthlib auto-generates a PKCE code_verifier and
         # embeds code_challenge in the auth URL. The callback must present

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,0 +1,70 @@
+"""Regression tests for auth_api_bp OAuth scope handling.
+
+Background: Google bundles previously-granted scopes (e.g. cloud-platform
+from a prior consent) into the token response and may reorder the scope
+list. oauthlib raises on any scope set/order mismatch by default, which
+fails the callback for returning users.
+
+Two complementary defenses, both verified here:
+1. /api/auth/login does NOT request include_granted_scopes — we ask for
+   the full scope set up front, so there's no reason to opt into Google's
+   incremental-auth bundling behavior.
+2. OAUTHLIB_RELAX_TOKEN_SCOPE=1 is set at module import time so any
+   residual mismatch (returning user with stale grant) is tolerated.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client-id")
+    os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-client-secret")
+    flask_app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SECRET_KEY="test-secret",
+        SERVER_NAME="testserver",
+    )
+    yield flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_oauthlib_relax_token_scope_env_set_at_import():
+    import blueprints.auth_api_bp  # noqa: F401
+
+    assert os.environ.get("OAUTHLIB_RELAX_TOKEN_SCOPE") == "1"
+
+
+def test_login_does_not_request_include_granted_scopes(client):
+    with patch(
+        "blueprints.auth_api_bp.Flow.authorization_url",
+        return_value=(
+            "https://accounts.google.com/o/oauth2/auth?state=x",
+            "test-state",
+        ),
+    ) as mock_auth_url:
+        resp = client.get("/api/auth/login")
+
+    assert resp.status_code == 200, resp.data
+    assert mock_auth_url.called
+    _, kwargs = mock_auth_url.call_args
+    assert "include_granted_scopes" not in kwargs, (
+        "include_granted_scopes must not be requested — it causes Google to "
+        "bundle previously-granted scopes (e.g. cloud-platform) into the "
+        "response, which trips oauthlib's scope-mismatch check."
+    )
+    assert kwargs.get("access_type") == "offline"


### PR DESCRIPTION
## Summary
- OAuth callback returns 500 `{"error":"Authentication failed"}` for users with prior `cloud-platform` consent. `oauthlib` raises on scope set/order mismatch and Google re-attaches previously-granted scopes.
- Drops `include_granted_scopes="true"` from `/api/auth/login` — we ask for the full scope set up front, so incremental-auth bundling buys nothing and causes the mismatch.
- Sets `OAUTHLIB_RELAX_TOKEN_SCOPE=1` at module import as a defense-in-depth for returning users whose accounts still carry a stale grant.

## Evidence
Cloud Run logs (`flask-backend`, `comdottasteslikegood`) at 2026-05-06T03:08:17 and 02:56:59 show the exact raise site:

```
File "/app/blueprints/auth_api_bp.py", line 147, in api_callback
    flow.fetch_token(authorization_response=authorization_response)
...
oauthlib.oauth2.rfc6749.parameters.validate_token_parameters
ERROR in auth_api_bp: OAuth callback failed:
  Scope has changed from "openid userinfo.email userinfo.profile" to
  "openid userinfo.profile cloud-platform userinfo.email"
```

The user previously consented to `cloud-platform` (likely from an earlier deploy that asked for it before commit `d85e3dd` removed the scope). Google now bundles it back into every token response.

## Test plan
- [x] Added `tests/test_auth_api.py` with two regression checks:
  - `test_oauthlib_relax_token_scope_env_set_at_import` — verifies the env var is set
  - `test_login_does_not_request_include_granted_scopes` — verifies kwargs to `flow.authorization_url`
- [x] Full pytest suite: **111 passed** locally (`uv run pytest`)
- [ ] Cookbook submodule bump PR follows in `tasteslikegoodtheangularsvegancookbook` after this lands
- [ ] Verify in prod by signing in with an affected Google account post-deploy

## Branching
- Off `dev` (per repo policy)
- Cookbook submodule will bump pointer in a separate PR after merge



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

