### PR TITLE
feat(publish): gate publishing to authenticated users; migrate guest-published rows

### DIFF
--- a/migrations/versions/e91b47a2c5d3_gate_guest_published_recipes.py
+++ b/migrations/versions/e91b47a2c5d3_gate_guest_published_recipes.py
@@ -1,0 +1,53 @@
+"""Gate guest-published recipes: reassign to an accountable owner or unpublish.
+
+Publishing is now restricted to authenticated (OAuth) users (see
+repositories/db_recipe_repository._gate_is_public). This data migration deals
+with rows published before the gate existed: guest-owned public recipes.
+
+Behavior (see scripts/gate_guest_public_recipes.py):
+- If GUEST_PUBLIC_REASSIGN_EMAIL is set in the migration job's environment,
+  guest-owned public rows are reassigned to that user — their /r/<slug> pages
+  (already in Google's index) stay live under an accountable owner.
+- If unset, they are unpublished.
+- If the email matches no user, the migration raises and the deploy aborts
+  (the old Flask revision keeps serving traffic).
+
+Inventory the affected rows first:
+    SELECT id, slug FROM recipe WHERE is_public AND user_id IS NULL;
+
+Revision ID: e91b47a2c5d3
+Revises: c60f6530f4ff
+Create Date: 2026-07-07
+"""
+
+import logging
+import os
+
+from alembic import op
+from sqlalchemy.orm import Session
+
+# revision identifiers, used by Alembic.
+revision = "e91b47a2c5d3"
+down_revision = "c60f6530f4ff"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade():
+    # Data-only migration: no schema change. Runs inside the app context that
+    # `flask db upgrade` provides, so app modules are importable.
+    from scripts.gate_guest_public_recipes import run_gate
+
+    session = Session(bind=op.get_bind())
+    summary = run_gate(
+        session, reassign_email=os.environ.get("GUEST_PUBLIC_REASSIGN_EMAIL")
+    )
+    logger.info("gate_guest_published_recipes: %s", summary)
+
+
+def downgrade():
+    # Irreversible data migration: we cannot know which rows were guest-owned
+    # before reassignment/unpublish. Intentionally a no-op.
+    pass

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -27,6 +27,23 @@ def _apply_recipe_scope(query, user_id: Optional[int], guest_session_id: Optiona
     return query.filter_by(user_id=None, guest_session_id=None)
 
 
+def _gate_is_public(recipe_data: Dict[str, Any], user_id: Optional[int]) -> Dict[str, Any]:
+    """Only authenticated users may publish: guests get is_public forced False.
+
+    A guest_session_id is a throwaway browser token — there is no accountable
+    owner to moderate or ban behind a guest-published /r/<slug> page. The flag
+    is normalized in the data blob itself so the JSON payload and the
+    is_public column can never disagree.
+    """
+    wants_public = bool(recipe_data.get("is_public", False))
+    if wants_public and user_id is None:
+        logger.warning(
+            "Guest attempted to publish recipe %s — forcing is_public=False",
+            recipe_data.get("id", "<no id>"),
+        )
+    return {**recipe_data, "is_public": wants_public if user_id is not None else False}
+
+
 def get_user_recipes(
     user_id: Optional[int], guest_session_id: Optional[str] = None
 ) -> List[Recipe]:
@@ -94,7 +111,7 @@ def create_recipe(
         recipe_name = recipe_data.get("name", "Unnamed Recipe")
 
         # Ensure the id in recipe_data matches the database record id
-        recipe_data_with_id = {**recipe_data, "id": recipe_id}
+        recipe_data_with_id = _gate_is_public({**recipe_data, "id": recipe_id}, user_id)
 
         existing = Recipe.query.filter_by(id=recipe_id).first()  # type: ignore[no-any-return]
         if existing:
@@ -166,8 +183,10 @@ def update_recipe(
             logger.warning(f"Recipe {recipe_id} not found for user {user_id}")
             return None
 
-        # Ensure the id in recipe_data matches the database record id
-        recipe_data_with_id = {**recipe_data, "id": recipe_id}
+        # Ensure the id in recipe_data matches the database record id.
+        # PUT does not write the is_public column, but the blob must not
+        # carry a guest-smuggled is_public=true either.
+        recipe_data_with_id = _gate_is_public({**recipe_data, "id": recipe_id}, user_id)
 
         # Update fields
         recipe.name = recipe_data.get("name", recipe.name)

--- a/scripts/gate_guest_public_recipes.py
+++ b/scripts/gate_guest_public_recipes.py
@@ -62,6 +62,11 @@ def run_gate(session, reassign_email: Optional[str] = None) -> Dict[str, int]:
     else:
         for row in rows:
             row.is_public = False
+            # Pre-gate rows carry is_public=true inside the JSON blob too;
+            # keep blob and column in agreement (same invariant as
+            # db_recipe_repository._gate_is_public).
+            if isinstance(row.data, dict) and row.data.get("is_public"):
+                row.data["is_public"] = False
         summary["unpublished"] = len(rows)
         logger.warning(
             "gate_guest_public_recipes: unpublished %d guest-owned rows "

--- a/scripts/gate_guest_public_recipes.py
+++ b/scripts/gate_guest_public_recipes.py
@@ -1,0 +1,73 @@
+"""Reassign-or-unpublish guest-owned public recipes (eng-review 3A/D8).
+
+Publishing is being gated to authenticated (OAuth) users so there is an
+accountable owner behind every public /r/<slug> page. Rows published before
+the gate may be guest-owned — most likely the founder's own pre-sign-in
+session. Unpublishing those would 404 URLs Google has already indexed, so:
+
+- With ``reassign_email`` set (env ``GUEST_PUBLIC_REASSIGN_EMAIL`` in the
+  migration): guest-owned public rows are reassigned to that user and their
+  pages stay live.
+- Without it: they are unpublished (the accountability-safe default).
+- An email that matches no user raises, aborting the migration — and with it
+  the deploy — rather than guessing.
+
+Used by the Alembic migration and unit-tested directly (same pattern as
+scripts/backfill_slugs.py).
+"""
+
+import logging
+from typing import Dict, Optional
+
+from models.recipe import Recipe
+from models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+def run_gate(session, reassign_email: Optional[str] = None) -> Dict[str, int]:
+    """Apply the gate to pre-existing rows. Returns a summary dict."""
+    rows = (
+        session.query(Recipe)
+        .filter(Recipe.is_public.is_(True), Recipe.user_id.is_(None))
+        .all()
+    )
+    summary = {"found": len(rows), "reassigned": 0, "unpublished": 0}
+    if not rows:
+        logger.info("gate_guest_public_recipes: no guest-owned public rows")
+        return summary
+
+    logger.info(
+        "gate_guest_public_recipes: %d guest-owned public rows: %s",
+        len(rows),
+        ", ".join(r.slug or r.id for r in rows),
+    )
+
+    if reassign_email:
+        user = session.query(User).filter_by(email=reassign_email).one_or_none()
+        if user is None:
+            raise RuntimeError(
+                f"GUEST_PUBLIC_REASSIGN_EMAIL={reassign_email!r} matches no user; "
+                "aborting so no public page silently changes ownership"
+            )
+        for row in rows:
+            row.user_id = user.id
+            row.guest_session_id = None
+        summary["reassigned"] = len(rows)
+        logger.info(
+            "gate_guest_public_recipes: reassigned %d rows to user %s",
+            len(rows),
+            reassign_email,
+        )
+    else:
+        for row in rows:
+            row.is_public = False
+        summary["unpublished"] = len(rows)
+        logger.warning(
+            "gate_guest_public_recipes: unpublished %d guest-owned rows "
+            "(set GUEST_PUBLIC_REASSIGN_EMAIL to reassign instead)",
+            len(rows),
+        )
+
+    session.commit()
+    return summary

--- a/tests/test_publish_gate.py
+++ b/tests/test_publish_gate.py
@@ -140,7 +140,8 @@ def _add_row(recipe_id, slug, is_public, user_id=None, guest_session_id=None):
         name=slug,
         slug=slug,
         is_public=is_public,
-        data={"id": recipe_id, "name": slug},
+        # Pre-gate rows carried the flag inside the blob too.
+        data={"id": recipe_id, "name": slug, "is_public": is_public},
     )
     db.session.add(r)
     db.session.commit()
@@ -153,7 +154,9 @@ def test_gate_unpublishes_guest_rows_without_email(app, user):
 
     summary = run_gate(db.session, reassign_email=None)
 
-    assert Recipe.query.get("g-pub").is_public is False
+    gated = Recipe.query.get("g-pub")
+    assert gated.is_public is False
+    assert gated.data["is_public"] is False  # blob agrees with the column
     assert Recipe.query.get("u-pub").is_public is True  # untouched
     assert summary == {"found": 1, "reassigned": 0, "unpublished": 1}
 

--- a/tests/test_publish_gate.py
+++ b/tests/test_publish_gate.py
@@ -1,0 +1,189 @@
+"""Publishing accountability gate (eng-review 3A/D8).
+
+Only authenticated (OAuth) users may publish: the repository forces
+``is_public=False`` for guest writes regardless of the request payload, and
+the data migration reassigns-or-unpublishes pre-existing guest-owned public
+rows so /r/<slug> pages backed by an accountable owner stay live.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app
+from extensions import db
+from models.recipe import Recipe
+from models.user import User
+from repositories import db_recipe_repository
+from scripts.gate_guest_public_recipes import run_gate
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def user(app):
+    u = User(email="owner@example.com", name="Owner")
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _recipe_data(recipe_id="r-1", **overrides):
+    data = {"id": recipe_id, "name": "Chili", "slug": "chili"}
+    data.update(overrides)
+    return data
+
+
+# ─── Repository gate: create path ────────────────────────────────────────
+
+
+def test_guest_create_cannot_publish(app):
+    recipe = db_recipe_repository.create_recipe(
+        _recipe_data(is_public=True), user_id=None, guest_session_id="g1"
+    )
+    assert recipe is not None
+    assert recipe.is_public is False
+    # The JSON blob must agree with the column, or later readers disagree.
+    assert recipe.data["is_public"] is False
+
+
+def test_user_create_can_publish(app, user):
+    recipe = db_recipe_repository.create_recipe(
+        _recipe_data(is_public=True), user_id=user.id
+    )
+    assert recipe is not None
+    assert recipe.is_public is True
+    assert recipe.data["is_public"] is True
+
+
+def test_guest_upsert_cannot_flip_public(app):
+    """REGRESSION (upsert branch): the Angular toggle persists via POST upsert."""
+    db_recipe_repository.create_recipe(
+        _recipe_data(is_public=False), user_id=None, guest_session_id="g1"
+    )
+    recipe = db_recipe_repository.create_recipe(
+        _recipe_data(is_public=True), user_id=None, guest_session_id="g1"
+    )
+    assert recipe is not None
+    assert recipe.is_public is False
+    assert recipe.data["is_public"] is False
+
+
+def test_user_upsert_can_flip_public(app, user):
+    """REGRESSION: authenticated publish via the same upsert branch still works."""
+    db_recipe_repository.create_recipe(_recipe_data(is_public=False), user_id=user.id)
+    recipe = db_recipe_repository.create_recipe(
+        _recipe_data(is_public=True), user_id=user.id
+    )
+    assert recipe is not None
+    assert recipe.is_public is True
+
+
+def test_guest_create_without_flag_still_works(app):
+    """REGRESSION: plain guest saves (no is_public key) are unaffected."""
+    recipe = db_recipe_repository.create_recipe(
+        _recipe_data(), user_id=None, guest_session_id="g1"
+    )
+    assert recipe is not None
+    assert recipe.is_public is False
+    assert recipe.name == "Chili"
+
+
+# ─── Repository gate: update path ────────────────────────────────────────
+
+
+def test_guest_update_blob_sanitized(app):
+    """REGRESSION (update path): PUT never wrote the column, but a guest must
+    not be able to smuggle is_public=true into the persisted JSON blob."""
+    db_recipe_repository.create_recipe(
+        _recipe_data(is_public=False), user_id=None, guest_session_id="g1"
+    )
+    recipe = db_recipe_repository.update_recipe(
+        "r-1", _recipe_data(is_public=True), user_id=None, guest_session_id="g1"
+    )
+    assert recipe is not None
+    assert recipe.is_public is False
+    assert recipe.data["is_public"] is False
+
+
+def test_guest_publish_attempt_is_logged(app, caplog):
+    with caplog.at_level("WARNING"):
+        db_recipe_repository.create_recipe(
+            _recipe_data(is_public=True), user_id=None, guest_session_id="g1"
+        )
+    assert any("publish" in rec.message.lower() for rec in caplog.records)
+
+
+# ─── Data migration logic (scripts/gate_guest_public_recipes.py) ─────────
+
+
+def _add_row(recipe_id, slug, is_public, user_id=None, guest_session_id=None):
+    r = Recipe(
+        id=recipe_id,
+        user_id=user_id,
+        guest_session_id=guest_session_id,
+        name=slug,
+        slug=slug,
+        is_public=is_public,
+        data={"id": recipe_id, "name": slug},
+    )
+    db.session.add(r)
+    db.session.commit()
+    return r
+
+
+def test_gate_unpublishes_guest_rows_without_email(app, user):
+    _add_row("g-pub", "guest-pub", True, guest_session_id="g1")
+    _add_row("u-pub", "user-pub", True, user_id=user.id)
+
+    summary = run_gate(db.session, reassign_email=None)
+
+    assert Recipe.query.get("g-pub").is_public is False
+    assert Recipe.query.get("u-pub").is_public is True  # untouched
+    assert summary == {"found": 1, "reassigned": 0, "unpublished": 1}
+
+
+def test_gate_reassigns_guest_rows_to_email(app, user):
+    _add_row("g-pub", "guest-pub", True, guest_session_id="g1")
+
+    summary = run_gate(db.session, reassign_email="owner@example.com")
+
+    row = Recipe.query.get("g-pub")
+    assert row.is_public is True  # page stays live
+    assert row.user_id == user.id  # now accountable
+    assert row.guest_session_id is None
+    assert summary == {"found": 1, "reassigned": 1, "unpublished": 0}
+
+
+def test_gate_unknown_email_aborts(app):
+    _add_row("g-pub", "guest-pub", True, guest_session_id="g1")
+
+    with pytest.raises(RuntimeError):
+        run_gate(db.session, reassign_email="nobody@example.com")
+
+    # Nothing changed — the migration (and therefore the deploy) aborts.
+    assert Recipe.query.get("g-pub").is_public is True
+
+
+def test_gate_noop_when_no_guest_public_rows(app, user):
+    _add_row("u-pub", "user-pub", True, user_id=user.id)
+
+    summary = run_gate(db.session, reassign_email=None)
+
+    assert summary == {"found": 0, "reassigned": 0, "unpublished": 0}
+    assert Recipe.query.get("u-pub").is_public is True


### PR DESCRIPTION
## What

Restores the original spec: **only authenticated (Google OAuth) users can publish recipes.** Currently guests can set `is_public=true` — an anonymous, unbannable `guest_session_id` can put content on the public site, sitemap, and Google index.

- `db_recipe_repository._gate_is_public()`: forces `is_public=false` for guest writes in **both** `create_recipe` branches (new + upsert — the upsert is how the Angular toggle actually persists) and sanitizes the `data` blob in `update_recipe` so guests can't smuggle the flag into the JSON. Blob and column can never disagree. Guest publish attempts log a warning.
- **Data migration `e91b47a2c5d3`** for rows published before the gate (guest-owned public recipes — likely the founder's own pre-sign-in session):
  - `GUEST_PUBLIC_REASSIGN_EMAIL` set on the migrate job → reassign them to that user; indexed `/r/<slug>` pages stay live under an accountable owner
  - unset → unpublish (accountability-safe default)
  - email matches no user → raise; migrate job aborts, deploy aborts, old revision keeps serving
- Inventory before deploying: `SELECT id, slug FROM recipe WHERE is_public AND user_id IS NULL;`

## Tests

`tests/test_publish_gate.py` — 11 tests: guest/user create, upsert flip (regression: the toggle's real path), update-blob smuggling, no-flag guest saves unaffected (regression), warning log, and all four migration paths. Full suite: 144 passed; the 4 `test_public_ssr.py` failures are pre-existing on `dev` (local `FRONTEND_URL` env leak — the fixture fix only ever lived on the archived draft branches).

Migration verified end-to-end on a scratch DB: `flask db upgrade` runs the chain through `e91b47a2c5d3`, single head.

## Context

Task T1 of the post-v0.3.2 plan (eng-review decisions 3A/D8, design doc `allisone-dev-design-20260705-211713`). Companion cookbook PR (guest UI affordance + submodule bump) follows after this merges. Blocks the week-2 distribution sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

