### PR TITLE
fix: retry async recipe generation on malformed model JSON; report real errors

### DIFF
--- a/blueprints/generation_bp.py
+++ b/blueprints/generation_bp.py
@@ -150,12 +150,15 @@ def attempt_recipe_generation(full_prompt, selected_model):  # noqa: C901
                 # Validate against schema
                 if not validate_recipe_data(data):
                     print(f"Validation failed for {source_name}")
-                    return None, None
+                    raise ValueError("Generated recipe failed schema validation")
 
                 return data, text_response
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as e:
                 print(f"JSON Decode Error for {source_name}: {text_response[:100]}...")
-                return None, None
+                raise ValueError(
+                    f"Model returned invalid JSON "
+                    f"(likely truncated, {len(text_response)} chars): {e}"
+                ) from e
 
         except Exception as e:
             print(f"Generation error with {source_name}: {e}")

--- a/blueprints/generation_bp.py
+++ b/blueprints/generation_bp.py
@@ -15,6 +15,7 @@ import time
 import google.oauth2.credentials  # noqa: F401
 from flask import Blueprint, redirect, render_template, request, session, url_for
 from google.genai import Client
+from jsonschema import ValidationError
 
 from config import (
     CONFIG,
@@ -147,10 +148,16 @@ def attempt_recipe_generation(full_prompt, selected_model):  # noqa: C901
                 # Normalize data to handle typos and variations
                 data = normalize_recipe_data(data)
 
-                # Validate against schema
-                if not validate_recipe_data(data):
-                    print(f"Validation failed for {source_name}")
-                    raise ValueError("Generated recipe failed schema validation")
+                # Validate against schema — validate_recipe_data raises
+                # ValidationError (it never returns False), so surface it
+                # with a clear cause instead of a generic error label.
+                try:
+                    validate_recipe_data(data)
+                except ValidationError as e:
+                    print(f"Validation failed for {source_name}: {e}")
+                    raise ValueError(
+                        f"Generated recipe failed schema validation: {e}"
+                    ) from e
 
                 return data, text_response
             except json.JSONDecodeError as e:

--- a/blueprints/worker_api_bp.py
+++ b/blueprints/worker_api_bp.py
@@ -31,7 +31,18 @@ PUBSUB_AUTH_OPTIONAL = os.environ.get("PUBSUB_AUTH_OPTIONAL", "0") == "1"
 # In-process retries for one push message. Each attempt is a fresh model call
 # (~10-25 s); 3 attempts stays well inside the Cloud Run request timeout and
 # the push subscription's ack deadline.
-GENERATION_MAX_ATTEMPTS = int(os.environ.get("GENERATION_MAX_ATTEMPTS", "3"))
+def _parse_max_attempts(raw, default=3):
+    """Parse the retry budget defensively: a misconfigured env var must not
+    break blueprint import, and anything below 1 would skip generation
+    entirely."""
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(f"Invalid GENERATION_MAX_ATTEMPTS {raw!r}; using {default}")
+        return default
+    return max(1, value)
+
+GENERATION_MAX_ATTEMPTS = _parse_max_attempts(os.environ.get("GENERATION_MAX_ATTEMPTS", "3"))
 
 def require_pubsub_oidc(fn):
     @wraps(fn)

--- a/blueprints/worker_api_bp.py
+++ b/blueprints/worker_api_bp.py
@@ -28,6 +28,11 @@ worker_api_bp = Blueprint('worker_api_bp', __name__, url_prefix='/api/worker')
 PUBSUB_INVOKER_SA = os.environ.get("PUBSUB_INVOKER_SA")
 PUBSUB_AUTH_OPTIONAL = os.environ.get("PUBSUB_AUTH_OPTIONAL", "0") == "1"
 
+# In-process retries for one push message. Each attempt is a fresh model call
+# (~10-25 s); 3 attempts stays well inside the Cloud Run request timeout and
+# the push subscription's ack deadline.
+GENERATION_MAX_ATTEMPTS = int(os.environ.get("GENERATION_MAX_ATTEMPTS", "3"))
+
 def require_pubsub_oidc(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):
@@ -83,9 +88,24 @@ def process_recipe():
 
     try:
         full_prompt = build_generation_prompt(prompt)
-        recipe_data, recipe_json_str, last_error = attempt_recipe_generation(
-            full_prompt, selected_model
-        )
+
+        # The model intermittently returns malformed/truncated JSON (a single
+        # bad sample at temperature 0.7); a fresh attempt usually succeeds, so
+        # retry in-process rather than surfacing an error status the user has
+        # to retry by hand.
+        recipe_data = None
+        recipe_json_str = None
+        last_error = None
+        for attempt in range(1, GENERATION_MAX_ATTEMPTS + 1):
+            recipe_data, recipe_json_str, last_error = attempt_recipe_generation(
+                full_prompt, selected_model
+            )
+            if recipe_data:
+                break
+            logger.warning(
+                f"Recipe generation attempt {attempt}/{GENERATION_MAX_ATTEMPTS} "
+                f"failed for {recipe_id}: {last_error}"
+            )
 
         if not recipe_data:
             logger.error(f"Recipe generation failed for {recipe_id}: {last_error}")

--- a/tests/test_worker_generation_retry.py
+++ b/tests/test_worker_generation_retry.py
@@ -161,3 +161,55 @@ def test_invalid_json_sets_real_error_message(app):
     assert raw_json is None
     assert last_error != "Unknown error"
     assert "invalid JSON" in last_error
+
+
+def test_schema_validation_failure_sets_real_error_message(app):
+    """Schema failures must surface the ValidationError cause, not
+    'Unknown error' (validate_recipe_data raises; it never returns False)."""
+    from jsonschema import ValidationError
+
+    from blueprints import generation_bp
+
+    class FakeModels:
+        def generate_content(self, **kwargs):
+            class FakeResponse:
+                text = json.dumps(VALID_RECIPE)
+
+            return FakeResponse()
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.models = FakeModels()
+
+    with app.test_request_context("/api/generate"), patch.object(
+        generation_bp, "Client", FakeClient
+    ), patch.object(generation_bp, "GOOGLE_API_KEY", "fake-key"), patch.object(
+        generation_bp,
+        "validate_recipe_data",
+        side_effect=ValidationError("'name' is a required property"),
+    ):
+        recipe_data, raw_json, last_error = generation_bp.attempt_recipe_generation(
+            "make peach salsa", "gemini-3.1-pro-preview"
+        )
+
+    assert recipe_data is None
+    assert last_error != "Unknown error"
+    assert "schema validation" in last_error
+    assert "required property" in last_error
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("3", 3),
+        ("5", 5),
+        ("0", 1),  # clamp: below 1 would skip generation entirely
+        ("-2", 1),
+        ("not-a-number", 3),  # bad env var must not break import
+        (None, 3),
+    ],
+)
+def test_parse_max_attempts_is_defensive(raw, expected):
+    from blueprints.worker_api_bp import _parse_max_attempts
+
+    assert _parse_max_attempts(raw) == expected

