### PR TITLE
feat(mcp): expose the cookbook pm-daemon and gcp-monitor MCP servers to Backend sessions

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "pm-daemon": {
+      "command": "bash",
+      "args": [
+        "-c",
+        "exec \"$(git rev-parse --show-toplevel)/scripts/mcp/run_parent_mcp.sh\" pm-daemon"
+      ],
+      "env": {}
+    },
+    "gcp-monitor": {
+      "command": "bash",
+      "args": [
+        "-c",
+        "exec \"$(git rev-parse --show-toplevel)/scripts/mcp/run_parent_mcp.sh\" gcp-monitor"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ the cookbook repo:
 
 Both entries go through `scripts/mcp/run_parent_mcp.sh`, which locates the
 cookbook checkout (via `git rev-parse --show-superproject-working-tree`, or by
-walking up parent directories for linked worktrees) and exec's the real
+walking up parent directories for linked worktrees) and `exec`s the real
 launchers there (`scripts/pm/run_pm_daemon.sh`,
 `scripts/monitoring/run_gcp_monitor.sh`). The launchers cd to the cookbook
 root, so credentials still come from the cookbook `.env`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,30 @@ In production all secrets come from Google Secret Manager via Cloud Run `--set-s
 - **Gemini model names include `models/` prefix** (e.g., `models/gemini-3.1-pro-preview`); filter API responses by `'generateContent' in supported_generation_methods`.
 - **Tests must hit the right DB engine** — `tests/test_migration_backfill_slug.py::test_backfill_slugs_retry_loop` set `SQLALCHEMY_DATABASE_URI` after `create_app()` and ran `db.create_all()` against a stale engine. Compare against `tests/test_public_ssr.py` for the working pattern (issue #118).
 
+## MCP servers (agent sessions)
+
+`.mcp.json` registers the cookbook superproject's two MCP servers so agent
+sessions started inside this repo get the same tooling as sessions started in
+the cookbook repo:
+
+- `pm-daemon` — PM tools (`get_project_status`, `sync_pm_documents`,
+  `refresh_project_briefing`, `create_epic_from_roadmap`, `log_agent_session`)
+  plus the Confluence file watcher (singleton via `flock`; extra daemons are
+  expected, one per session).
+- `gcp-monitor` — read-only Cloud Monitoring tools (`check_system_health`,
+  `list_available_metrics`, `query_metric`) for the production stack.
+
+Both entries go through `scripts/mcp/run_parent_mcp.sh`, which locates the
+cookbook checkout (via `git rev-parse --show-superproject-working-tree`, or by
+walking up parent directories for linked worktrees) and exec's the real
+launchers there (`scripts/pm/run_pm_daemon.sh`,
+`scripts/monitoring/run_gcp_monitor.sh`). The launchers cd to the cookbook
+root, so credentials still come from the cookbook `.env`
+(`ATLASSIAN_EMAIL`/`ATLASSIAN_API_TOKEN` for pm-daemon,
+`GOOGLE_APPLICATION_CREDENTIALS` for gcp-monitor) — see the cookbook
+`CLAUDE.md` § Startup. In a standalone checkout (no cookbook superproject) the
+wrapper exits with a clear error and the servers are simply unavailable.
+
 ## Related docs
 
 - `API.md` — endpoint reference

--- a/scripts/mcp/run_parent_mcp.sh
+++ b/scripts/mcp/run_parent_mcp.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Launch one of the cookbook superproject's MCP servers (pm-daemon or
+# gcp-monitor) from an agent session started inside this Backend checkout.
+#
+# The server implementations live in the cookbook repo
+# (adamtasteslikegood/tasteslikegoodtheangularsvegancookbook) under
+# scripts/pm/ and scripts/monitoring/; this repo is normally checked out as
+# its Backend/ submodule. The parent launchers are already cwd-independent —
+# they resolve their own repo root from BASH_SOURCE, cd there, and read the
+# cookbook .env — so the only job here is *finding* them.
+
+server="${1:-}"
+shift || true
+
+case "$server" in
+  pm-daemon) launcher_rel="scripts/pm/run_pm_daemon.sh" ;;
+  gcp-monitor) launcher_rel="scripts/monitoring/run_gcp_monitor.sh" ;;
+  *)
+    echo "usage: ${BASH_SOURCE[0]} {pm-daemon|gcp-monitor} [args...]" >&2
+    exit 2
+    ;;
+esac
+
+backend_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Preferred: git knows the superproject when this checkout is the submodule.
+superproject="$(git -C "$backend_root" rev-parse --show-superproject-working-tree 2>/dev/null || true)"
+
+# Fallback: walk up from this checkout until a directory contains the
+# launcher. Covers linked worktrees (Backend/.claude/worktrees/<name>), where
+# git cannot resolve the superproject because the worktree is not at the path
+# the parent repo's gitlink points to.
+if [[ -z "$superproject" || ! -f "$superproject/$launcher_rel" ]]; then
+  superproject=""
+  dir="$backend_root"
+  while [[ "$dir" != "/" ]]; do
+    dir="$(dirname "$dir")"
+    if [[ -f "$dir/$launcher_rel" ]]; then
+      superproject="$dir"
+      break
+    fi
+  done
+fi
+
+if [[ -z "$superproject" ]]; then
+  cat >&2 <<EOF
+Cannot find the cookbook superproject that provides the '$server' MCP server.
+This repo must be checked out as the Backend/ submodule of
+adamtasteslikegood/tasteslikegoodtheangularsvegancookbook, which contains the
+server implementation at $launcher_rel. In a standalone checkout these
+servers are unavailable — clone the cookbook repo and start the session from
+its Backend/ directory instead.
+EOF
+  exit 1
+fi
+
+exec bash "$superproject/$launcher_rel" "$@"


### PR DESCRIPTION
## Description

Agent sessions started inside this repo (directly in `Backend/`, or in one of its linked worktrees) previously got **neither project MCP server** — `.mcp.json` only exists in the cookbook superproject, so `pm-daemon` (Jira/Confluence PM tools + agent session logging) and `gcp-monitor` (read-only Cloud Monitoring) never spawned.

This PR adds:

- **`.mcp.json`** — registers both servers, resolving the wrapper via `git rev-parse --show-toplevel` so sessions launched from a subdirectory also work (same pattern as cookbook PR adamtasteslikegood/tasteslikegoodtheangularsvegancookbook#3026).
- **`scripts/mcp/run_parent_mcp.sh`** — locates the cookbook checkout via `git rev-parse --show-superproject-working-tree`, falling back to walking up parent directories (linked worktrees under `.claude/worktrees/` can't resolve the superproject via git), then `exec`s the real launchers there. The cookbook launchers are already cwd-independent and `cd` to the cookbook root, so credentials keep coming from the cookbook `.env` (`ATLASSIAN_*`, `GOOGLE_APPLICATION_CREDENTIALS`). Standalone checkouts get a clear stderr message instead of a cryptic spawn failure.
- **`CLAUDE.md`** — new "MCP servers (agent sessions)" section documenting the above.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- JSON-RPC `initialize` handshake against `pm-daemon` through the wrapper returns a clean response (`serverInfo: PM Daemon 1.27.2`)
- `gcp-monitor --bootstrap-only` through the wrapper exits 0 from: the repo root, a subdirectory (`blueprints/`, using the exact `.mcp.json` command line), and a linked worktree (exercises the walk-up fallback — `--show-superproject-working-tree` is empty there)
- `git -C Backend rev-parse --show-superproject-working-tree` confirmed to resolve the cookbook root from the real submodule checkout (preferred path)
- Unknown server name exits 2 with usage
- `.mcp.json` validates with `jq`
- n/a: pytest — no Python app code touched

## Additional Notes

No cookbook-repo change is required: nothing ships to production here (agent tooling only), so this doesn't need a submodule-pointer bump beyond the routine ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jwzX7Foh3pVxnCJ5hgUjR



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

