### PR TITLE
test: make the suite hermetic — SSR env leakage + import-time Pub/Sub client

### DIFF
--- a/services/pubsub_service.py
+++ b/services/pubsub_service.py
@@ -1,14 +1,25 @@
 import json
 import logging
+from typing import Optional
+
 from google.cloud import pubsub_v1
 
 from config import GCP_PROJECT_ID
 
 logger = logging.getLogger(__name__)
 
-# Initialize publishers
-# If PUBSUB_EMULATOR_HOST is set, this client automatically uses it.
-publisher = pubsub_v1.PublisherClient()
+# The publisher client is created lazily: PublisherClient() needs Google
+# credentials, so constructing it at import time made merely importing (or
+# patching) this module raise DefaultCredentialsError anywhere without ADC.
+# If PUBSUB_EMULATOR_HOST is set, the client automatically uses it.
+_publisher: Optional[pubsub_v1.PublisherClient] = None
+
+
+def _get_publisher() -> pubsub_v1.PublisherClient:
+    global _publisher
+    if _publisher is None:
+        _publisher = pubsub_v1.PublisherClient()
+    return _publisher
 
 
 def publish_message(topic_name: str, data: dict) -> str:
@@ -22,6 +33,7 @@ def publish_message(topic_name: str, data: dict) -> str:
     Returns:
         The message ID as a string.
     """
+    publisher = _get_publisher()
     topic_path = publisher.topic_path(GCP_PROJECT_ID, topic_name)
     data_str = json.dumps(data)
     data_bytes = data_str.encode("utf-8")

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -26,7 +26,11 @@ from models.user import User  # noqa: E402
 
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
+    # _public_base_url() reads FRONTEND_URL per-request; a developer's .env
+    # (e.g. http://localhost:8080) must not leak into the canonical-URL and
+    # sitemap assertions. These tests pin the request-derived base.
+    monkeypatch.delenv("FRONTEND_URL", raising=False)
     app = create_app(
         TESTING=True,
         SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",


### PR DESCRIPTION
## Summary

Phase 2, final step ([TODO.md](../blob/dev/docs/ci/refresh/TODO.md) T5). Root-caused per the spec's decision gate: **neither failure is a product regression** — both are environment coupling in the test suite.

### 1. The 4 `test_public_ssr.py` failures — local-only env leakage
They only reproduce on machines whose `.env` sets `FRONTEND_URL` (e.g. `http://localhost:8080`): `_public_base_url()` honors it per-request, shifting every canonical/sitemap URL, and `load_dotenv()` finds the parent checkout's `.env` even from a worktree. **CI never saw these failures.** The SSR pages were always correct — canonical tags render fine under both configurations, so there is no SEO bug. The fixture now `monkeypatch.delenv`s `FRONTEND_URL` so the tests pin the request-derived base they assert.

### 2. `test_worker_retries_transient_generation_failure` — CI-only credentials crash
`services/pubsub_service.py` constructed `PublisherClient()` at **import time**, so even `patch("services.pubsub_service.publish_message")` raised `DefaultCredentialsError` while setting up the mock on any machine without ADC. The client is now created lazily on first publish. `publish_message` is the module's only external consumer, and the worker's publish path already try/excepts — production behavior unchanged.

## Verification

- `uv run pytest` → **164 passed** on a machine with a populated `.env` **and** under a simulated credential-less environment (`GOOGLE_APPLICATION_CREDENTIALS=/nonexistent`)
- black clean · flake8 0 · mypy 0 issues

## Expected checks

**All four Backend CI jobs should be green on this PR — the first fully green run.** That closes Phase 2; next up is the docker build gate (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

