### PR TITLE
ci: add docker build gate (Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,20 @@ jobs:
           path: coverage.xml
           retention-days: 7
 
+  build:
+    name: Build (docker)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Validates the image the release pipeline actually ships: the
+      # Dockerfile installs from requirements.txt, which uv sync never
+      # exercises. No push, no registry credentials.
+      - name: Build Docker image
+        run: docker build -f Dockerfile .
+
   security:
     name: Security Scan (pip-audit)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Phase 3 of the CI/CD refresh ([TODO.md](../blob/dev/docs/ci/refresh/TODO.md), [SPEC-01 §4.1](../blob/dev/docs/ci/refresh/SPEC-01-ci-quality-gates.md)): a `Build (docker)` job that runs `docker build -f Dockerfile .` on every PR — no push, no registry credentials.

Why it earns a job: the Dockerfile installs from `requirements.txt`, a surface `uv sync` never exercises. A Dependabot bump once regenerated `requirements.txt` without most runtime deps and killed the v0.3.0 deploy inside the migrate Job. The Lint job's sync check catches divergence from `uv.lock`; this catches image-level breakage (base image, apt deps, COPY paths).

## Verification

- `actionlint .github/workflows/ci.yml` — clean
- Build job green on this PR (all other jobs stay green post-Phase-2)
- **Red-test** per TODO: a scratch draft PR with a deliberately broken `requirements.txt` must turn the build job red — will run it after this PR's own run is green, then close the scratch PR immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

