### PR TITLE
build: align Docker base image with requires-python (3.12 → 3.13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
## Summary

Found while triaging Dependabot #157 (python 3.14 bump, correctly rejected by the new `Build (docker)` gate): the production image runs `python:3.12-slim` while `pyproject.toml` pins `requires-python >=3.13,<3.14` and uv.lock/CI/requirements all target 3.13. This aligns the image to 3.13.

## Verification
- `Build (docker)` job on this PR builds the 3.13 image end-to-end
- Full CI suite (lint/mypy/pytest run on 3.13 already — no change in behavior expected)

Part of the T8 Dependabot-drain in [TODO.md](../blob/dev/docs/ci/refresh/TODO.md) Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

