### PR TITLE
release: sync Backend dev to main for v0.3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ uv.lock
 Google Cloud App Designs/app-template-5-main.tf
 Google Cloud App Designs/app-template-5_terraform_code_2026-03-04T21_09_21Z.zip
 Google Cloud App Designs/app-template-5_terraform_code_2026-03-04T21_09_21Z
+.gstack/

--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -212,6 +212,22 @@ def _recipe_json_ld(recipe: Recipe, canonical_url: str, image_url: str | None) -
     return cleaned
 
 
+def _has_pinnable_image(recipe: Recipe) -> bool:
+    """True only when the recipe has an image Pinterest can actually fetch.
+
+    A recipe row can carry an ``ai_image_url`` whose bytes were never
+    persisted (the /api/recipes/<id>/image endpoint then 404s), which makes
+    ``_recipe_image_url`` return a dead link. Pinning that produces a broken
+    pin — and a run of broken pins to a fresh domain is exactly what trips
+    Pinterest's new-account spam heuristics. Gate on the same signal the image
+    endpoint serves from (real GCS/base64 bytes) plus an external stock image.
+    """
+    data = recipe.data or {}
+    return bool(
+        data.get("ai_image_gcs") or data.get("ai_image_data") or data.get("stock_image_url")
+    )
+
+
 def _pinterest_share_url(canonical_url: str, image_url: str | None, recipe_name: str) -> str:
     params = {
         "url": canonical_url,
@@ -275,7 +291,11 @@ def show_public_recipe(slug):
         instructions=instructions,
         tags=tags,
         recipe_json_ld=_recipe_json_ld(recipe, canonical_url, image_url),
-        pinterest_share_url=_pinterest_share_url(canonical_url, image_url, recipe.name),
+        pinterest_share_url=(
+            _pinterest_share_url(canonical_url, image_url, recipe.name)
+            if _has_pinnable_image(recipe)
+            else None
+        ),
         spa_save_url=f"{_public_base_url()}/?save={recipe.slug}#kitchen",
         save_to_cookbook_url=f"{_public_base_url()}/#kitchen",
     )

--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -212,20 +212,23 @@ def _recipe_json_ld(recipe: Recipe, canonical_url: str, image_url: str | None) -
     return cleaned
 
 
-def _has_pinnable_image(recipe: Recipe) -> bool:
-    """True only when the recipe has an image Pinterest can actually fetch.
+def _pinnable_image_url(recipe: Recipe) -> str | None:
+    """URL of an image Pinterest can actually fetch, or ``None`` to hide the button.
 
     A recipe row can carry an ``ai_image_url`` whose bytes were never
     persisted (the /api/recipes/<id>/image endpoint then 404s), which makes
     ``_recipe_image_url`` return a dead link. Pinning that produces a broken
     pin — and a run of broken pins to a fresh domain is exactly what trips
