### PR TITLE
ci(gemini): standalone label-gated PR review (Phase 6)

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,183 @@
+name: '🔎 Gemini Review'
+
+# Standalone successor to the dispatch-hub review deleted in 9ef54fc
+# (SPEC-02 §3.6: docs/ci/refresh/SPEC-02-ai-triage-and-review.md).
+# Opt-in only: a human applies the 'gemini-review' label (or dispatches
+# manually). Never a required check.
+
+on:
+  pull_request:
+    types:
+      - 'labeled'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        type: 'string'
+        description: 'Pull request number to review'
+        required: true
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}'
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: 'bash'
+
+jobs:
+  review:
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    # Advisory automation: a Gemini outage must never redden a PR
+    # (SPEC-02 §3.3 — event-triggered workflows only; the scheduled triage
+    # keeps its loud failures + alerting).
+    continue-on-error: true
+    # Event model (SPEC-02 §3.6): only the 'gemini-review' label triggers a
+    # run; Dependabot- and fork-headed PRs receive no repository secrets on
+    # pull_request events, so Gemini auth is structurally impossible there —
+    # skip cleanly instead of failing. workflow_dispatch is maintainer-only
+    # by definition and resolves its PR via input.
+    if: |-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.label.name == 'gemini-review' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.login != 'dependabot[bot]' &&
+        github.actor != 'dependabot[bot]'
+      )
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      issues: 'write'
+      pull-requests: 'write'
+    env:
+      # The headless CLI refuses to operate on an untrusted checkout — the
+      # 2026-07-09 review run (job 86047077397) exited before doing any work
+      # for exactly this reason. Required on any job that checks out code.
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
+    steps:
+      - name: 'Resolve pull request'
+        id: 'pr'
+        env:
+          EVENT_PR_NUMBER: '${{ github.event.pull_request.number }}'
+          INPUT_PR_NUMBER: '${{ inputs.pr_number }}'
+        uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3' # ratchet:actions/github-script@v9.0.0
+        with:
+          # core.setOutput escapes multiline values with randomized
+          # delimiters, so untrusted PR titles/bodies cannot inject outputs.
+          script: |-
+            const raw = (process.env.EVENT_PR_NUMBER || process.env.INPUT_PR_NUMBER || '').trim();
+            const prNumber = Number.parseInt(raw, 10);
+            if (!Number.isInteger(prNumber) || prNumber <= 0 || String(prNumber) !== raw) {
+              core.setFailed(`Invalid pull request number: ${JSON.stringify(raw)}`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            // workflow_dispatch bypasses the event-level guard, so re-apply
+            // it here: same-repo head, non-Dependabot author.
+            if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed(`PR #${prNumber} head is not in this repository — fork PRs are not reviewed.`);
+              return;
+            }
+            if (pr.user.login === 'dependabot[bot]') {
+              core.info(`PR #${prNumber} is a Dependabot PR — skipping cleanly.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.setOutput('skip', 'false');
+            core.setOutput('number', String(prNumber));
+            core.setOutput('title', pr.title || '');
+            core.setOutput('body', pr.body || '');
+
+      - name: 'Mint identity token'
+        id: 'mint_identity_token'
+        if: |-
+          ${{ steps.pr.outputs.skip == 'false' && vars.APP_ID }}
+        uses: 'actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1' # ratchet:actions/create-github-app-token@v2
+        with:
+          app-id: '${{ vars.APP_ID }}'
+          private-key: '${{ secrets.APP_PRIVATE_KEY }}'
+          permission-contents: 'read'
+          permission-issues: 'write'
+          permission-pull-requests: 'write'
+
+      - name: 'Checkout repository'
+        if: |-
+          ${{ steps.pr.outputs.skip == 'false' }}
+        uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # ratchet:actions/checkout@v7
+
+      - name: 'Run Gemini pull request review'
+        if: |-
+          ${{ steps.pr.outputs.skip == 'false' }}
+        uses: 'google-github-actions/run-gemini-cli@f77273f4c914e4bf38440cf36a0369cb64a37489' # ratchet:google-github-actions/run-gemini-cli@v0.1.22
+        id: 'gemini_pr_review'
+        env:
+          GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
+          ISSUE_TITLE: '${{ steps.pr.outputs.title }}'
+          ISSUE_BODY: '${{ steps.pr.outputs.body }}'
+          PULL_REQUEST_NUMBER: '${{ steps.pr.outputs.number }}'
+          REPOSITORY: '${{ github.repository }}'
+          ADDITIONAL_CONTEXT: ''
+        with:
+          gcp_location: '${{ vars.GOOGLE_CLOUD_LOCATION }}'
+          gcp_project_id: '${{ vars.GOOGLE_CLOUD_PROJECT }}'
+          gcp_service_account: '${{ vars.SERVICE_ACCOUNT_EMAIL }}'
+          gcp_workload_identity_provider: '${{ vars.GCP_WIF_PROVIDER }}'
+          gemini_api_key: '${{ secrets.GEMINI_API_KEY || secrets.GOOGLE_API_KEY }}'
+          gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
+          gemini_debug: '${{ fromJSON(vars.DEBUG || vars.ACTIONS_STEP_DEBUG || false) }}'
+          gemini_model: '${{ vars.GEMINI_MODEL }}'
+          use_gemini_code_assist: '${{ vars.GOOGLE_GENAI_USE_GCA }}'
+          use_vertex_ai: '${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}'
+          upload_artifacts: '${{ vars.UPLOAD_ARTIFACTS }}'
+          workflow_name: 'gemini-review'
+          settings: |-
+            {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "telemetry": {
+                "enabled": true,
+                "target": "local",
+                "outfile": ".gemini/telemetry.log"
+              },
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.18.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "create_pending_pull_request_review",
+                    "pull_request_read",
+                    "submit_pending_pull_request_review"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
+              "tools": {
+                "core": [
+                  "run_shell_command(cat)",
+                  "run_shell_command(echo)",
+                  "run_shell_command(grep)",
+                  "run_shell_command(head)",
+                  "run_shell_command(tail)"
+                ]
+              }
+            }
+          prompt: '/gemini-review'


### PR DESCRIPTION
## Summary

Phase 6, step 3 ([SPEC-02 §3.6](../blob/dev/docs/ci/refresh/SPEC-02-ai-triage-and-review.md)): resurrects PR review as a **standalone, opt-in** workflow reusing the preserved `gemini-review.toml`. Runs only when a human applies the `gemini-review` label, or via `workflow_dispatch` with a `pr_number`.

Event model, mapped to the documented failure modes:
- **Same-repo + non-Dependabot guard in the job `if:`** — Dependabot- and fork-headed `pull_request` runs receive no repository secrets, so Gemini auth is structurally impossible there; the job **skips cleanly** instead of failing (the acceptance criterion that killed the old pipeline).
- **`workflow_dispatch` re-applies the guard** inside the resolve step (fork PRs rejected, Dependabot PRs skip with a log message) since dispatch bypasses event-level conditions.
- **`GEMINI_CLI_TRUST_WORKSPACE: 'true'`** on the job — this one genuinely checks out code; the 2026-07-09 run (job 86047077397) died without it.
- PR resolved via `github-script` with a validated number and injection-safe outputs (same hardening as #181's triage after review).
- `continue-on-error: true`, 10-min timeout, per-PR concurrency, all action SHAs pinned. **Never a required check.**

## Verification

- `actionlint` — clean
- Post-merge live tests: apply `gemini-review` to an internal PR → review comments appear; dispatch against a closed Dependabot PR (#166) → clean skip. Will run both and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

