### PR TITLE
fix(public): pin the image URL that passed the Pinterest gate

### DIFF
--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -212,20 +212,23 @@ def _recipe_json_ld(recipe: Recipe, canonical_url: str, image_url: str | None) -
     return cleaned
 
 
-def _has_pinnable_image(recipe: Recipe) -> bool:
-    """True only when the recipe has an image Pinterest can actually fetch.
+def _pinnable_image_url(recipe: Recipe) -> str | None:
+    """URL of an image Pinterest can actually fetch, or ``None`` to hide the button.
 
     A recipe row can carry an ``ai_image_url`` whose bytes were never
     persisted (the /api/recipes/<id>/image endpoint then 404s), which makes
     ``_recipe_image_url`` return a dead link. Pinning that produces a broken
     pin — and a run of broken pins to a fresh domain is exactly what trips
-    Pinterest's new-account spam heuristics. Gate on the same signal the image
-    endpoint serves from (real GCS/base64 bytes) plus an external stock image.
+    Pinterest's new-account spam heuristics. Derive the pin media from the
+    signal the image endpoint actually serves from (real GCS/base64 bytes),
+    else an external stock image — the shared URL is the value that passed
+    the gate, so the two can never disagree (a stale ``ai_image_url`` next
+    to a valid stock image must pin the stock image, not the dead link).
     """
     data = recipe.data or {}
-    return bool(
-        data.get("ai_image_gcs") or data.get("ai_image_data") or data.get("stock_image_url")
-    )
+    if data.get("ai_image_gcs") or data.get("ai_image_data"):
+        return _canonical_url("generation_api.serve_recipe_image", recipe_id=recipe.id)
+    return _absolute_url(data.get("stock_image_url"))
 
 
 def _pinterest_share_url(canonical_url: str, image_url: str | None, recipe_name: str) -> str:
@@ -277,6 +280,7 @@ def show_public_recipe(slug):
     data = recipe.data or {}
     canonical_url = _canonical_url("public.show_public_recipe", slug=recipe.slug)
     image_url = _recipe_image_url(recipe)
+    pinterest_image_url = _pinnable_image_url(recipe)
     description = data.get("description") or "A vegan recipe from TastesLikeGood."
     instructions = _recipe_instructions(data)
     tags = _recipe_tags(data)
@@ -292,8 +296,8 @@ def show_public_recipe(slug):
         tags=tags,
         recipe_json_ld=_recipe_json_ld(recipe, canonical_url, image_url),
         pinterest_share_url=(
-            _pinterest_share_url(canonical_url, image_url, recipe.name)
-            if _has_pinnable_image(recipe)
+            _pinterest_share_url(canonical_url, pinterest_image_url, recipe.name)
+            if pinterest_image_url
             else None
         ),
         spa_save_url=f"{_public_base_url()}/?save={recipe.slug}#kitchen",

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -10,10 +10,13 @@ Covers:
 """
 
 import base64
+import html
+import re
 import sys
 import uuid
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from sqlalchemy import event
@@ -173,15 +176,34 @@ def test_pinterest_button_hidden_when_recipe_has_no_image(app, client):
     assert "Save to your cookbook" in body
 
 
+def _pinterest_media_param(body: str) -> str:
+    match = re.search(r'href="(https://www\.pinterest\.com/pin/create/button/\?[^"]+)"', body)
+    assert match, "no Pinterest share link in page"
+    href = html.unescape(match.group(1))
+    return parse_qs(urlsplit(href).query)["media"][0]
+
+
 @pytest.mark.parametrize(
-    "image_field",
+    "image_field, expected_media",
     [
-        {"ai_image_data": base64.b64encode(b"\x89PNGpin").decode("ascii")},
-        {"ai_image_gcs": "gs://bucket/recipe/v1.png"},
-        {"stock_image_url": "https://img.example/stock.jpg"},
+        (
+            {"ai_image_data": base64.b64encode(b"\x89PNGpin").decode("ascii")},
+            "endpoint",
+        ),
+        ({"ai_image_gcs": "gs://bucket/recipe/v1.png"}, "endpoint"),
+        ({"stock_image_url": "https://img.example/stock.jpg"}, "https://img.example/stock.jpg"),
+        (
+            # Stored bytes win over whatever ai_image_url claims — the pin
+            # media must be the URL the gate actually verified.
+            {
+                "ai_image_data": base64.b64encode(b"\x89PNGpin").decode("ascii"),
+                "ai_image_url": "https://cdn.example/old.png",
+            },
+            "endpoint",
+        ),
     ],
 )
