### PR TITLE
chore(public): point template comment at _pinnable_image_url

### DIFF
--- a/templates/public/recipe.html
+++ b/templates/public/recipe.html
@@ -73,7 +73,7 @@
                     Save to your cookbook
                 </a>
                 {# Only offer the Pinterest pin when the recipe has a fetchable
-                   image (see public_bp._has_pinnable_image). Pinning a recipe
+                   image (see public_bp._pinnable_image_url). Pinning a recipe
                    whose image 404s creates a broken pin. #}
                 {% if pinterest_share_url %}
                 <a href="{{ pinterest_share_url }}" target="_blank" rel="noopener noreferrer" class="public-recipe-action-link" aria-label="Share {{ recipe.name }} on Pinterest">


### PR DESCRIPTION
Copilot follow-up on the v0.3.7 promotion PR #202: the Jinja comment in `templates/public/recipe.html` still referenced `_has_pinnable_image`, which #203 renamed to `_pinnable_image_url`. Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