-    Pinterest's new-account spam heuristics. Gate on the same signal the image
-    endpoint serves from (real GCS/base64 bytes) plus an external stock image.
+    Pinterest's new-account spam heuristics. Derive the pin media from the
+    signal the image endpoint actually serves from (real GCS/base64 bytes),
+    else an external stock image — the shared URL is the value that passed
+    the gate, so the two can never disagree (a stale ``ai_image_url`` next
+    to a valid stock image must pin the stock image, not the dead link).
     """
     data = recipe.data or {}
-    return bool(
-        data.get("ai_image_gcs") or data.get("ai_image_data") or data.get("stock_image_url")
-    )
+    if data.get("ai_image_gcs") or data.get("ai_image_data"):
+        return _canonical_url("generation_api.serve_recipe_image", recipe_id=recipe.id)
+    return _absolute_url(data.get("stock_image_url"))
 
 
 def _pinterest_share_url(canonical_url: str, image_url: str | None, recipe_name: str) -> str:
@@ -277,6 +280,7 @@ def show_public_recipe(slug):
     data = recipe.data or {}
     canonical_url = _canonical_url("public.show_public_recipe", slug=recipe.slug)
     image_url = _recipe_image_url(recipe)
+    pinterest_image_url = _pinnable_image_url(recipe)
     description = data.get("description") or "A vegan recipe from TastesLikeGood."
     instructions = _recipe_instructions(data)
     tags = _recipe_tags(data)
@@ -292,8 +296,8 @@ def show_public_recipe(slug):
         tags=tags,
         recipe_json_ld=_recipe_json_ld(recipe, canonical_url, image_url),
         pinterest_share_url=(
-            _pinterest_share_url(canonical_url, image_url, recipe.name)
-            if _has_pinnable_image(recipe)
+            _pinterest_share_url(canonical_url, pinterest_image_url, recipe.name)
+            if pinterest_image_url
             else None
         ),
         spa_save_url=f"{_public_base_url()}/?save={recipe.slug}#kitchen",

--- a/templates/public/base_public.html
+++ b/templates/public/base_public.html
@@ -3,6 +3,15 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <!--
+          Pinterest domain verification (placeholder — not yet active).
+          Claim tasteslikegood.org at https://www.pinterest.com/settings/claim/,
+          paste the token Pinterest gives you into `content`, and uncomment the
+          tag below. Verifying the domain unlocks Rich Pins (this site already
+          emits the Recipe JSON-LD they consume) and lowers the new-account
+          spam-flagging that can get pins/accounts deactivated.
+        -->
+        <!-- <meta name="p:domain_verify" content="REPLACE_WITH_PINTEREST_TOKEN" /> -->
         <title>{% block title %}TastesLikeGood{% endblock %}</title>
         <link
             rel="icon"

--- a/templates/public/recipe.html
+++ b/templates/public/recipe.html
@@ -72,9 +72,14 @@
                 <a href="{{ spa_save_url }}" class="public-save-cta" data-save-recipe>
                     Save to your cookbook
                 </a>
+                {# Only offer the Pinterest pin when the recipe has a fetchable
+                   image (see public_bp._has_pinnable_image). Pinning a recipe
+                   whose image 404s creates a broken pin. #}
+                {% if pinterest_share_url %}
                 <a href="{{ pinterest_share_url }}" target="_blank" rel="noopener noreferrer" class="public-recipe-action-link" aria-label="Share {{ recipe.name }} on Pinterest">
                     Save to Pinterest
                 </a>
+                {% endif %}
             </div>
         </div>
     </section>

--- a/templates/public/recipe.html
+++ b/templates/public/recipe.html
@@ -73,7 +73,7 @@
                     Save to your cookbook
                 </a>
                 {# Only offer the Pinterest pin when the recipe has a fetchable
-                   image (see public_bp._has_pinnable_image). Pinning a recipe
+                   image (see public_bp._pinnable_image_url). Pinning a recipe
                    whose image 404s creates a broken pin. #}
                 {% if pinterest_share_url %}
                 <a href="{{ pinterest_share_url }}" target="_blank" rel="noopener noreferrer" class="public-recipe-action-link" aria-label="Share {{ recipe.name }} on Pinterest">

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -10,10 +10,13 @@ Covers:
 """
 
 import base64
+import html
+import re
 import sys
 import uuid
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from sqlalchemy import event
@@ -173,15 +176,34 @@ def test_pinterest_button_hidden_when_recipe_has_no_image(app, client):
     assert "Save to your cookbook" in body
 
 
+def _pinterest_media_param(body: str) -> str:
+    match = re.search(r'href="(https://www\.pinterest\.com/pin/create/button/\?[^"]+)"', body)
+    assert match, "no Pinterest share link in page"
+    href = html.unescape(match.group(1))
+    return parse_qs(urlsplit(href).query)["media"][0]
+
+
 @pytest.mark.parametrize(
-    "image_field",
+    "image_field, expected_media",
     [
-        {"ai_image_data": base64.b64encode(b"\x89PNGpin").decode("ascii")},
-        {"ai_image_gcs": "gs://bucket/recipe/v1.png"},
-        {"stock_image_url": "https://img.example/stock.jpg"},
+        (
+            {"ai_image_data": base64.b64encode(b"\x89PNGpin").decode("ascii")},
+            "endpoint",
+        ),
+        ({"ai_image_gcs": "gs://bucket/recipe/v1.png"}, "endpoint"),
+        ({"stock_image_url": "https://img.example/stock.jpg"}, "https://img.example/stock.jpg"),
+        (
+            # Stored bytes win over whatever ai_image_url claims — the pin
+            # media must be the URL the gate actually verified.
+            {
+                "ai_image_data": base64.b64encode(b"\x89PNGpin").decode("ascii"),
+                "ai_image_url": "https://cdn.example/old.png",
+            },
+            "endpoint",
+        ),
     ],
 )
-def test_pinterest_button_shown_when_recipe_has_image(app, client, image_field):
+def test_pinterest_button_shown_when_recipe_has_image(app, client, image_field, expected_media):
     with app.app_context():
         recipe = _make_recipe(
             "Pinnable Pie",
@@ -190,12 +212,41 @@ def test_pinterest_button_shown_when_recipe_has_image(app, client, image_field):
         )
         db.session.add(recipe)
         db.session.commit()
