### PR TITLE
docs(ci): CI/CD refresh close-out — audit addendum, SPEC-02 correction, gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,9 @@ In production all secrets come from Google Secret Manager via Cloud Run `--set-s
 - **Flask SQLite paths resolve under `instance/`** — `sqlite:///foo.db` writes to `instance/foo.db`, not the cwd.
 - **Gemini model names include `models/` prefix** (e.g., `models/gemini-3.1-pro-preview`); filter API responses by `'generateContent' in supported_generation_methods`.
 - **Tests must hit the right DB engine** — `tests/test_migration_backfill_slug.py::test_backfill_slugs_retry_loop` set `SQLALCHEMY_DATABASE_URI` after `create_app()` and ran `db.create_all()` against a stale engine. Compare against `tests/test_public_ssr.py` for the working pattern (issue #118).
+- **`requirements.txt` is generated, never hand-edited** — regenerate with `uv export --format requirements-txt --no-dev --extra postgres --no-hashes --no-emit-project -o requirements.txt`. CI's Lint job fails if it diverges from `uv.lock` (Dependabot's own regeneration drops packages/markers — that's why its uv PRs can't merge as-is; see `docs/ci/CI-AUDIT-REPORT.md` addendum).
+- **mypy config lives only in `pyproject.toml` `[tool.mypy]`** — a `setup.cfg` `[mypy]` section is silently shadowed by it (that shadowing shipped a config that crashed mypy for months; `setup.cfg` was deleted 2026-07-14). `explicit_package_bases = true` is required because `scripts/` has no `__init__.py`.
+- **Every `run-gemini-cli` job needs `GEMINI_CLI_TRUST_WORKSPACE: 'true'`** — current gemini-cli refuses to run in an untrusted directory even without a checkout. CI quality gates and the required-check list are documented in `docs/ci/refresh/` (SPEC-01/SPEC-02).
 
 ## Related docs
 

