### PR TITLE
fix(gemini): double review session turn budget (25 → 50)

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -141,7 +141,7 @@ jobs:
           settings: |-
             {
               "model": {
-                "maxSessionTurns": 25
+                "maxSessionTurns": 50
               },
               "telemetry": {
                 "enabled": true,


### PR DESCRIPTION
## Summary

First live `gemini-review` run (29357111780, dispatched against #185) failed with `FatalTurnLimitedError`: the model exhausted its 25 `maxSessionTurns`, burning several on `run_shell_command` calls the tool policy correctly denied. Auth, workspace trust, and the GitHub MCP server all worked — this is purely a turn-budget tuning fix. Policy stays as-is (deny-by-default is the injection guard); the 10-minute job timeout still bounds cost.

## Verification
- `actionlint` clean
- Post-merge: re-dispatch `gemini-review.yml -f pr_number=<internal PR>` → review submitted (will run and report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zexy5hNw3BsPWERnjj7Zy
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

