### PR TITLE
feat: public recipe JSON endpoint + SPA-routed Save CTA

### DIFF
--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -19,7 +19,7 @@ from typing import Any
 from urllib.parse import urlencode
 from xml.etree.ElementTree import Element, SubElement, tostring
 
-from flask import Blueprint, Response, abort, render_template, request, url_for
+from flask import Blueprint, Response, abort, jsonify, render_template, request, url_for
 from sqlalchemy.orm import joinedload
 
 from models import Recipe
@@ -238,9 +238,21 @@ def show_public_recipe(slug):
         description=description,
         recipe_json_ld=_recipe_json_ld(recipe, canonical_url, image_url),
         pinterest_share_url=_pinterest_share_url(canonical_url, image_url, recipe.name),
-        save_recipe_payload=_save_recipe_payload(recipe, image_url),
+        spa_save_url=f"{_public_base_url()}/?save={recipe.slug}#kitchen",
         save_to_cookbook_url=f"{_public_base_url()}/#kitchen",
     )
+
+
+@public_bp.route("/api/recipes/public/<slug>", methods=["GET"])
+def public_recipe_json(slug):
+    """JSON payload of a published recipe for the SPA's ?save=<slug> flow.
+
+    Returns 404 when no recipe matches the slug or the recipe is not public.
+    """
+    recipe = Recipe.query.filter(Recipe.slug == slug, Recipe.is_public.is_(True)).first()
+    if recipe is None:
+        abort(404)
+    return jsonify(_save_recipe_payload(recipe, _recipe_image_url(recipe)))
 
 
 @public_bp.route("/browse", methods=["GET"])

--- a/templates/public/base_public.html
+++ b/templates/public/base_public.html
@@ -100,65 +100,17 @@
                     });
                 }
 
+                // The Save CTA is a plain anchor to /?save=<slug>#kitchen — the
+                // SPA performs the save through its session-aware flow. Add a
+                // small acknowledgement before the navigation happens.
                 const saveButton = document.querySelector('[data-save-recipe]');
-                if (!saveButton) return;
-
-                const recipeScript = document.getElementById('save-recipe-payload');
-                if (!recipeScript) return;
-
-                let recipe;
-                try {
-                    recipe = JSON.parse(recipeScript.textContent || '{}');
-                } catch (_error) {
-                    return;
+                if (saveButton && toast) {
+                    saveButton.addEventListener('click', () => {
+                        saveButton.classList.add('is-saved');
+                        toast.textContent = 'Opening your kitchen…';
+                        toast.hidden = false;
+                    });
                 }
-
-                const SESSION_KEY = 'vegan_genius_session';
-                const getSession = () => {
-                    try {
-                        return JSON.parse(localStorage.getItem(SESSION_KEY) || 'null');
-                    } catch (_error) {
-                        return null;
-                    }
-                };
-
-                const createGuest = () => ({
-                    id:
-                        globalThis.crypto && typeof globalThis.crypto.randomUUID === 'function'
-                            ? globalThis.crypto.randomUUID()
-                            : `guest-${Date.now()}`,
-                    name: 'Guest Chef',
-                    isGuest: true,
-                    authProvider: 'guest',
-                    savedRecipes: [],
-                    cookbooks: [],
-                    deletedRecipes: [],
-                });
-
-                const showToast = (message) => {
-                    if (!toast) return;
-                    toast.textContent = message;
-                    toast.hidden = false;
-                    window.clearTimeout(showToast._timer);
-                    showToast._timer = window.setTimeout(() => {
-                        toast.hidden = true;
-                    }, 2500);
-                };
-
-                saveButton.addEventListener('click', () => {
-                    const session = getSession() || createGuest();
-                    const recipes = Array.isArray(session.savedRecipes) ? session.savedRecipes : [];
-                    const nextRecipes = recipes.filter((entry) => entry.id !== recipe.id);
-                    nextRecipes.push(recipe);
-                    session.savedRecipes = nextRecipes;
-                    if (!Array.isArray(session.cookbooks)) session.cookbooks = [];
-                    if (!Array.isArray(session.deletedRecipes)) session.deletedRecipes = [];
-                    localStorage.setItem(SESSION_KEY, JSON.stringify(session));
-                    saveButton.classList.add('is-saved');
-                    saveButton.textContent = 'Saved — opening kitchen';
-                    showToast('Saved to your cookbook');
-                    window.setTimeout(openKitchen, 350);
-                });
             })();
         </script>
     </body>

