### PR TITLE
fix(api): gate POST /api/migrate behind admin token; repair /api/status DB probe

### DIFF
--- a/blueprints/api_bp.py
+++ b/blueprints/api_bp.py
@@ -15,6 +15,7 @@ import logging
 import os
 
 from flask import Blueprint, jsonify, request, session
+from sqlalchemy import text
 
 from config import CONFIG, DEFAULT_MODEL, GOOGLE_API_KEY
 from repositories.recipe_repository import (
@@ -29,6 +30,7 @@ from services.model_service import (
     refresh_models_from_api,
 )
 from services.reporting_service import ReportingService
+from utils.admin_auth import require_admin
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +172,7 @@ def api_status():
     try:
         from extensions import db
 
-        db.session.execute("SELECT 1")
+        db.session.execute(text("SELECT 1"))
         db_status = "connected"
     except Exception:
         db_status = "error"
@@ -190,7 +192,13 @@ def api_status():
 def run_migration():
     """
     Migrate all recipes in the recipes directory to the latest schema.
+
+    Requires admin bearer token (same gate as the /api/admin/* routes).
     """
+    auth_error = require_admin()
+    if auth_error:
+        return auth_error
+
     try:
         results = MigrationService.migrate_all_recipes()
         return jsonify(results)

--- a/blueprints/generation_api_bp.py
+++ b/blueprints/generation_api_bp.py
@@ -30,6 +30,7 @@ from utils.cache_utils import (
     safe_set,
     TTL_IMAGE,
 )
+from utils.admin_auth import require_admin
 from utils.session_utils import get_or_create_session_id, get_user_metadata
 
 logger = logging.getLogger(__name__)
@@ -254,22 +255,11 @@ def serve_recipe_image(recipe_id):
     )
 
 
-def _require_admin():
-    """Check for admin bearer token (ADMIN_API_TOKEN). Returns error response or None."""
-    import os
-
-    admin_key = os.environ.get("ADMIN_API_TOKEN", "")
-    auth_header = request.headers.get("Authorization", "")
-    if not admin_key or not auth_header.startswith("Bearer ") or auth_header[7:] != admin_key:
-        return jsonify({"error": "Unauthorized — admin token required"}), 403
-    return None
-
-
 @generation_api_bp.route("/admin/image-audit", methods=["GET"])
 def audit_recipe_images():
     """Diagnostic: show which recipes have/lack image data in the DB.
     Requires admin bearer token."""
-    err = _require_admin()
+    err = require_admin()
     if err:
         return err
 
