### PR TITLE
docs(pm): align backend with official Atlassian source-of-truth workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,15 @@ uv run flask db merge -m "..." A B  # unify branched heads
 
 On feature branches, commit and push after every significant work-run so work is recoverable from the remote if the VM/session dies. Stage only intentional files, keep commits scoped, and push immediately after each local commit unless the user explicitly says not to.
 
+## Atlassian source of truth
+
+For repo coordination outside git, use:
+- **Jira KAN** for active execution state and branch/work ownership
+- **Jira RCP** for delivery planning, epics, sprints, and acceptance scope
+- **Confluence TLG** for durable planning/session narrative and documentation
+
+The cookbook repo owns the PM daemon and briefing scripts. Backend work should keep those Atlassian systems current so cross-agent sessions can see accurate project state without relying on local file context.
+
 ## Environment variables
 
 | Var | Purpose |


### PR DESCRIPTION
## Summary
Align Backend repo guidance with the official Atlassian PM workflow used by the cookbook repo.

## What changed
- documents **KAN** as the execution board
- documents **RCP** as the delivery board
- documents **Confluence TLG** as the durable planning/session context source
- clarifies that Backend work should keep those systems current so cross-agent sessions do not depend on local file context

## Why
The backend is part of the same SSR workstream, so its repo guidance needs to match the shared external source-of-truth model.




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

