### PR TITLE
fix(auth): 302-redirect OAuth callback so Helmet CSP can't blank it

### DIFF
--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -14,7 +14,7 @@ from functools import wraps
 import google.oauth2.credentials  # noqa: F401
 import googleapiclient.discovery
 from dotenv import load_dotenv
-from flask import Blueprint, jsonify, request, session, url_for
+from flask import Blueprint, jsonify, redirect, request, session, url_for
 from google_auth_oauthlib.flow import Flow
 
 load_dotenv()
@@ -234,10 +234,15 @@ def api_callback():  # noqa: C901
                     merge_error,
                 )
 
-        # Redirect to frontend (Angular)
-        # In production, redirect to your actual frontend URL
+        # Redirect to frontend (Angular) with a real HTTP 302.
+        # Must NOT be an inline <script> redirect: Express fronts this response
+        # with a Helmet CSP of `script-src 'self'`, which blocks inline scripts,
+        # so a `<script>window.location…</script>` body never executes and the
+        # browser is left stranded on a blank callback page. A 302 Location
+        # redirect carries no script for CSP to block and preserves the
+        # Set-Cookie session header. (regression: #3109 enabled scoped CSP)
         frontend_url = os.environ.get("FRONTEND_URL", "http://localhost:3000")
-        return f'<script>window.location.href = "{frontend_url}?auth=success";</script>'
+        return redirect(f"{frontend_url}?auth=success")
 
     except Exception as e:
         logger.exception("OAuth callback failed: %s", e)

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -16,13 +16,15 @@ Two complementary defenses, both verified here:
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
 
 
 @pytest.fixture
@@ -68,3 +70,72 @@ def test_login_does_not_request_include_granted_scopes(client):
         "response, which trips oauthlib's scope-mismatch check."
     )
     assert kwargs.get("access_type") == "offline"
+
+
+@pytest.fixture
+def db_app():
+    """App with tables created — the callback persists a User row."""
+    os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client-id")
+    os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-client-secret")
+    flask_app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SECRET_KEY="test-secret",
+        SERVER_NAME="testserver",
+    )
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+def test_callback_returns_302_redirect_not_inline_script(db_app):
+    """The OAuth callback must redirect with a real HTTP 302, never an inline
+    <script> body.
+
+    Regression: PR #3109 turned on a Helmet CSP of `script-src 'self'` in the
+    Express layer that fronts this endpoint. That CSP blocks inline scripts, so
+    the previous `<script>window.location.href=…</script>` success response
+    never executed — users were stranded on a blank callback page. A 302
+    Location redirect carries no script for CSP to block.
+    """
+    client = db_app.test_client()
+
+    with client.session_transaction() as sess:
+        sess["state"] = "test-state"
+        sess["code_verifier"] = "test-verifier"
+
+    fake_credentials = SimpleNamespace(
+        token="test-token",
+        refresh_token="test-refresh",
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id="test-client-id",
+        scopes=["openid", "email", "profile"],
+    )
+    fake_flow = MagicMock()
+    fake_flow.credentials = fake_credentials
+
+    userinfo = {"id": "google-123", "email": "chef@example.com", "name": "Chef"}
+    fake_userinfo_service = MagicMock()
+    fake_userinfo_service.userinfo.return_value.get.return_value.execute.return_value = (
+        userinfo
+    )
+
+    with (
+        patch(
+            "blueprints.auth_api_bp.Flow.from_client_config", return_value=fake_flow
+        ),
+        patch(
+            "blueprints.auth_api_bp.googleapiclient.discovery.build",
+            return_value=fake_userinfo_service,
+        ),
+        patch.dict(os.environ, {"FRONTEND_URL": "https://tasteslikegood.org"}),
+    ):
+        resp = client.get("/api/auth/callback?state=test-state&code=test-code")
+
+    assert resp.status_code == 302, resp.data
+    assert resp.headers["Location"] == "https://tasteslikegood.org?auth=success"
+    # The failure mode we are guarding against: a 200 body containing an inline
+    # script that the CSP would refuse to execute.
+    assert b"<script" not in resp.data

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -118,14 +118,10 @@ def test_callback_returns_302_redirect_not_inline_script(db_app):
 
     userinfo = {"id": "google-123", "email": "chef@example.com", "name": "Chef"}
     fake_userinfo_service = MagicMock()
-    fake_userinfo_service.userinfo.return_value.get.return_value.execute.return_value = (
-        userinfo
-    )
+    fake_userinfo_service.userinfo.return_value.get.return_value.execute.return_value = userinfo
 
     with (
-        patch(
-            "blueprints.auth_api_bp.Flow.from_client_config", return_value=fake_flow
-        ),
+        patch("blueprints.auth_api_bp.Flow.from_client_config", return_value=fake_flow),
         patch(
             "blueprints.auth_api_bp.googleapiclient.discovery.build",
             return_value=fake_userinfo_service,


### PR DESCRIPTION
## Production incident: OAuth login stuck on a blank callback page

### Symptom
After the newest release, completing Google OAuth lands the browser on `https://tasteslikegood.org/api/auth/callback?...` and **stays there — blank page**. Dev tools show the callback HTML loaded but nothing ran. On some devices the failure path surfaces the raw `{"error":"Authentication failed"}` 500 body instead.

### Root cause (confirmed with live prod evidence)
Cookbook PR #3109 (`fix(security): enable scoped CSP in Helmet`) turned on a Content-Security-Policy of `script-src 'self'` in the Express layer. That header is applied globally **before** the Flask proxy and is merged onto every proxied `/api/*` response. Verified live:

```
$ curl -sD- https://tasteslikegood.org/api/auth/check
content-security-policy: default-src 'self';…;script-src 'self';…
```

This endpoint's success response was an **inline script**:

```python
return f'<script>window.location.href = "{frontend_url}?auth=success";</script>'
```

`script-src 'self'` refuses to execute inline scripts, so the redirect never fires and the user is stranded on a blank callback page. Before #3109, CSP was disabled and the inline script ran — hence "the newest release broke auth."

### Fix
Return a real **HTTP 302 Location redirect** instead of an inline script. It carries no script for the CSP to block and still emits the `Set-Cookie` session header, so the browser stores the session and follows the redirect. This matches the pattern the legacy `auth.py` callback already uses. No CSP relaxation needed.

### Tests
- New regression test `test_callback_returns_302_redirect_not_inline_script` — asserts the callback returns 302 with a bare `Location` and no `<script>` body. Verified it **fails** against the old inline-script return and **passes** with the fix.
- Full backend suite: **261 passed**. flake8 clean.

### Ships with
A companion cookbook PR bumps the `Backend/` submodule pointer to this commit (production deploys the pinned SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

