### PR TITLE
ci(gemini): retune scheduled triage — 6h cadence + ci-health failure alert

### DIFF
--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -2,7 +2,7 @@ name: '📋 Gemini Scheduled Issue Triage'
 
 on:
   schedule:
-    - cron: '0 * * * *' # Runs every hour
+    - cron: '0 */6 * * *' # Every 6 hours — hourly was over-provisioned for issue volume (SPEC-02 §3.4)
   pull_request:
     branches:
       - 'main'
@@ -210,4 +210,78 @@ jobs:
                 issue_number: issueNumber,
                 labels: labelsToSet,
               });
+            }
+
+  # A silently-failing scheduled workflow must page someone (SPEC-02 §3.3).
+  # This must be its own job: a step inside triage/label cannot see the other
+  # job's result, triage only has issues:read, and job-level continue-on-error
+  # anywhere in this workflow would report failed jobs as succeeded and keep
+  # failure() here from ever firing.
+  alert:
+    runs-on: 'ubuntu-latest'
+    needs:
+      - 'triage'
+      - 'label'
+    if: |-
+      failure() &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    permissions:
+      issues: 'write'
+    steps:
+      - name: 'Open or update ci-health issue'
+        uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' # ratchet:actions/github-script@v9.0.0
+        with:
+          script: |-
+            const title = '[ci-health] gemini-scheduled-triage is failing';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Scheduled issue triage failed. Latest failing run: ${runUrl}\n\n` +
+              'One of the `triage`/`label` jobs concluded `failure`. Check API keys / WIF ' +
+              'configuration and the run logs. This issue is updated automatically by the ' +
+              '`alert` job in `gemini-scheduled-triage.yml`; close it once runs are green.';
+
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ci-health',
+                color: 'B60205',
+                description: 'Automated alerts about CI / agent workflow health',
+              });
+            } catch (e) {
+              // Only tolerate "label already exists" (422 validation error);
+              // anything else (permissions, outage) must fail the alert job
+              // visibly rather than half-run.
+              const alreadyExists = e.status === 422 &&
+                (e.response?.data?.errors || []).some((err) => err.code === 'already_exists');
+              if (!alreadyExists) {
+                throw e;
+              }
+            }
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci-health',
+              per_page: 100,
+            });
+            const match = existing.data.find((issue) => issue.title === title);
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Still failing: ${runUrl}`,
+              });
+              core.info(`Updated existing ci-health issue #${match.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['ci-health'],
+              });
+              core.info(`Opened ci-health issue #${created.data.number}`);
             }


### PR DESCRIPTION
## Summary

Phase 6, step 1 of the CI/CD refresh ([SPEC-02 §3.3/§3.4](../blob/dev/docs/ci/refresh/SPEC-02-ai-triage-and-review.md)) — the lowest-risk AI-workflow change first, per the rollout order.

- **Cron hourly → every 6 hours.** 24 runs/day was over-provisioned for current issue volume (flagged by the April audit).
- **Failure alerting.** The old pipeline failed silently for two months. A dedicated final `alert` job (`needs: [triage, label]`, `if: failure()` on schedule/dispatch events, own `issues: write`) opens — or comments on — a `[ci-health] gemini-scheduled-triage is failing` issue, creating the `ci-health` label on first use.

Design constraints honored (each maps to a documented failure mode):
- **Dedicated job, not a step**: a step inside `triage`/`label` can't see the other job's result, and `triage` only has `issues: read`.
- **No job-level `continue-on-error` anywhere in this workflow**: it reports failed jobs as succeeded, so the alert's `failure()` would never fire — the exact silent-failure mode this exists to prevent.
- Alert scoped to `schedule`/`workflow_dispatch` so PR-touch test runs don't file issues.

## Verification

- `actionlint` clean
- This is **not** a required check anywhere (AI workflows never gate merges — SPEC-02 hard rule)
- Forced-failure validation: next natural failure (or a `workflow_dispatch` with keys revoked) must open the `ci-health` issue — the alert path is exercised then; happy-path scheduled runs stay green and skip the alert job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

