### PR TITLE
fix(gemini): triage needs GEMINI_CLI_TRUST_WORKSPACE even without checkout

### DIFF
--- a/.github/workflows/gemini-scheduled-triage.yml
+++ b/.github/workflows/gemini-scheduled-triage.yml
@@ -34,6 +34,14 @@ jobs:
       id-token: 'write'
       issues: 'read'
       pull-requests: 'read'
+    env:
+      # Current gemini-cli refuses to run in an untrusted directory even
+      # without a checkout (see fix for the standalone triage, run
+      # 29353718769). This job's Gemini step is skipped whenever there are
+      # no untriaged issues, so historical green runs never exercised it —
+      # the next real batch would have hit the trust error and paged via
+      # the alert job. The workspace is empty; trusting it is safe.
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     outputs:
       available_labels: '${{ steps.get_labels.outputs.available_labels }}'
       triaged_issues: '${{ env.TRIAGED_ISSUES }}'

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -36,6 +36,13 @@ jobs:
       contents: 'read'
       id-token: 'write'
       issues: 'read'
+    env:
+      # Current gemini-cli refuses to run in an untrusted directory even
+      # with no checkout (run 29353718769 exited: "Gemini CLI is not
+      # running in a trusted directory"). The workspace here is empty, so
+      # trusting it is safe. SPEC-02 §3.5 assumed only checkout jobs need
+      # this — the requirement has since widened to every run-gemini-cli job.
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     outputs:
       available_labels: '${{ steps.get_labels.outputs.available_labels }}'
       selected_labels: '${{ env.SELECTED_LABELS }}'


### PR DESCRIPTION
## Summary

T10's live smoke test caught this: opening test issue #182 triggered the new standalone triage (#181), whose Gemini step died with **"Gemini CLI is not running in a trusted directory"** (run 29353718769) — the overall run showed green because of the by-design `continue-on-error`.

Current gemini-cli requires `GEMINI_CLI_TRUST_WORKSPACE=true` on **every** run, not only on jobs that check out code as SPEC-02 §3.5 assumed (the older scheduled-triage runs predate the stricter CLI). The triage job's workspace is empty, so trusting it is safe. The docs close-out PR will amend the spec's claim.

## Verification

- `actionlint` clean
- Post-merge: re-dispatch triage against issue #182 → labels applied (will report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

