### PR TITLE
docs(ci): Mermaid markdown companions for the refresh diagram SVGs

### DIFF
--- a/docs/ci/refresh/README.md
+++ b/docs/ci/refresh/README.md
@@ -12,6 +12,7 @@ rotted without gates.
 | [TODO.md](TODO.md) | Phase-by-phase execution checklist; every item carries its verify command |
 | [PROMPT.md](PROMPT.md) | Agent-harness / loop goal definition: task table with verifies, retry caps, escalation rules, close condition |
 | `diagram-*.svg` | Pre-rendered exports of the specs' Mermaid diagrams: [current state](diagram-current-state.svg) · [target pipeline](diagram-target-pipeline.svg) · [AI workflows](diagram-ai-workflows.svg) · [harness loop](diagram-harness-loop.svg) |
+| `diagram-*.md` | Mermaid source for each SVG, GitHub-renderable: [current state](diagram-current-state.md) · [target pipeline](diagram-target-pipeline.md) · [AI workflows](diagram-ai-workflows.md) · [harness loop](diagram-harness-loop.md) |
 
 Predecessor: [../CI-AUDIT-REPORT.md](../CI-AUDIT-REPORT.md) (April 2026 audit — its
 branch-protection recommendation was never implemented; SPEC-01 finishes the job).

--- a/docs/ci/refresh/diagram-ai-workflows.md
+++ b/docs/ci/refresh/diagram-ai-workflows.md
@@ -1,0 +1,22 @@
+# AI Workflows — Gemini triage / review / invoke (standalone, non-blocking)
+
+Mermaid source for [diagram-ai-workflows.svg](diagram-ai-workflows.svg).
+Canonical context: [SPEC-02-ai-triage-and-review.md](SPEC-02-ai-triage-and-review.md).
+
+```mermaid
+flowchart TD
+    subgraph EVENTS
+        E1["cron (every 6h)"]
+        E2["issue opened"]
+        E3["PR labeled 'gemini-review'"]
+        E4["comment '@gemini-cli ...'<br/>from OWNER/MEMBER/COLLABORATOR only"]
+    end
+    E1 --> W1["gemini-scheduled-triage.yml<br/>(exists — keep, retune cadence)"]
+    E2 --> W2["gemini-triage.yml<br/>standalone, reuses commands/gemini-triage.toml"]
+    E3 --> W3["gemini-review.yml<br/>standalone, reuses commands/gemini-review.toml"]
+    E4 --> W4["gemini-invoke.yml<br/>standalone, reuses commands/gemini-invoke.toml"]
+    W1 & W2 & W3 & W4 --> GUARD["Shared guardrails:<br/>timeout-minutes: 10<br/>concurrency per ref<br/>continue-on-error on event-triggered jobs only<br/>(never on scheduled — it would mask the alert)<br/>never a required check · pinned action SHAs<br/>checkout jobs: GEMINI_CLI_TRUST_WORKSPACE=true"]
+    W1 -->|on failure of either job| ALERT["dedicated alert job<br/>needs: [triage, label], issues: write<br/>auto-open issue, label: ci-health"]
+    style GUARD fill:#7c3aed,color:#fff
+    style ALERT fill:#b91c1c,color:#fff
+```

--- a/docs/ci/refresh/diagram-current-state.md
+++ b/docs/ci/refresh/diagram-current-state.md
@@ -1,0 +1,16 @@
+# Current State — CI on `dev` (measured 2026-07-14)
+
+Mermaid source for [diagram-current-state.svg](diagram-current-state.svg).
+Canonical context: [SPEC-01-ci-quality-gates.md](SPEC-01-ci-quality-gates.md).
+
+```mermaid
+flowchart LR
+    subgraph NOW["Today (dev branch, measured 2026-07-14)"]
+        direction TB
+        PR1[PR into dev] --> N1["CodeQL ✅"]
+        PR1 --> N2["Non-ASCII check ✅"]
+        PR1 --> N3["Copilot review ✅"]
+        PR1 -.->|"branch filter never matches"| N4["Backend CI (lint/type/test/security)<br/>💀 never runs"]
+        N2 --> M1{{"Merge — ungated:<br/>no test, no lint signal"}}
+    end
+```

