### PR TITLE
docs: state the real Gemini credential flow in CLAUDE.md §Authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,7 @@ recipe_schema.json              # canonical recipe shape
 
 ### Authentication
 
-Dual-credential strategy in services that call Gemini:
-
-1. **Primary** — user OAuth credentials from session.
-2. **Fallback** — server `GOOGLE_API_KEY`.
+Gemini credential handling lives in `services/gemini_service.py:get_genai_client(session_credentials)`: it prefers caller-supplied user OAuth credentials, falls back to the server `GOOGLE_API_KEY`, and returns `None` if neither works — it never reads the Flask session itself. Today both live generation call sites (`services/image_service.py` and the Pub/Sub worker in `blueprints/worker_api_bp.py`) pass `None`, so generation runs on the server key; only model refresh (`blueprints/api_bp.py` → `refresh_models_from_api`) forwards `session.get("credentials")`. Preserve that preference order.
 
 OAuth flow lives in `blueprints/auth_api_bp.py`. PKCE `code_verifier` is persisted across the redirect (see `fix(auth): persist PKCE code_verifier across OAuth redirect`).
 


### PR DESCRIPTION
## Description

`CLAUDE.md` §Authentication described a "dual-credential strategy: 1. Primary — user OAuth credentials from session. 2. Fallback — server `GOOGLE_API_KEY`", which overstates reality — nothing that generates content reads the Flask session today. This rewrites the paragraph to state the verified flow, mirroring the wording #210 shipped in `.github/copilot-instructions.md`:

- `services/gemini_service.py:get_genai_client(session_credentials)` prefers caller-supplied user OAuth credentials, falls back to the server `GOOGLE_API_KEY`, and returns `None` if neither works — it never reads the Flask session itself.
- Both live generation call sites pass `None` (`services/image_service.py:64`, `blueprints/worker_api_bp.py:604`), so generation runs on the server key. `image_service` even documents why: identity-only OAuth credentials are insufficient for Imagen.
- Only model refresh (`blueprints/api_bp.py` `/models/refresh` → `refresh_models_from_api`) forwards `session.get("credentials")`.

A matching fix for the cookbook repo's `CLAUDE.md` is going up separately (same branch name, `chore/claude-md-gemini-auth`).

## Type of Change

- [x] Documentation update

## Testing

Docs-only; no code paths touched. Facts verified against the current `dev` tip (file:line references above).

## Database Changes

- [x] No database changes

## Environment Variables

- [x] No new environment variables

## API Changes

- [x] No API changes

## Dependencies

- [x] No new dependencies

## Deployment Notes

- [x] No special deployment steps

## Related Issues

Related to #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