--- a/docs/ci/CI-AUDIT-REPORT.md
+++ b/docs/ci/CI-AUDIT-REPORT.md
@@ -175,3 +175,32 @@ Event arrives (push, PR, issue, schedule, comment)
 │            └──────────────────┘                      │
 └──────────────────────────────────────────────────────┘
 ```
+
+---
+
+## Addendum — 2026-07-14: CI/CD Refresh executed (supersedes the recommendations above)
+
+The April audit's key recommendation — required status checks — was never
+implemented, and between April and July the pipeline regressed further:
+`ci.yml`'s branch filters stopped matching the integration branch entirely, so
+the Lint/Type-Check/Test/Security jobs silently never ran, and the Gemini
+dispatch pipeline was deleted (`9ef54fc`) after months of failures. The full
+post-mortem and redesign live in [`refresh/`](refresh/) (SPEC-01, SPEC-02,
+TODO, PROMPT).
+
+Executed 2026-07-14 via an agent-harness loop; state of the world as of close:
+
+| Area | Change | Landed in |
+|---|---|---|
+| CI triggers | `on.push`/`on.pull_request` → `[main, dev]`; concurrency group; safety→pip-audit | #169 |
+| Tree health | Black sweep (15 files, `.git-blame-ignore-revs`), flake8 0 (E266/E501 now enforced), mypy fixed (`explicit_package_bases` in pyproject; `setup.cfg` deleted — it was shadowed), test suite hermetic (FRONTEND_URL leakage, lazy Pub/Sub client) | #170 #171 #172 #173 |
+| Build gate | `Build (docker)` job (no push); red-tested via #175 | #174 |
+| Branch protection | 8 required contexts on `dev` **and** `main` via repository rulesets (`rule222`, `protect-main`), incl. per-language `Analyze (…)` CodeQL contexts | rulesets |
+| Dependency queue | 10 Dependabot PRs drained: #158 merged; #157 closed (py3.14 vs `requires-python <3.14`; Dockerfile aligned to 3.13 in #178); #159–#166 superseded by consolidated refresh #179 (Dependabot's own `requirements.txt` regeneration drops packages/markers — the sync gate caught all eight) | #178 #179 |
+| AI workflows | Scheduled triage: 6h cron + `ci-health` failure-alert job (#180); standalone `gemini-triage.yml` (#181, hardened #183); standalone label-gated `gemini-review.yml` (#184); standalone `gemini-invoke.yml` with deterministic two-phase approval (#185) | #180–#185 |
+
+Correction to SPEC-02 §3.5 discovered during rollout: current gemini-cli
+requires `GEMINI_CLI_TRUST_WORKSPACE=true` on **every** `run-gemini-cli` job,
+not only those that check out code (evidence: run 29353718769 failed in an
+empty workspace; the scheduled workflow's historical greens were vacuous —
+its Gemini step skips when there are no untriaged issues).

--- a/docs/ci/refresh/SPEC-02-ai-triage-and-review.md
+++ b/docs/ci/refresh/SPEC-02-ai-triage-and-review.md
@@ -96,9 +96,16 @@ Key choices, mapped to the failure lessons:
    sufficient for the restored jobs: any job that **checks out the repo**
    (review, invoke) must also set `GEMINI_CLI_TRUST_WORKSPACE: true` — the headless
    CLI refuses to operate on an untrusted checkout (job 86047077397 on 2026-07-09
-   exited before doing any work for exactly this reason). The scheduled triage never
-   checks out code, which is why it works without the setting and cannot serve as
-   the reference for this requirement.
+   exited before doing any work for exactly this reason).
+
+   > **Correction (2026-07-14, found during rollout):** the trust requirement has
+   > widened — current gemini-cli refuses to run in an untrusted directory on
+   > **every** invocation, even with no checkout at all (run 29353718769 failed in
+   > an empty workspace). Set `GEMINI_CLI_TRUST_WORKSPACE: 'true'` on *every*
+   > `run-gemini-cli` job. The scheduled triage's historical green runs were no
+   > counter-evidence: its Gemini step skips whenever there are no untriaged
+   > issues, so those runs never exercised the CLI (fixed alongside the standalone
+   > triage in #183).
 6. **Event model for review** (secrets vs forks): `gemini-review.yml` triggers on
    `pull_request` with `types: [labeled]` plus a guard that the head repo is this
    repo and the actor is not `dependabot[bot]`. Dependabot- and fork-triggered

--- a/docs/ci/refresh/SPEC-02-ai-triage-and-review.md
+++ b/docs/ci/refresh/SPEC-02-ai-triage-and-review.md
@@ -93,19 +93,17 @@ Key choices, mapped to the failure lessons:
 5. **Secrets/auth**: reuse whatever `gemini-scheduled-triage.yml` uses today
    (`GEMINI_API_KEY` / Vertex WIF) — it is the working reference implementation.
    Pin `google-github-actions/run-gemini-cli` to a commit SHA. Auth alone is not
-   sufficient for the restored jobs: any job that **checks out the repo**
-   (review, invoke) must also set `GEMINI_CLI_TRUST_WORKSPACE: true` — the headless
-   CLI refuses to operate on an untrusted checkout (job 86047077397 on 2026-07-09
-   exited before doing any work for exactly this reason).
+   sufficient: **every** job that invokes `run-gemini-cli` must set
+   `GEMINI_CLI_TRUST_WORKSPACE: 'true'` — the headless CLI refuses to run in an
+   untrusted directory whether or not the job checks out code (checkout case:
+   job 86047077397 on 2026-07-09 exited before doing any work; no-checkout case:
+   run 29353718769 failed the same way in an empty workspace).
 
-   > **Correction (2026-07-14, found during rollout):** the trust requirement has
-   > widened — current gemini-cli refuses to run in an untrusted directory on
-   > **every** invocation, even with no checkout at all (run 29353718769 failed in
-   > an empty workspace). Set `GEMINI_CLI_TRUST_WORKSPACE: 'true'` on *every*
-   > `run-gemini-cli` job. The scheduled triage's historical green runs were no
-   > counter-evidence: its Gemini step skips whenever there are no untriaged
-   > issues, so those runs never exercised the CLI (fixed alongside the standalone
-   > triage in #183).
+   > **History (2026-07-14):** this spec originally scoped the requirement to
+   > checkout jobs only, citing the scheduled triage's green runs as evidence it
+   > was unnecessary elsewhere. Those greens were vacuous — the scheduled Gemini
+   > step skips whenever there are no untriaged issues, so it never exercised the
+   > CLI. Corrected during rollout (#183).
 6. **Event model for review** (secrets vs forks): `gemini-review.yml` triggers on
    `pull_request` with `types: [labeled]` plus a guard that the head repo is this
    repo and the actor is not `dependabot[bot]`. Dependabot- and fork-triggered


### PR DESCRIPTION
## Summary

Phase 7 close-out of the CI/CD refresh (TODO.md):

- **`docs/ci/CI-AUDIT-REPORT.md`** — dated addendum superseding the April audit: maps every refresh change to its landing PR (#169–#185 + the ruleset changes) and records the Dependabot `requirements.txt` regeneration failure mode that the sync gate now catches.
- **SPEC-02 §3.5 correction** (found during rollout): current gemini-cli needs `GEMINI_CLI_TRUST_WORKSPACE: 'true'` on **every** `run-gemini-cli` job, not only checkout jobs — evidence run 29353718769; the scheduled workflow's historical greens were vacuous (its Gemini step skips with an empty triage queue).
- **`CLAUDE.md` gotchas** — three durable lessons: `requirements.txt` is generated (exact `uv export` command), `pyproject.toml` silently shadows `setup.cfg` mypy config (how the crash shipped), and the workspace-trust requirement.

The companion cookbook-repo PR bumps the `Backend` submodule pointer (two-step flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

