### PR TITLE
chore: ignore .gstack/ (gstack agent-tooling state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ uv.lock
 Google Cloud App Designs/app-template-5-main.tf
 Google Cloud App Designs/app-template-5_terraform_code_2026-03-04T21_09_21Z.zip
 Google Cloud App Designs/app-template-5_terraform_code_2026-03-04T21_09_21Z
+.gstack/


### PR DESCRIPTION
One-line `.gitignore` addition: ignore `.gstack/`, the per-machine gstack agent-tooling state dir. The cookbook parent repo already ignores `.gstack/` and `skills/` for the same reason; gstack sessions running inside `Backend/` create the dir here too, which showed up as submodule dirt in the parent checkout.

Found as an uncommitted local change during the PR sync for cookbook #3138; extracted to its own branch so it ships properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