+        recipe_id = recipe.id
 
     resp = client.get("/r/pinnable-pie")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "Save to Pinterest" in body
-    assert "pinterest.com/pin/create/button/" in body
+    if expected_media == "endpoint":
+        expected_media = f"http://localhost/api/recipes/{recipe_id}/image"
+    assert _pinterest_media_param(body) == expected_media
+
+
+def test_pinterest_media_ignores_stale_ai_url_when_stock_exists(app, client):
+    # Regression (Copilot review on #202): a stale ai_image_url with no
+    # stored bytes next to a valid stock image passed the gate via the stock
+    # URL but shipped the dead ai_image_url as the pin media. The media must
+    # be the stock URL — the value that made the recipe pinnable.
+    with app.app_context():
+        recipe = _make_recipe(
+            "Stale Link Curry",
+            "stale-link-curry",
+            data={
+                "name": "Stale Link Curry",
+                "description": "AI image bytes were never persisted.",
+                "ai_image_url": "/api/recipes/00000000-dead-dead-dead-000000000000/image",
+                "stock_image_url": "https://img.example/stock.jpg",
+            },
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/stale-link-curry")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Save to Pinterest" in body
+    assert _pinterest_media_param(body) == "https://img.example/stock.jpg"
 
 
 def test_show_public_recipe_404_when_missing(client):

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -152,6 +152,52 @@ def test_show_public_recipe_includes_seo_meta_and_json_ld(app, client):
     assert "Save to Pinterest" in body
 
 
+def test_pinterest_button_hidden_when_recipe_has_no_image(app, client):
+    # A recipe with no fetchable image (no ai_image_gcs/ai_image_data/stock)
+    # must not render a "Save to Pinterest" link — pinning it would create a
+    # broken pin whose media 404s.
+    with app.app_context():
+        recipe = _make_recipe(
+            "Imageless Stew",
+            "imageless-stew",
+            data={"name": "Imageless Stew", "description": "No picture yet."},
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/imageless-stew")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Save to Pinterest" not in body
+    # The cookbook CTA is unconditional and must still be present.
+    assert "Save to your cookbook" in body
+
+
+@pytest.mark.parametrize(
+    "image_field",
+    [
+        {"ai_image_data": base64.b64encode(b"\x89PNGpin").decode("ascii")},
+        {"ai_image_gcs": "gs://bucket/recipe/v1.png"},
+        {"stock_image_url": "https://img.example/stock.jpg"},
+    ],
+)
+def test_pinterest_button_shown_when_recipe_has_image(app, client, image_field):
+    with app.app_context():
+        recipe = _make_recipe(
+            "Pinnable Pie",
+            "pinnable-pie",
+            data={"name": "Pinnable Pie", "description": "Has a photo.", **image_field},
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/pinnable-pie")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Save to Pinterest" in body
+    assert "pinterest.com/pin/create/button/" in body
+
+
 def test_show_public_recipe_404_when_missing(client):
     resp = client.get("/r/does-not-exist")
     assert resp.status_code == 404


### PR DESCRIPTION
Promotes Backend `dev` to `main` alongside cookbook release v0.3.7 (cookbook PR adamtasteslikegood/tasteslikegoodtheangularsvegancookbook#3150), following the v0.3.6 pattern (#198).

### Contents (main ← dev)

- **fix(public): hide Pinterest button without a fetchable image + `p:domain_verify` placeholder** (#200, lands as `1baa118` + `043a62e`) — the "Save to Pinterest" button no longer renders for recipes whose image bytes are missing, preventing broken pins that can trip Pinterest's new-domain spam heuristics; adds an inert domain-verification meta for Rich Pins.
- **fix(public): pin the image URL that passed the Pinterest gate** (#203, `daa4da7`) — the pin `media` is now derived from the same signal that gates the button (stored bytes → canonical image endpoint, else the stock URL), closing the stale-`ai_image_url` + valid-stock combination both Copilot review comments on this PR flagged.
- **chore(public): point template comment at `_pinnable_image_url`** (#204, `c3e4687`) — comment-only Copilot follow-up from this PR's review.
- **chore: ignore `.gstack/`** (#201, `7ee11d5`) — matches the cookbook parent repo's gitignore for agent-tooling state.

The cookbook release pins the submodule at `c3e4687`, which is exactly this dev tip — so production (which deploys the pinned SHA) and Backend `main` stay in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->
