### PR TITLE
types: unbreak mypy — explicit_package_bases + fix the two real errors

### DIFF
--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -174,7 +174,8 @@ def _recipe_json_ld(recipe: Recipe, canonical_url: str, image_url: str | None) -
         "keywords": ", ".join(data.get("tags", [])) if isinstance(data.get("tags"), list) else None,
         "recipeCategory": "Vegan",
     }
-    return _clean_json(json_ld)
+    cleaned: dict[str, Any] = _clean_json(json_ld)
+    return cleaned
 
 
 def _pinterest_share_url(canonical_url: str, image_url: str | None, recipe_name: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,12 @@ python_version = "3.13"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
+# scripts/ has no __init__.py, so without explicit package bases mypy maps
+# scripts/backfill_slugs.py to two module names and aborts the whole run.
+# (This lived in setup.cfg's [mypy] before, but pyproject's [tool.mypy]
+# shadows setup.cfg entirely — which is how the crash shipped.)
+explicit_package_bases = true
+ignore_missing_imports = true
 exclude = [
     "migrate_recipes\\.py",
     "debug_generation\\.py",

--- a/services/pubsub_service.py
+++ b/services/pubsub_service.py
@@ -28,7 +28,7 @@ def publish_message(topic_name: str, data: dict) -> str:
 
     try:
         future = publisher.publish(topic_path, data=data_bytes)
-        message_id = future.result()
+        message_id = str(future.result())
         logger.info(f"Published message {message_id} to {topic_name}")
         return message_id
     except Exception as e:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-explicit_package_bases = True


### PR DESCRIPTION
## Summary

Phase 2, step 3 of the CI/CD refresh ([TODO.md](../blob/dev/docs/ci/refresh/TODO.md)).

**Root cause of the crash:** `scripts/` has no `__init__.py`, so mypy mapped `scripts/backfill_slugs.py` to two module names and aborted before checking anything. The fix — `explicit_package_bases = True` — has existed in `setup.cfg` all along, but **`pyproject.toml`'s `[tool.mypy]` shadows `setup.cfg` entirely**, so it never applied. This PR moves it (plus `ignore_missing_imports`) into `pyproject.toml` and deletes the now-dead `setup.cfg` (nothing else referenced it).

With mypy actually running (71 files), exactly two real `[no-any-return]` errors surfaced — both fixed, no ignores:

- `services/pubsub_service.py` — `future.result()` is `Any`; wrapped in `str()` to honor the declared `-> str`
- `blueprints/public_bp.py` — `_clean_json` returns `Any`; bound to an annotated `dict[str, Any]` before returning

## Verification

- `uv run mypy . --ignore-missing-imports` → **Success: no issues found in 71 source files** (baseline: hard crash, nothing checked)
- black clean · flake8 0 · pytest unchanged (4 failed / 160 passed — the SSR failures, next PR)

## Expected checks

- Lint ✅ · **Type Check (mypy) ✅ expected green for the first time**
- Test (pytest): still ❌ pre-existing — final Phase-2 PR (T5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