--- a/templates/public/recipe.html
+++ b/templates/public/recipe.html
@@ -28,7 +28,6 @@
 {% endif %}
 
 <script type="application/ld+json">{{ recipe_json_ld | tojson(indent=2) }}</script>
-<script type="application/json" id="save-recipe-payload">{{ save_recipe_payload | tojson }}</script>
 {% endblock %}
 
 {% block content %}
@@ -67,9 +66,12 @@
                 {% if recipe.user and recipe.user.name %}<li>By {{ recipe.user.name }}</li>{% endif %}
             </ul>
             <div class="public-recipe-actions">
-                <button type="button" class="public-save-cta" data-save-recipe>
+                {# Plain anchor: the SPA's ?save= flow fetches the recipe from
+                   /api/recipes/public/<slug> and saves it through the hardened
+                   session-aware path (fresh id, image fields, auth-race guard). #}
+                <a href="{{ spa_save_url }}" class="public-save-cta" data-save-recipe>
                     Save to your cookbook
-                </button>
+                </a>
                 <a href="{{ pinterest_share_url }}" target="_blank" rel="noopener noreferrer" class="public-recipe-action-link" aria-label="Share {{ recipe.name }} on Pinterest">
                     Save to Pinterest
                 </a>

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -267,3 +267,53 @@ def test_private_recipe_image_still_requires_ownership(app, client):
 
     resp = client.get(f"/api/recipes/{recipe_id}/image")
     assert resp.status_code == 404
+
+
+def test_public_recipe_json_returns_save_payload(app, client):
+    with app.app_context():
+        recipe = _make_recipe(
+            "Thai Peanut Noodles",
+            "thai-peanut-noodles",
+            data={
+                "name": "Thai Peanut Noodles",
+                "description": "Creamy noodles",
+                "prepTime": 10,
+                "cookTime": 20,
+                "servings": 4,
+                "ingredients": {"wet": [], "dry": [], "other": []},
+                "instructions": ["Boil noodles"],
+                "tags": ["thai"],
+                "stock_image_url": "https://img.example/stock.jpg",
+            },
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/api/recipes/public/thai-peanut-noodles")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/json"
+    payload = resp.get_json()
+    assert payload["name"] == "Thai Peanut Noodles"
+    assert payload["description"] == "Creamy noodles"
+    assert payload["instructions"] == ["Boil noodles"]
+    assert payload["stock_image_url"] == "https://img.example/stock.jpg"
+
+
+def test_public_recipe_json_404_for_private_or_missing(app, client):
+    with app.app_context():
+        db.session.add(_make_recipe("Secret Stew", "secret-stew", public=False))
+        db.session.commit()
+
+    assert client.get("/api/recipes/public/secret-stew").status_code == 404
+    assert client.get("/api/recipes/public/never-existed").status_code == 404
+
+
+def test_public_recipe_page_links_save_cta_to_spa_save_url(app, client):
+    with app.app_context():
+        recipe = _make_recipe("Thai Peanut Noodles", "thai-peanut-noodles")
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/thai-peanut-noodles")
+    body = resp.get_data(as_text=True)
+    assert "/?save=thai-peanut-noodles#kitchen" in body


### PR DESCRIPTION
Closes the release-blocking gap found by /review on cookbook release PR #3030: the SPA's `?save=<slug>` flow calls `GET /api/recipes/public/<slug>`, which did not exist, and the public pages' Save CTA bypassed the SPA entirely with an inline localStorage write (original id + slug + is_public → wiped by stale-session cleanup, can never sync server-side).

- **`GET /api/recipes/public/<slug>`** — returns `_save_recipe_payload()` JSON (the SSR pages already build this payload), 404 for private/missing slugs. Lives in `public_bp` next to the rest of the public surface; no auth required by design.
- **CTA → plain anchor** to `/?save=<slug>#kitchen` (server-rendered, works without JS); the SPA's session-aware save flow (fresh id, image fields preserved, auth-race guarded — cookbook #3031) takes over from there. The inline localStorage script is deleted.
- TDD: 3 new tests watched fail first; full suite 116/116.

Companion cookbook PR will bump the submodule pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