-def test_pinterest_button_shown_when_recipe_has_image(app, client, image_field):
+def test_pinterest_button_shown_when_recipe_has_image(app, client, image_field, expected_media):
     with app.app_context():
         recipe = _make_recipe(
             "Pinnable Pie",
@@ -190,12 +212,41 @@ def test_pinterest_button_shown_when_recipe_has_image(app, client, image_field):
         )
         db.session.add(recipe)
         db.session.commit()
+        recipe_id = recipe.id
 
     resp = client.get("/r/pinnable-pie")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "Save to Pinterest" in body
-    assert "pinterest.com/pin/create/button/" in body
+    if expected_media == "endpoint":
+        expected_media = f"http://localhost/api/recipes/{recipe_id}/image"
+    assert _pinterest_media_param(body) == expected_media
+
+
+def test_pinterest_media_ignores_stale_ai_url_when_stock_exists(app, client):
+    # Regression (Copilot review on #202): a stale ai_image_url with no
+    # stored bytes next to a valid stock image passed the gate via the stock
+    # URL but shipped the dead ai_image_url as the pin media. The media must
+    # be the stock URL — the value that made the recipe pinnable.
+    with app.app_context():
+        recipe = _make_recipe(
+            "Stale Link Curry",
+            "stale-link-curry",
+            data={
+                "name": "Stale Link Curry",
+                "description": "AI image bytes were never persisted.",
+                "ai_image_url": "/api/recipes/00000000-dead-dead-dead-000000000000/image",
+                "stock_image_url": "https://img.example/stock.jpg",
+            },
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/stale-link-curry")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Save to Pinterest" in body
+    assert _pinterest_media_param(body) == "https://img.example/stock.jpg"
 
 
 def test_show_public_recipe_404_when_missing(client):


### PR DESCRIPTION
Addresses both Copilot review comments on #202 (the same defect, flagged at `_has_pinnable_image` and its call site).

### The bug

#200 gated the "Save to Pinterest" button on a boolean — stored AI bytes (`ai_image_gcs`/`ai_image_data`) OR `stock_image_url` — but the pin's `media` URL still came from `_recipe_image_url()`, which returns `ai_image_url` unconditionally when set. A recipe with a **stale `ai_image_url` (bytes never persisted) next to a valid stock image** passed the gate via the stock URL yet pinned the dead AI link — the exact broken-pin case the gate exists to prevent (Pinterest new-domain spam heuristics).

### The fix

`_has_pinnable_image() -> bool` becomes `_pinnable_image_url() -> str | None`: it derives the media URL from the gate's own signals (canonical `/api/recipes/<id>/image` endpoint when bytes exist, else the absolute stock URL) and the button renders only when that URL exists. Gate and shared value are now the same value and can never disagree.

Behavior-unchanged for healthy recipes: when bytes exist, `ai_image_url` already holds the same API path the canonical endpoint yields. The SSR hero/og:image continue to use `_recipe_image_url()` — only the pin media derivation changes, matching #200's scope.

### Tests

- Parametrized visibility test now asserts the exact `media` param per image source, including bytes + conflicting `ai_image_url` → canonical endpoint wins.
- New regression: stale `ai_image_url` + valid stock → button renders with the stock URL as media.
- Full suite: 267 passed.

### Release train

v0.3.7 promotion #202 (dev→main) picks this up on merge; the cookbook pin in release PR #3150 then needs a bump to the new dev tip (which also carries #201, merged to dev this morning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

