### PR TITLE
ci: re-arm Backend CI — triggers to [main, dev], concurrency, pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,13 @@ permissions:
 
 on:
   push:
-    branches: [main, dev/backend_sub222, develop]
+    branches: [main, dev]
   pull_request:
-    branches: [main, dev/backend_sub222, develop]
+    branches: [main, dev]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -115,7 +119,7 @@ jobs:
           retention-days: 7
 
   security:
-    name: Security Scan (Safety)
+    name: Security Scan (pip-audit)
     runs-on: ubuntu-latest
 
     steps:
@@ -130,12 +134,9 @@ jobs:
       - name: Set up Python
         run: uv python install 3.13
 
-      - name: Install dependencies
+      # Audits the pinned production set the Docker image actually installs.
+      # Advisory for now (SPEC-01 §4.1) — promote to blocking after a clean week.
+      - name: Run pip-audit (advisory)
         run: |
-          uv sync --dev
-
-      - name: Run safety check
-        run: |
-          uv pip install safety
-          uv run safety check --json || true
+          uvx pip-audit -r requirements.txt
         continue-on-error: true


### PR DESCRIPTION
## Summary

Phase 1 of the CI/CD refresh ([TODO.md](../blob/dev/docs/ci/refresh/TODO.md), [SPEC-01 §4.1](../blob/dev/docs/ci/refresh/SPEC-01-ci-quality-gates.md)), merged as #168.

- **Triggers → `[main, dev]`.** The old filters (`main, dev/backend_sub222, develop`) never matched the integration branch, so the Lint/Type-Check/Test/Security jobs have silently not run on any PR. This PR is itself the verification: those four jobs should appear in its checks — the first `Backend CI` run in months.
- **`concurrency` group with `cancel-in-progress: true`** so force-pushes cancel superseded runs instead of stacking them.
- **`safety check` → `pip-audit`.** safety's CLI is deprecated and was already neutered with `|| true`. pip-audit audits `requirements.txt` — the pinned set the Dockerfile installs. Kept advisory (`continue-on-error: true`) per SPEC-01; promote to blocking after a clean week.

## ⚠️ Expected-red jobs (deliberate)

Per the measured baseline (2026-07-14) in SPEC-01, the tree has rotted while CI was dark. **These jobs will fail on this PR and that is the point** — Phase 1 turns the signal on; Phase 2 fixes the tree with real red/green feedback:

| Job | Expected | Why |
|---|---|---|
| Lint (Black + Flake8) | ❌ | 15 files unformatted, 38 flake8 violations |
| Type Check (mypy) | ❌ | crash on `scripts/backfill_slugs.py` (package-bases) |
| Test (pytest) | ❌ | 4 failures in `tests/test_public_ssr.py` |
| Security Scan (pip-audit) | ✅ (advisory) | reports 4 known advisories: click, cryptography, httplib2, mako |

Do **not** hold this PR for green lint/type/test — those are Phase 2 PRs. Checks required for merge today (CodeQL Analyze ×3, non-ASCII) are unaffected.

## Verification

- `actionlint .github/workflows/ci.yml` — clean
- `uvx pip-audit -r requirements.txt` — runs locally, exits with a findings report (advisory in CI)
- The four `Backend CI` jobs appearing on this PR's checks = the trigger fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