@@ -326,7 +316,7 @@ def migrate_image_urls():
     Also fixes legacy URL patterns (data: URLs, /static/ paths).
     Returns summary of migrated recipes.
     """
-    auth_error = _require_admin()
+    auth_error = require_admin()
     if auth_error:
         return auth_error
     from models import Recipe

--- a/tests/test_api_status_and_migrate.py
+++ b/tests/test_api_status_and_migrate.py
@@ -1,0 +1,75 @@
+"""Regression tests for /api/status DB probe (#146) and /api/migrate auth (#145).
+
+- /api/status must report database "connected" against a healthy DB; the old
+  raw-string ``db.session.execute("SELECT 1")`` raised under SQLAlchemy 2.x and
+  was swallowed into a permanent ``database: error``.
+- POST /api/migrate must require the same admin bearer token as the
+  /api/admin/* routes, and fail closed when ADMIN_API_TOKEN is unset.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app
+from extensions import db
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestApiStatus:
+    def test_reports_database_connected(self, client):
+        resp = client.get("/api/status")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["database"]["status"] == "connected"
+        assert body["database"]["error"] is None
+
+
+class TestMigrateAuth:
+    def test_no_token_rejected(self, client, monkeypatch):
+        monkeypatch.setenv("ADMIN_API_TOKEN", "sekrit")
+        resp = client.post("/api/migrate")
+        assert resp.status_code == 403
+
+    def test_wrong_token_rejected(self, client, monkeypatch):
+        monkeypatch.setenv("ADMIN_API_TOKEN", "sekrit")
+        resp = client.post("/api/migrate", headers={"Authorization": "Bearer wrong"})
+        assert resp.status_code == 403
+
+    def test_fails_closed_when_token_unset(self, client, monkeypatch):
+        monkeypatch.delenv("ADMIN_API_TOKEN", raising=False)
+        resp = client.post("/api/migrate", headers={"Authorization": "Bearer anything"})
+        assert resp.status_code == 403
+
+    def test_valid_token_runs_migration(self, client, monkeypatch):
+        monkeypatch.setenv("ADMIN_API_TOKEN", "sekrit")
+        with patch(
+            "blueprints.api_bp.MigrationService.migrate_all_recipes",
+            return_value={"migrated_count": 0, "files": []},
+        ) as migrate_all:
+            resp = client.post("/api/migrate", headers={"Authorization": "Bearer sekrit"})
+        assert resp.status_code == 200
+        assert resp.get_json() == {"migrated_count": 0, "files": []}
+        migrate_all.assert_called_once()

--- a/utils/admin_auth.py
+++ b/utils/admin_auth.py
@@ -1,0 +1,17 @@
+"""Shared admin bearer-token check for privileged HTTP endpoints."""
+
+import os
+
+from flask import jsonify, request
+
+
+def require_admin():
+    """Check for admin bearer token (ADMIN_API_TOKEN). Returns error response or None.
+
+    Fails closed: when ADMIN_API_TOKEN is unset, every request is rejected.
+    """
+    admin_key = os.environ.get("ADMIN_API_TOKEN", "")
+    auth_header = request.headers.get("Authorization", "")
+    if not admin_key or not auth_header.startswith("Bearer ") or auth_header[7:] != admin_key:
+        return jsonify({"error": "Unauthorized — admin token required"}), 403
+    return None


### PR DESCRIPTION
## Description

Fixes the two priority gaps surfaced by the cookbook PRD reverse-engineering pass (cookbook PR adamtasteslikegood/tasteslikegoodtheangularsvegancookbook#3082).

### 1. `POST /api/migrate` now requires the admin token (Fixes #145)

The route had no auth and is reachable through the public Express proxy — anyone could trigger a bulk migration pass over the legacy file-based recipe store. It now uses the same `ADMIN_API_TOKEN` bearer check as the `/api/admin/*` routes and **fails closed** when the token is unset.

The check is extracted from `generation_api_bp`'s private `_require_admin` into `utils/admin_auth.require_admin`, so both blueprints share one implementation (behavior unchanged for the existing `/admin/image-audit` and `/admin/migrate-image-urls` routes).

Gating rather than deleting was chosen deliberately: `MigrationService` migrates the legacy file-store recipes, which Alembic does not cover, so the endpoint may still have a purpose. Deleting it outright remains an option — happy to follow up if preferred.

### 2. `/api/status` DB probe repaired (Fixes #146)

`db.session.execute("SELECT 1")` raises `ArgumentError` under SQLAlchemy 2.x (raw strings need `text()`), and the surrounding `except` swallowed it — so the endpoint permanently reported `database: error` even against a healthy DB. Now wrapped in `sqlalchemy.text()`.

## Testing

TDD: `tests/test_api_status_and_migrate.py` was written first and failed on all four assertions against the old code (status reported `error`; `/api/migrate` returned 200 with no/wrong/absent token). All five tests pass after the fix.

- Full suite: **138 passed**; the only failures are the 4 pre-existing `test_public_ssr.py` failures, which reproduce identically on clean `origin/dev` (verified via stash).
- `black` + `flake8` clean on the new/changed code (remaining `flake8` warnings in `generation_api_bp.py` are pre-existing; PR #125 covers repo-wide formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kc81qmLi3GYQU2SAsQVnb7
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