--- a/docs/ci/refresh/diagram-harness-loop.md
+++ b/docs/ci/refresh/diagram-harness-loop.md
@@ -1,0 +1,27 @@
+# Harness Loop — bounded agent loop for the CI/CD refresh
+
+Mermaid source for [diagram-harness-loop.svg](diagram-harness-loop.svg).
+Canonical context: [PROMPT.md](PROMPT.md).
+
+```mermaid
+flowchart TD
+    START([Pick next unverified task]) --> SYNC["Sync: fetch, divergence,<br/>in-flight PR scan"]
+    SYNC --> WORK["Branch → implement → local verify"]
+    WORK --> V{Local verify<br/>passes?}
+    V -->|no, retries left| WORK
+    V -->|no, retries exhausted| ESC
+    V -->|yes| PR["Open PR → wait CI → address review"]
+    PR --> CIV{CI + review<br/>clean?}
+    CIV -->|no, retries left| WORK
+    CIV -->|no, retries exhausted| ESC["ESCALATE to human:<br/>task id, attempts, failing output,<br/>proposed options"]
+    CIV -->|yes| MERGE["Merge"]
+    MERGE --> REG{Global suite<br/>regressed?}
+    REG -->|yes| HALT["HALT — fix regression<br/>before any new task"]
+    REG -->|no| NEXT{All tasks verified<br/>or waived?}
+    NEXT -->|no| START
+    NEXT -->|yes| CLOSE([CLOSE: emit final report])
+    ESC -->|human waives| NEXT
+    ESC -->|human redirects| WORK
+    style ESC fill:#b91c1c,color:#fff
+    style CLOSE fill:#2d6a4f,color:#fff
+```

--- a/docs/ci/refresh/diagram-target-pipeline.md
+++ b/docs/ci/refresh/diagram-target-pipeline.md
@@ -1,0 +1,22 @@
+# Target Pipeline — CI after SPEC-01
+
+Mermaid source for [diagram-target-pipeline.svg](diagram-target-pipeline.svg).
+Canonical context: [SPEC-01-ci-quality-gates.md](SPEC-01-ci-quality-gates.md).
+
+```mermaid
+flowchart LR
+    subgraph TARGET["Target (after this spec)"]
+        direction TB
+        PR2[PR into dev / main] --> T0["changes filter<br/>(skip docs-only)"]
+        T0 --> T1["Lint<br/>black --check + flake8<br/>+ requirements.txt ⇄ uv.lock"]
+        T0 --> T2["Type Check<br/>mypy (fixed config)"]
+        T0 --> T3["Test<br/>pytest + coverage"]
+        T0 --> T5["Build<br/>docker build (validate image)"]
+        PR2 --> T6["Security<br/>pip-audit (advisory)"]
+        PR2 --> T7["CodeQL: Analyze (actions | python |<br/>javascript-typescript) ✅ (unchanged)"]
+        PR2 --> T8["Non-ASCII ✅ (unchanged)"]
+        T1 & T2 & T3 & T5 --> G{{"Branch protection:<br/>required checks"}}
+        G -->|all green| MERGE([Merge])
+    end
+    style G fill:#2d6a4f,color:#fff
+```


### PR DESCRIPTION
Adds a GitHub-renderable `diagram-*.md` next to each `diagram-*.svg` in `docs/ci/refresh/`, containing the exact Mermaid source the SVG was rendered from:

- `diagram-current-state.md` — from SPEC-01 (current-state flowchart)
- `diagram-target-pipeline.md` — from SPEC-01 (target pipeline flowchart)
- `diagram-ai-workflows.md` — from SPEC-02 (Gemini workflows flowchart)
- `diagram-harness-loop.md` — from PROMPT.md (harness loop flowchart)

Also adds a README table row linking the four new files.

Based on `chore/ci-docker-build-gate` (the CI-refresh proposal branch, where `docs/ci/refresh/` lives) and targets it so the diff is only these five doc files. The Mermaid blocks are verbatim copies of the spec sources, so they render identically to the SVG exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNCDTakcQbpZN7d3Lhn1cA
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