--- a/tests/test_worker_generation_retry.py
+++ b/tests/test_worker_generation_retry.py
@@ -1,0 +1,163 @@
+"""Regression tests for async recipe-generation robustness.
+
+Production incident 2026-07-04: gemini-3.1-pro-preview intermittently returned
+malformed/truncated JSON. The worker made a single attempt, marked the recipe
+status "error" (surfacing "generation failed during async processing" in the
+SPA), and logged only "Unknown error" because the JSONDecodeError path in
+attempt_recipe_generation never set an error message.
+
+Covers:
+- worker retries a failed generation attempt before marking status "error"
+- worker marks status "error" only after all attempts fail
+- attempt_recipe_generation reports a real error message for invalid JSON
+  instead of "Unknown error"
+"""
+
+import base64
+import json
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def _skip_pubsub_auth(monkeypatch):
+    """Bypass OIDC verification — these tests exercise the handler body."""
+    monkeypatch.setattr("blueprints.worker_api_bp.PUBSUB_AUTH_OPTIONAL", True)
+
+
+VALID_RECIPE = {
+    "name": "Fresh Peach Salsa",
+    "description": "A sweet and spicy salsa.",
+    "ingredients": [],
+    "instructions": [],
+}
+
+
+def _push_envelope(recipe_id):
+    payload = {
+        "recipe_id": recipe_id,
+        "prompt": "peach salsa",
+        "model": "gemini-3.1-pro-preview",
+        "user_id": None,
+        "guest_session_id": "guest-1",
+    }
+    data = base64.b64encode(json.dumps(payload).encode()).decode()
+    return {"message": {"data": data}}
+
+
+def _make_pending_recipe(recipe_id):
+    recipe = Recipe(
+        id=recipe_id,
+        user_id=None,
+        guest_session_id="guest-1",
+        name="Generating...",
+        status="generating",
+        data={"id": recipe_id, "name": "Generating..."},
+    )
+    db.session.add(recipe)
+    db.session.commit()
+    return recipe
+
+
+def test_worker_retries_transient_generation_failure(app, client):
+    """One bad model sample must not surface an error to the user."""
+    recipe_id = str(uuid.uuid4())
+    with app.app_context():
+        _make_pending_recipe(recipe_id)
+
+    attempts = [
+        (None, None, "Model returned invalid JSON (likely truncated)"),
+        (VALID_RECIPE, json.dumps(VALID_RECIPE), None),
+    ]
+    with patch(
+        "blueprints.worker_api_bp.attempt_recipe_generation",
+        side_effect=attempts,
+    ) as mock_attempt, patch(
+        "blueprints.worker_api_bp.invalidate_recipe"
+    ), patch("services.pubsub_service.publish_message"):
+        resp = client.post("/api/worker/recipe", json=_push_envelope(recipe_id))
+
+    assert resp.status_code == 200
+    assert mock_attempt.call_count == 2
+    with app.app_context():
+        recipe = db.session.get(Recipe, recipe_id)
+        assert recipe.status == "ready"
+        assert recipe.data["name"] == "Fresh Peach Salsa"
+
+
+def test_worker_marks_error_after_all_attempts_fail(app, client):
+    recipe_id = str(uuid.uuid4())
+    with app.app_context():
+        _make_pending_recipe(recipe_id)
+
+    with patch(
+        "blueprints.worker_api_bp.attempt_recipe_generation",
+        return_value=(None, None, "Model returned invalid JSON"),
+    ) as mock_attempt, patch(
+        "blueprints.worker_api_bp.GENERATION_MAX_ATTEMPTS", 3
+    ):
+        resp = client.post("/api/worker/recipe", json=_push_envelope(recipe_id))
+
+    assert resp.status_code == 200
+    assert mock_attempt.call_count == 3
+    with app.app_context():
+        recipe = db.session.get(Recipe, recipe_id)
+        assert recipe.status == "error"
+
+
+def test_invalid_json_sets_real_error_message(app):
+    """attempt_recipe_generation must not report 'Unknown error' for bad JSON."""
+    from blueprints import generation_bp
+
+    class FakeModels:
+        def generate_content(self, **kwargs):
+            class FakeResponse:
+                # Truncated mid-string, as seen in production logs
+                text = '{\n  "name": "Fresh Peach Salsa",\n  "description": "A swe'
+
+            return FakeResponse()
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.models = FakeModels()
+
+    with app.test_request_context("/api/generate"), patch.object(
+        generation_bp, "Client", FakeClient
+    ), patch.object(generation_bp, "GOOGLE_API_KEY", "fake-key"):
+        recipe_data, raw_json, last_error = generation_bp.attempt_recipe_generation(
+            "make peach salsa", "gemini-3.1-pro-preview"
+        )
+
+    assert recipe_data is None
+    assert raw_json is None
+    assert last_error != "Unknown error"
+    assert "invalid JSON" in last_error


