### PR TITLE
fix(public): hide Pinterest button without a fetchable image + domain-verify placeholder

### DIFF
--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -212,6 +212,22 @@ def _recipe_json_ld(recipe: Recipe, canonical_url: str, image_url: str | None) -
     return cleaned
 
 
+def _has_pinnable_image(recipe: Recipe) -> bool:
+    """True only when the recipe has an image Pinterest can actually fetch.
+
+    A recipe row can carry an ``ai_image_url`` whose bytes were never
+    persisted (the /api/recipes/<id>/image endpoint then 404s), which makes
+    ``_recipe_image_url`` return a dead link. Pinning that produces a broken
+    pin — and a run of broken pins to a fresh domain is exactly what trips
+    Pinterest's new-account spam heuristics. Gate on the same signal the image
+    endpoint serves from (real GCS/base64 bytes) plus an external stock image.
+    """
+    data = recipe.data or {}
+    return bool(
+        data.get("ai_image_gcs") or data.get("ai_image_data") or data.get("stock_image_url")
+    )
+
+
 def _pinterest_share_url(canonical_url: str, image_url: str | None, recipe_name: str) -> str:
     params = {
         "url": canonical_url,
@@ -275,7 +291,11 @@ def show_public_recipe(slug):
         instructions=instructions,
         tags=tags,
         recipe_json_ld=_recipe_json_ld(recipe, canonical_url, image_url),
-        pinterest_share_url=_pinterest_share_url(canonical_url, image_url, recipe.name),
+        pinterest_share_url=(
+            _pinterest_share_url(canonical_url, image_url, recipe.name)
+            if _has_pinnable_image(recipe)
+            else None
+        ),
         spa_save_url=f"{_public_base_url()}/?save={recipe.slug}#kitchen",
         save_to_cookbook_url=f"{_public_base_url()}/#kitchen",
     )

--- a/templates/public/base_public.html
+++ b/templates/public/base_public.html
@@ -3,6 +3,15 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <!--
+          Pinterest domain verification (placeholder — not yet active).
+          Claim tasteslikegood.org at https://www.pinterest.com/settings/claim/,
+          paste the token Pinterest gives you into `content`, and uncomment the
+          tag below. Verifying the domain unlocks Rich Pins (this site already
+          emits the Recipe JSON-LD they consume) and lowers the new-account
+          spam-flagging that can get pins/accounts deactivated.
+        -->
+        <!-- <meta name="p:domain_verify" content="REPLACE_WITH_PINTEREST_TOKEN" /> -->
         <title>{% block title %}TastesLikeGood{% endblock %}</title>
         <link
             rel="icon"

--- a/templates/public/recipe.html
+++ b/templates/public/recipe.html
@@ -72,9 +72,14 @@
                 <a href="{{ spa_save_url }}" class="public-save-cta" data-save-recipe>
                     Save to your cookbook
                 </a>
+                {# Only offer the Pinterest pin when the recipe has a fetchable
+                   image (see public_bp._has_pinnable_image). Pinning a recipe
+                   whose image 404s creates a broken pin. #}
+                {% if pinterest_share_url %}
                 <a href="{{ pinterest_share_url }}" target="_blank" rel="noopener noreferrer" class="public-recipe-action-link" aria-label="Share {{ recipe.name }} on Pinterest">
                     Save to Pinterest
                 </a>
+                {% endif %}
             </div>
         </div>
     </section>

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -152,6 +152,52 @@ def test_show_public_recipe_includes_seo_meta_and_json_ld(app, client):
     assert "Save to Pinterest" in body
 
 
+def test_pinterest_button_hidden_when_recipe_has_no_image(app, client):
+    # A recipe with no fetchable image (no ai_image_gcs/ai_image_data/stock)
+    # must not render a "Save to Pinterest" link — pinning it would create a
+    # broken pin whose media 404s.
+    with app.app_context():
+        recipe = _make_recipe(
+            "Imageless Stew",
+            "imageless-stew",
+            data={"name": "Imageless Stew", "description": "No picture yet."},
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/imageless-stew")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Save to Pinterest" not in body
+    # The cookbook CTA is unconditional and must still be present.
+    assert "Save to your cookbook" in body
+
+
+@pytest.mark.parametrize(
+    "image_field",
+    [
+        {"ai_image_data": base64.b64encode(b"\x89PNGpin").decode("ascii")},
+        {"ai_image_gcs": "gs://bucket/recipe/v1.png"},
+        {"stock_image_url": "https://img.example/stock.jpg"},
+    ],
+)
+def test_pinterest_button_shown_when_recipe_has_image(app, client, image_field):
+    with app.app_context():
+        recipe = _make_recipe(
+            "Pinnable Pie",
+            "pinnable-pie",
+            data={"name": "Pinnable Pie", "description": "Has a photo.", **image_field},
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/pinnable-pie")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Save to Pinterest" in body
+    assert "pinterest.com/pin/create/button/" in body
+
+
 def test_show_public_recipe_404_when_missing(client):
     resp = client.get("/r/does-not-exist")
     assert resp.status_code == 404


### PR DESCRIPTION
Backend PR (submodule `adamtasteslikegood/tasteslikegood.com`). Ships behind a later cookbook submodule-pointer bump — no deploy on merge.

## Why

While reviewing the live site we confirmed the "Save to Pinterest" button is a plain link and the site loads **zero** Pinterest scripts / makes **zero** automated Pinterest calls — so nothing auto-pins. But a brand-new Pinterest account was deactivated shortly after manually pinning from the site. The likely trigger is Pinterest's new-account spam heuristics: several manual pins to a fresh, **unverified** domain, some with a **broken `media` image**.

Root of the broken image: a recipe row can carry an `ai_image_url` whose bytes were never persisted, so `/api/recipes/<id>/image` 404s (three published recipes are currently in this state). Pinning that yields a broken pin.

## Changes

1. **Broken-pin safety net.** `show_public_recipe` now passes `pinterest_share_url=None` unless `_has_pinnable_image(recipe)` is true — gated on the same signal the image endpoint serves from (`ai_image_gcs` / `ai_image_data`) plus an external `stock_image_url`. The template wraps the button in `{% if pinterest_share_url %}`, so no button (and no broken pin) when there's no real image.
2. **Domain-verify placeholder.** A commented `<meta name="p:domain_verify">` stub with instructions in the public `<head>`. Left **inert** until the real token comes from the Pinterest claim flow (Adam is verifying now). Verifying unlocks Rich Pins (Recipe JSON-LD already emitted) and lowers spam flagging.

## Verification

- `tests/test_public_ssr.py`: new parametrized tests — button **hidden** with no image; **present** for each of `ai_image_data` / `ai_image_gcs` / `stock_image_url`. Full file: **39 passed**.
- `mypy` clean, `black`/`ruff` clean on changed files.

## Known follow-up (not fixed here)

The same `ai_image_url`-without-bytes anomaly also renders a **blank hero** and a **dead `og:image`** on those pages. This PR only suppresses the broken Pinterest pin. Options for the data side: regenerate the missing images (owner-scoped — 2 of the 3 belong to non-`user_id=1` records) and/or make `_recipe_image_url` not trust `ai_image_url` without stored bytes. Filed here to surface it for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

