### PR TITLE
ci: pin CodeQL bundle with tools: linked to fix "2 configurations not found"

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,12 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
+          # Force the bundle shipped with the pinned action version. Without
+          # this, push and pull_request runs can resolve different CodeQL
+          # versions (dev baseline 2.26.1 vs PR 2.26.0), and the PR check then
+          # can't match the baseline configs ("2 configurations not found"),
+          # which blocks the code_scanning ruleset gate on every PR.
+          tools: linked
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0


### PR DESCRIPTION
## Problem

Every PR into `dev` currently shows the code-scanning summary check as neutral:

> **CodeQL — 2 configurations not found**: Code scanning cannot determine the alerts introduced by this pull request, because 2 configurations present on `refs/heads/dev` were not found: `/language:javascript-typescript/build-mode:none`, `/language:python/build-mode:none`

Seen on #205, #206, #209, #210 — all `Analyze` jobs green and all SARIF uploads succeed, yet the check can't compute the alert diff. Because the `dev` ruleset has a `code_scanning` rule (CodeQL, alerts=errors, security=high_or_higher), the undeterminable diff leaves every PR `BLOCKED` and forces admin merges.

## Root cause

The base-branch baseline and the PR analyses are produced with **different CodeQL bundle versions**, so the PR alert-diff can't match the configurations. `tool.version` from `GET /code-scanning/analyses`:

| ref | actions | javascript-typescript | python |
|---|---|---|---|
| `refs/heads/dev` (push runs) | 2.26.1 | **2.26.1** | **2.26.1** |
| PR merge refs (pull_request runs) | 2.26.1 | **2.26.0** | **2.26.0** |

The two "not found" configurations are exactly the two whose versions differ, on every PR. Both event types run the same pinned `codeql-action`, so the skew comes from runtime bundle resolution (toolcache/cache differs between the push path and the PR path). Known failure mode: github/codeql-action#1179.

## Fix

Add `tools: linked` to the `init` step so every job uses the exact bundle shipped with the pinned action version. Push and PR runs then always analyze with the identical CodeQL version, baseline matching is deterministic, and it stays fixed across future CodeQL releases.

## Merge notes

- **This PR will itself still show the neutral "configurations not found" check** — its analyses are compared against the old baseline. Merge with `--admin`.
- After merge, the push run on `dev` rebuilds the baseline with the linked bundle; PRs opened or updated after that compare cleanly.
- Compatible with #207 (bumps the action pins v4.37.0 → v4.37.1). This change is inside the `with:` block; whichever lands second rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