### PR DESCRIPTION
## Problem

Production incident 2026-07-04 (post v0.3.1): users saw **"generation failed during async processing"** on multiple devices; manual retries succeeded. Logs showed 3 of 8 generation attempts failing with:

```
JSON Decode Error for API Key: { "name": "Fresh Peach Salsa", ...
ERROR in worker_api_bp: Recipe generation failed for <id>: Unknown error
```

Root cause: `gemini-3.1-pro-preview` intermittently returns truncated/malformed JSON (preview alias, updated server-side by Google — the generation code, SDK pin 1.56.0, model, and env are byte-identical to the previous deploy; traffic was near-zero before, so it looked new). The worker made a **single** attempt, ACKed the Pub/Sub push with 200, and marked the recipe `error` — pushing the retry burden onto the user. "Unknown error" appeared because the `JSONDecodeError` path returned `(None, None)` without ever setting an error message.

## Fix

- **`worker_api_bp.py`** — retry `attempt_recipe_generation` up to `GENERATION_MAX_ATTEMPTS` (default 3, env-overridable) before marking the recipe `error`. Each attempt is a fresh model sample at temperature 0.7, which is why user-driven retries were succeeding; now the worker does that in-process (~10–25 s per attempt, well inside Cloud Run/ack deadlines).
- **`generation_bp.py`** — raise `ValueError` with the real cause (invalid JSON with response length, or schema-validation failure) so `last_error_message` reflects it in logs instead of "Unknown error".

## Tests

`tests/test_worker_generation_retry.py` — retry-then-succeed, exhausted-retries→error, and error-message propagation. All three **fail without the fix** (verified via stash) and pass with it. Full suite: 118 passed; the 4 pre-existing `test_public_ssr.py` canonical-URL failures reproduce identically on the clean base (known env-sensitive-pytest follow-up) and are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

