### PR TITLE
fix(collections): unique cookbook name per owner + idempotent create (dup-cookbook race)

### DIFF
--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -41,6 +41,59 @@ SCOPES = [
     "https://www.googleapis.com/auth/userinfo.profile",
 ]
 
+_COOKBOOK_NAME_MAX = 200  # Cookbook.name is String(200)
+
+
+def _dedupe_cookbook_name(name, taken):
+    """Return ``name`` if free under this owner, else a suffixed variant.
+
+    Mirrors migration b7e2a9c4d1f8's policy ("Name (2)", "Name (3)", …) and
+    trims the base so the suffixed result still fits ``Cookbook.name``.
+    """
+    if name not in taken:
+        return name
+    n = 2
+    while True:
+        tag = f" ({n})"
+        candidate = name[: max(0, _COOKBOOK_NAME_MAX - len(tag))] + tag
+        if candidate not in taken:
+            return candidate
+        n += 1
+
+
+def _merge_guest_session_into_user(user, guest_session_id):
+    """Reassign a guest session's recipes and cookbooks to an authenticated user.
+
+    Cookbook names are unique per owner (``uq_cookbook_user_name``), so a guest
+    cookbook whose name already exists under the target user would collide on
+    reassignment and roll back the entire merge — silently orphaning the guest's
+    rows under the now-authenticated session. Rename such guest cookbooks with a
+    numeric suffix instead, so every row is preserved. Commits on success and
+    raises on failure so the caller can roll back and log.
+    """
+    from extensions import db
+    from models import Cookbook, Recipe
+
+    Recipe.query.filter_by(user_id=None, guest_session_id=guest_session_id).update(
+        {"user_id": user.id, "guest_session_id": None},
+        synchronize_session=False,
+    )
+
+    guest_cookbooks = Cookbook.query.filter_by(
+        user_id=None, guest_session_id=guest_session_id
+    ).all()
+    if guest_cookbooks:
+        taken = {
+            row.name for row in db.session.query(Cookbook.name).filter_by(user_id=user.id).all()
+        }
+        for cb in guest_cookbooks:
+            cb.name = _dedupe_cookbook_name(cb.name, taken)
+            cb.user_id = user.id
+            cb.guest_session_id = None
+            taken.add(cb.name)
+
+    db.session.commit()
+
 
 def credentials_to_dict(credentials):
     """Convert credentials object to a JSON-serializable dictionary.
@@ -165,7 +218,7 @@ def api_callback():  # noqa: C901
 
         # Persist user to database (Phase 3)
         from extensions import db
-        from models import Cookbook, Recipe, User
+        from models import User
 
         google_id = user_info.get("id")
         email = user_info.get("email")
@@ -207,24 +260,13 @@ def api_callback():  # noqa: C901
         session["user_id"] = user.id
         session["db_user"] = user.to_dict()  # Cache user info
 
-        # Merge anonymous rows for this browser session into the authenticated user.
+        # Merge anonymous rows for this browser session into the authenticated
+        # user. Cookbook names are unique per owner, so the merge renames any
+        # guest cookbook whose name collides with one the user already owns
+        # rather than failing and orphaning the guest's rows.
         if previous_guest_session_id:
             try:
-                Recipe.query.filter_by(
-                    user_id=None, guest_session_id=previous_guest_session_id
-                ).update(
-                    {"user_id": user.id, "guest_session_id": None},
-                    synchronize_session=False,
-                )
-
-                Cookbook.query.filter_by(
-                    user_id=None, guest_session_id=previous_guest_session_id
-                ).update(
-                    {"user_id": user.id, "guest_session_id": None},
-                    synchronize_session=False,
-                )
-
-                db.session.commit()
+                _merge_guest_session_into_user(user, previous_guest_session_id)
             except Exception as merge_error:
                 db.session.rollback()
                 logger.warning(

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -15,6 +15,7 @@ import googleapiclient.discovery
 from dotenv import load_dotenv
 from flask import Blueprint, jsonify, redirect, request, session, url_for
 from google_auth_oauthlib.flow import Flow
+from sqlalchemy.exc import IntegrityError
 
 load_dotenv()
 
@@ -61,38 +62,54 @@ def _dedupe_cookbook_name(name, taken):
         n += 1
 
 
-def _merge_guest_session_into_user(user, guest_session_id):
+def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
     """Reassign a guest session's recipes and cookbooks to an authenticated user.
 
     Cookbook names are unique per owner (``uq_cookbook_user_name``), so a guest
     cookbook whose name already exists under the target user would collide on
     reassignment and roll back the entire merge — silently orphaning the guest's
     rows under the now-authenticated session. Rename such guest cookbooks with a
-    numeric suffix instead, so every row is preserved. Commits on success and
-    raises on failure so the caller can roll back and log.
+    numeric suffix instead, so every row is preserved.
+
+    Reading the occupied names and committing the rename is a check-then-act
+    sequence: a concurrent create/merge for the same owner could claim a name in
+    the window and make the commit hit the unique index. Retry on
+    ``IntegrityError`` (re-reading the occupied names each attempt) so a lost
+    race re-resolves instead of leaving the session unmerged. Commits on success
+    and raises after exhausting retries so the caller can roll back and log.
     """
     from extensions import db
     from models import Cookbook, Recipe
 
-    Recipe.query.filter_by(user_id=None, guest_session_id=guest_session_id).update(
-        {"user_id": user.id, "guest_session_id": None},
-        synchronize_session=False,
-    )
+    for attempt in range(max_retries):
+        try:
+            Recipe.query.filter_by(user_id=None, guest_session_id=guest_session_id).update(
+                {"user_id": user.id, "guest_session_id": None},
+                synchronize_session=False,
+            )
 
-    guest_cookbooks = Cookbook.query.filter_by(
-        user_id=None, guest_session_id=guest_session_id
-    ).all()
-    if guest_cookbooks:
-        taken = {
-            row.name for row in db.session.query(Cookbook.name).filter_by(user_id=user.id).all()
-        }
-        for cb in guest_cookbooks:
-            cb.name = _dedupe_cookbook_name(cb.name, taken)
-            cb.user_id = user.id
-            cb.guest_session_id = None
-            taken.add(cb.name)
+            guest_cookbooks = Cookbook.query.filter_by(
+                user_id=None, guest_session_id=guest_session_id
+            ).all()
+            if guest_cookbooks:
+                taken = {
+                    row.name
+                    for row in db.session.query(Cookbook.name).filter_by(user_id=user.id).all()
+                }
+                for cb in guest_cookbooks:
+                    cb.name = _dedupe_cookbook_name(cb.name, taken)
+                    cb.user_id = user.id
+                    cb.guest_session_id = None
+                    taken.add(cb.name)
 
-    db.session.commit()
+            db.session.commit()
+            return
+        except IntegrityError:
+            # Rollback reverts the uncommitted recipe reassignment too, so the
+            # next attempt re-reads guest rows and occupied names from scratch.
+            db.session.rollback()
+            if attempt == max_retries - 1:
+                raise
 
 
 def credentials_to_dict(credentials):

--- a/blueprints/collections_api_bp.py
+++ b/blueprints/collections_api_bp.py
@@ -105,6 +105,19 @@ def create_collection(user_id, guest_session_id):
         # Idempotent replay: if the caller supplied a key we already have a
         # cookbook for (in their scope), return it unchanged rather than error.
         requested_id = data.get("id") or request.headers.get("Idempotency-Key")
+        # The id / Idempotency-Key becomes Cookbook.id (String(36)). Reject an
+        # oversized or non-string value up front with a 400 — otherwise Postgres
+        # raises at commit (surfacing as an opaque 500) while SQLite silently
+        # accepts it, so behavior would diverge between prod and tests.
+        if requested_id is not None and (
+            not isinstance(requested_id, str) or not 0 < len(requested_id) <= 36
+        ):
+            return (
+                jsonify(
+                    {"error": "id / Idempotency-Key must be a string of at most 36 characters"}
+                ),
+                400,
+            )
         if requested_id:
             existing = (
                 _scope_collections_query(user_id, guest_session_id)
@@ -144,9 +157,7 @@ def create_collection(user_id, guest_session_id):
             if replay is not None:
                 return jsonify(replay.to_dict()), 200
         existing = (
-            _scope_collections_query(user_id, guest_session_id)
-            .filter_by(name=data["name"])
-            .first()
+            _scope_collections_query(user_id, guest_session_id).filter_by(name=data["name"]).first()
         )
         if existing is not None:
             return (

--- a/blueprints/collections_api_bp.py
+++ b/blueprints/collections_api_bp.py
@@ -15,6 +15,7 @@ import uuid
 from datetime import datetime
 
 from flask import Blueprint, jsonify, request, session
+from sqlalchemy.exc import IntegrityError
 
 from extensions import db
 from models import Cookbook
@@ -90,14 +91,31 @@ def create_collection(user_id, guest_session_id):
     Create a new cookbook.
 
     Request body: {"name": "...", "description": "...", "id": "<optional-uuid>"}
+
+    Idempotency: a client may pass a stable ``id`` in the body (also accepted
+    as an ``Idempotency-Key`` header). Replaying a request with an id we already
+    hold returns the existing cookbook (200) instead of creating a duplicate.
+    Duplicate names within the caller's scope are rejected with 409.
     """
     try:
         data = request.get_json()
         if not data or not data.get("name"):
             return jsonify({"error": "name is required"}), 400
 
+        # Idempotent replay: if the caller supplied a key we already have a
+        # cookbook for (in their scope), return it unchanged rather than error.
+        requested_id = data.get("id") or request.headers.get("Idempotency-Key")
+        if requested_id:
+            existing = (
+                _scope_collections_query(user_id, guest_session_id)
+                .filter_by(id=requested_id)
+                .first()
+            )
+            if existing is not None:
+                return jsonify(existing.to_dict()), 200
+
         cookbook = Cookbook(
-            id=data.get("id") or str(uuid.uuid4()),
+            id=requested_id or str(uuid.uuid4()),
             user_id=user_id,
             guest_session_id=None if user_id is not None else guest_session_id,
             name=data["name"],
@@ -108,6 +126,28 @@ def create_collection(user_id, guest_session_id):
         db.session.add(cookbook)
         db.session.commit()
         return jsonify(cookbook.to_dict()), 201
+    except IntegrityError:
+        # Lost a race: either the same id was inserted concurrently (idempotent
+        # replay → 200) or a cookbook with this name already exists in scope
+        # (unique index → 409). Resolve against the now-committed row.
+        db.session.rollback()
+        if requested_id:
+            replay = (
+                _scope_collections_query(user_id, guest_session_id)
+                .filter_by(id=requested_id)
+                .first()
+            )
+            if replay is not None:
+                return jsonify(replay.to_dict()), 200
+        existing = (
+            _scope_collections_query(user_id, guest_session_id)
+            .filter_by(name=data.get("name"))
+            .first()
+        )
+        payload = {"error": "You already have a cookbook with that name"}
+        if existing is not None:
+            payload["collection"] = existing.to_dict()
+        return jsonify(payload), 409
     except Exception as e:
         logger.error(f"Error creating collection: {e}")
         db.session.rollback()

--- a/blueprints/collections_api_bp.py
+++ b/blueprints/collections_api_bp.py
@@ -129,7 +129,11 @@ def create_collection(user_id, guest_session_id):
     except IntegrityError:
         # Lost a race: either the same id was inserted concurrently (idempotent
         # replay → 200) or a cookbook with this name already exists in scope
-        # (unique index → 409). Resolve against the now-committed row.
+        # (unique index → 409). Resolve against the now-committed row. Fall
+        # through to a generic conflict when neither an in-scope id nor an
+        # in-scope name matches — the IntegrityError was on the primary key
+        # cross-scope, or on the FK to user (stale session), and reporting a
+        # name collision the caller does not actually own would mislead them.
         db.session.rollback()
         if requested_id:
             replay = (
@@ -141,13 +145,20 @@ def create_collection(user_id, guest_session_id):
                 return jsonify(replay.to_dict()), 200
         existing = (
             _scope_collections_query(user_id, guest_session_id)
-            .filter_by(name=data.get("name"))
+            .filter_by(name=data["name"])
             .first()
         )
-        payload = {"error": "You already have a cookbook with that name"}
         if existing is not None:
-            payload["collection"] = existing.to_dict()
-        return jsonify(payload), 409
+            return (
+                jsonify(
+                    {
+                        "error": "You already have a cookbook with that name",
+                        "collection": existing.to_dict(),
+                    }
+                ),
+                409,
+            )
+        return jsonify({"error": "Could not create cookbook due to a conflict"}), 409
     except Exception as e:
         logger.error(f"Error creating collection: {e}")
         db.session.rollback()

--- a/migrations/versions/b7e2a9c4d1f8_cookbook_name_unique_indexes.py
+++ b/migrations/versions/b7e2a9c4d1f8_cookbook_name_unique_indexes.py
@@ -79,6 +79,17 @@ def _dedupe_scope(bind, scope_col):
 
 def upgrade():
     bind = op.get_bind()
+
+    # The prod migrate job (flask-backend-migrate) runs while the OLD Flask
+    # revision is still serving traffic, so it could INSERT a fresh duplicate
+    # between the de-dup pass below and CREATE UNIQUE INDEX — which would make
+    # the index build fail and abort the deploy. Take an exclusive table lock
+    # (held until this transaction commits, i.e. past index creation) so no
+    # write can slip into that window. Postgres only: SQLite has no LOCK TABLE
+    # and runs the migration single-connection anyway.
+    if bind.dialect.name == "postgresql":
+        op.execute("LOCK TABLE cookbook IN ACCESS EXCLUSIVE MODE")
+
     _dedupe_scope(bind, "user_id")
     _dedupe_scope(bind, "guest_session_id")
 

--- a/migrations/versions/b7e2a9c4d1f8_cookbook_name_unique_indexes.py
+++ b/migrations/versions/b7e2a9c4d1f8_cookbook_name_unique_indexes.py
@@ -1,0 +1,105 @@
+"""Enforce unique cookbook name per owner scope
+
+Adds two partial unique indexes so the app can no longer persist the duplicate
+cookbooks produced by rapid repeat "Create" clicks:
+
+    uq_cookbook_user_name   UNIQUE (user_id, name)          WHERE user_id IS NOT NULL
+    uq_cookbook_guest_name  UNIQUE (guest_session_id, name) WHERE guest_session_id IS NOT NULL
+
+Exactly one of (user_id, guest_session_id) is non-NULL on every row, so two
+partial indexes (rather than one composite constraint) are the correct shape.
+
+Existing rows may already violate the new constraint (the duplicate-cookbook
+race shipped duplicates to production). Creating a unique index over dirty data
+fails, which would abort the flask-backend-migrate job and block every deploy.
+So ``upgrade()`` first de-duplicates by RENAMING later collisions — it keeps the
+earliest row per (scope, name) untouched and suffixes the rest ("Name (2)", …).
+No rows are deleted; all data is preserved.
+
+Revision ID: b7e2a9c4d1f8
+Revises: f4a1c2d3e4b5
+Create Date: 2026-07-18 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b7e2a9c4d1f8"
+down_revision = "f4a1c2d3e4b5"
+branch_labels = None
+depends_on = None
+
+_NAME_MAX = 200  # cookbook.name is String(200)
+
+
+def _suffixed(base, n):
+    """Return ``"base (n)"`` trimmed to fit the name column."""
+    tag = f" ({n})"
+    return base[: max(0, _NAME_MAX - len(tag))] + tag
+
+
+def _dedupe_scope(bind, scope_col):
+    """Rename duplicate (scope, name) rows so a unique index can be created.
+
+    Keeps the earliest row (by created_at, then id) per (scope, name) and
+    appends an incrementing suffix to the rest, avoiding new collisions.
+    """
+    rows = bind.execute(
+        sa.text(
+            f"SELECT id, {scope_col} AS scope, name "  # noqa: S608 - scope_col is a fixed literal
+            "FROM cookbook "
+            f"WHERE {scope_col} IS NOT NULL "
+            f"ORDER BY {scope_col}, name, created_at, id"
+        )
+    ).fetchall()
+
+    taken = {(r.scope, r.name) for r in rows}
+    seen: dict[tuple, int] = {}
+
+    for r in rows:
+        key = (r.scope, r.name)
+        count = seen.get(key, 0)
+        seen[key] = count + 1
+        if count == 0:
+            continue  # earliest row for this (scope, name) — leave it alone
+
+        suffix = count + 1
+        new_name = _suffixed(r.name, suffix)
+        while (r.scope, new_name) in taken:
+            suffix += 1
+            new_name = _suffixed(r.name, suffix)
+        taken.add((r.scope, new_name))
+        bind.execute(
+            sa.text("UPDATE cookbook SET name = :name WHERE id = :id"),
+            {"name": new_name, "id": r.id},
+        )
+
+
+def upgrade():
+    bind = op.get_bind()
+    _dedupe_scope(bind, "user_id")
+    _dedupe_scope(bind, "guest_session_id")
+
+    op.create_index(
+        "uq_cookbook_user_name",
+        "cookbook",
+        ["user_id", "name"],
+        unique=True,
+        postgresql_where=sa.text("user_id IS NOT NULL"),
+        sqlite_where=sa.text("user_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_cookbook_guest_name",
+        "cookbook",
+        ["guest_session_id", "name"],
+        unique=True,
+        postgresql_where=sa.text("guest_session_id IS NOT NULL"),
+        sqlite_where=sa.text("guest_session_id IS NOT NULL"),
+    )
+
+
+def downgrade():
+    op.drop_index("uq_cookbook_guest_name", table_name="cookbook")
+    op.drop_index("uq_cookbook_user_name", table_name="cookbook")

--- a/models/cookbook.py
+++ b/models/cookbook.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from sqlalchemy import JSON as GenericJSON
+from sqlalchemy import Index, text
 
 from extensions import db
 
@@ -18,6 +19,33 @@ class Cookbook(db.Model):  # type: ignore[name-defined, misc]
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(
         db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    # A cookbook name must be unique within its owner scope so the app cannot
+    # persist the duplicate rows produced by rapid repeat "Create" clicks.
+    # Exactly one of (user_id, guest_session_id) is non-NULL per row, so we use
+    # two partial unique indexes rather than a single composite constraint —
+    # a plain UniqueConstraint would collapse every guest row to (NULL, name)
+    # and never (Postgres) or wrongly (some engines) collide. The WHERE clause
+    # is emitted for both Postgres (prod) and SQLite (dev/test), which both
+    # support partial indexes.
+    __table_args__ = (
+        Index(
+            "uq_cookbook_user_name",
+            "user_id",
+            "name",
+            unique=True,
+            postgresql_where=text("user_id IS NOT NULL"),
+            sqlite_where=text("user_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_cookbook_guest_name",
+            "guest_session_id",
+            "name",
+            unique=True,
+            postgresql_where=text("guest_session_id IS NOT NULL"),
+            sqlite_where=text("guest_session_id IS NOT NULL"),
+        ),
     )
 
     user = db.relationship("User", backref=db.backref("cookbooks", lazy=True))

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -148,6 +148,39 @@ def test_missing_name_still_400(app, client):
     assert resp.status_code == 400
 
 
+def test_oversized_id_rejected_400(app, client):
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+    _login(client, uid)
+    # id longer than Cookbook.id String(36) — must 400, not 500 (Postgres) or
+    # a silently-accepted overlong row (SQLite).
+    resp = client.post("/api/collections", json={"name": "X", "id": "y" * 64})
+    assert resp.status_code == 400
+    assert _count(client) == 0
+
+
+def test_oversized_idempotency_key_header_rejected_400(app, client):
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+    _login(client, uid)
+    resp = client.post(
+        "/api/collections",
+        json={"name": "X"},
+        headers={"Idempotency-Key": "z" * 64},
+    )
+    assert resp.status_code == 400
+    assert _count(client) == 0
+
+
+def test_non_string_id_rejected_400(app, client):
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+    _login(client, uid)
+    resp = client.post("/api/collections", json={"name": "X", "id": 12345})
+    assert resp.status_code == 400
+    assert _count(client) == 0
+
+
 # ── Guests ─────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -1,0 +1,191 @@
+"""Tests for the collections (cookbook) API — duplicate-cookbook race fix.
+
+Covers the server-side defenses added to stop rapid repeat "Create" clicks from
+persisting duplicate cookbooks:
+
+- a partial unique index on (owner scope, name), surfaced as HTTP 409
+- idempotent replay when the same id / Idempotency-Key is retried (HTTP 200)
+
+Owner scope is (user_id) for authenticated users and (guest_session_id) for
+guests; the two are enforced by separate partial unique indexes.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models import Cookbook  # noqa: E402
+from models.user import User  # noqa: E402
+
+
+@pytest.fixture
+def app(tmp_path):
+    # A file-backed SQLite DB is shared across the test client's per-request
+    # connections (an in-memory DB is not), so schema created here is visible
+    # to the HTTP handlers. See CLAUDE.md "Tests must hit the right DB engine".
+    flask_app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{tmp_path / 'test.db'}",
+        SECRET_KEY="test-secret",
+    )
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_user(email):
+    u = User(email=email, name=email.split("@")[0])
+    db.session.add(u)
+    db.session.commit()
+    return u.id
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+
+
+def _create(client, name, **body):
+    payload = {"name": name}
+    payload.update(body)
+    return client.post("/api/collections", json=payload)
+
+
+def _count(client):
+    resp = client.get("/api/collections")
+    return len(resp.get_json()["collections"])
+
+
+# ── Authenticated users ────────────────────────────────────────────────────
+
+
+def test_duplicate_name_same_user_returns_409(app, client):
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+    _login(client, uid)
+
+    r1 = _create(client, "Weeknight Dinners")
+    assert r1.status_code == 201, r1.data
+
+    r2 = _create(client, "Weeknight Dinners")
+    assert r2.status_code == 409, r2.data
+    body = r2.get_json()
+    assert "already have a cookbook" in body["error"].lower()
+    # The 409 payload echoes the existing cookbook so the client can reconcile.
+    assert body["collection"]["name"] == "Weeknight Dinners"
+
+    assert _count(client) == 1
+
+
+def test_same_name_different_users_both_succeed(app):
+    with app.app_context():
+        uid1 = _make_user("a@example.com")
+        uid2 = _make_user("b@example.com")
+
+    # Use two independent clients so sessions don't bleed.
+    client1 = _client_for(app)
+    client2 = _client_for(app)
+    _login(client1, uid1)
+    _login(client2, uid2)
+
+    assert _create(client1, "Shared Name").status_code == 201
+    assert _create(client2, "Shared Name").status_code == 201
+
+    assert _count(client1) == 1
+    assert _count(client2) == 1
+
+
+def test_idempotent_replay_same_id_returns_200(app, client):
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+    _login(client, uid)
+
+    fixed_id = "cookbook-fixed-id-1"
+    r1 = _create(client, "My Book", id=fixed_id)
+    assert r1.status_code == 201, r1.data
+
+    r2 = _create(client, "My Book", id=fixed_id)
+    assert r2.status_code == 200, r2.data
+    assert r2.get_json()["id"] == fixed_id
+
+    assert _count(client) == 1
+
+
+def test_idempotency_key_header_replays(app, client):
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+    _login(client, uid)
+
+    headers = {"Idempotency-Key": "key-abc"}
+    r1 = client.post("/api/collections", json={"name": "Header Book"}, headers=headers)
+    assert r1.status_code == 201, r1.data
+    assert r1.get_json()["id"] == "key-abc"
+
+    r2 = client.post("/api/collections", json={"name": "Header Book"}, headers=headers)
+    assert r2.status_code == 200, r2.data
+    assert r2.get_json()["id"] == "key-abc"
+
+    assert _count(client) == 1
+
+
+def test_missing_name_still_400(app, client):
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+    _login(client, uid)
+    resp = client.post("/api/collections", json={})
+    assert resp.status_code == 400
+
+
+# ── Guests ─────────────────────────────────────────────────────────────────
+
+
+def test_guest_duplicate_name_returns_409(client):
+    # No login → guest scope; the client keeps its guest session across requests.
+    assert _create(client, "Guest Cookbook").status_code == 201
+    assert _create(client, "Guest Cookbook").status_code == 409
+    assert _count(client) == 1
+
+
+def test_guest_and_user_may_share_a_name(app):
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+
+    guest = _client_for(app)
+    authed = _client_for(app)
+    _login(authed, uid)
+
+    # Same name, different scopes (guest vs. authenticated) → no collision.
+    assert _create(guest, "Overlap").status_code == 201
+    assert _create(authed, "Overlap").status_code == 201
+
+
+# ── Model-level constraint ─────────────────────────────────────────────────
+
+
+def test_model_rejects_duplicate_user_name(app):
+    from sqlalchemy.exc import IntegrityError
+
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+        db.session.add(Cookbook(id="c1", user_id=uid, name="Dup"))
+        db.session.commit()
+        db.session.add(Cookbook(id="c2", user_id=uid, name="Dup"))
+        with pytest.raises(IntegrityError):
+            db.session.commit()
+        db.session.rollback()
+
+
+def _client_for(app):
+    return app.test_client()

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -261,5 +261,39 @@ def test_login_merge_no_collision_reassigns_cleanly(app):
         assert moved.guest_session_id is None
 
 
+def test_login_merge_retries_on_integrity_error_then_raises(app, monkeypatch):
+    """A name lost to a concurrent write mid-merge must retry, not fail silently.
+
+    Force every rename to land on a name the user already owns so the commit
+    keeps hitting the unique index; the loop must retry the configured number of
+    times and then re-raise so the caller rolls back (never leaving the session
+    half-merged without signalling).
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    import blueprints.auth_api_bp as auth_mod
+
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+        db.session.add(Cookbook(id="u1", user_id=uid, name="Taken"))
+        db.session.add(Cookbook(id="g1", guest_session_id="sess-3", name="Guest Book"))
+        db.session.commit()
+
+        calls = {"n": 0}
+
+        def _always_collide(name, taken):
+            calls["n"] += 1
+            return "Taken"  # collides with the user's existing cookbook every time
+
+        monkeypatch.setattr(auth_mod, "_dedupe_cookbook_name", _always_collide)
+
+        user = db.session.get(User, uid)
+        with pytest.raises(IntegrityError):
+            auth_mod._merge_guest_session_into_user(user, "sess-3", max_retries=3)
+
+        # One dedupe call per attempt → proves it retried the full budget.
+        assert calls["n"] == 3
+
+
 def _client_for(app):
     return app.test_client()

--- a/tests/test_collections_api.py
+++ b/tests/test_collections_api.py
@@ -220,5 +220,46 @@ def test_model_rejects_duplicate_user_name(app):
         db.session.rollback()
 
 
+# ── Guest → user login merge (regression: unique index must not orphan rows) ──
+
+
+def test_login_merge_renames_colliding_guest_cookbook(app):
+    from blueprints.auth_api_bp import _merge_guest_session_into_user
+
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+        # User already owns "My Book". Guest has a same-named "My Book" plus a
+        # distinct "Other" — without collision handling the merge would fail on
+        # the (user_id, name) index and roll back, losing all guest rows.
+        db.session.add(Cookbook(id="u1", user_id=uid, name="My Book"))
+        db.session.add(Cookbook(id="g1", guest_session_id="sess-1", name="My Book"))
+        db.session.add(Cookbook(id="g2", guest_session_id="sess-1", name="Other"))
+        db.session.commit()
+
+        user = db.session.get(User, uid)
+        _merge_guest_session_into_user(user, "sess-1")
+
+        owned = sorted(cb.name for cb in Cookbook.query.filter_by(user_id=uid).all())
+        assert owned == ["My Book", "My Book (2)", "Other"]  # nothing lost
+        # No orphaned guest rows remain for that session.
+        assert Cookbook.query.filter_by(guest_session_id="sess-1").count() == 0
+
+
+def test_login_merge_no_collision_reassigns_cleanly(app):
+    from blueprints.auth_api_bp import _merge_guest_session_into_user
+
+    with app.app_context():
+        uid = _make_user("owner@example.com")
+        db.session.add(Cookbook(id="g1", guest_session_id="sess-2", name="Weeknight"))
+        db.session.commit()
+
+        user = db.session.get(User, uid)
+        _merge_guest_session_into_user(user, "sess-2")
+
+        moved = Cookbook.query.filter_by(user_id=uid).one()
+        assert moved.name == "Weeknight"
+        assert moved.guest_session_id is None
+
+
 def _client_for(app):
     return app.test_client()

--- a/tests/test_migration_cookbook_unique.py
+++ b/tests/test_migration_cookbook_unique.py
@@ -1,0 +1,102 @@
+"""Tests for the cookbook-name de-duplication step in migration b7e2a9c4d1f8.
+
+The migration must rename pre-existing duplicate (scope, name) rows before it can
+create the unique index — otherwise ``flask db upgrade`` fails on dirty prod data
+and blocks the deploy. This exercises the rename helper directly against a table
+built WITHOUT the unique index (the model now carries it, so a normal
+``db.create_all`` cannot hold duplicates to test against).
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import sqlalchemy as sa
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+
+def _load_migration():
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "migrations"
+        / "versions"
+        / "b7e2a9c4d1f8_cookbook_name_unique_indexes.py"
+    )
+    spec = importlib.util.spec_from_file_location("mig_b7e2a9c4d1f8", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _bare_cookbook_engine(tmp_path):
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'mig.db'}")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE cookbook ("
+                "id TEXT PRIMARY KEY, user_id INTEGER, guest_session_id TEXT, "
+                "name TEXT NOT NULL, created_at TEXT)"
+            )
+        )
+    return engine
+
+
+def test_dedupe_renames_user_duplicates_keeping_earliest(tmp_path):
+    mig = _load_migration()
+    engine = _bare_cookbook_engine(tmp_path)
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO cookbook (id, user_id, name, created_at) VALUES "
+                "('a', 1, 'Dooypkiitts', '2026-01-01'),"
+                "('b', 1, 'Dooypkiitts', '2026-01-02'),"
+                "('c', 1, 'Dooypkiitts', '2026-01-03'),"
+                "('d', 2, 'Dooypkiitts', '2026-01-01')"
+            )
+        )
+        mig._dedupe_scope(conn, "user_id")
+        u1 = conn.execute(
+            sa.text("SELECT name FROM cookbook WHERE user_id=1 ORDER BY created_at")
+        ).fetchall()
+        u2 = conn.execute(sa.text("SELECT name FROM cookbook WHERE user_id=2")).fetchall()
+
+    # Earliest kept; later collisions suffixed.
+    assert [r.name for r in u1] == ["Dooypkiitts", "Dooypkiitts (2)", "Dooypkiitts (3)"]
+    # A different user's identical name is untouched.
+    assert [r.name for r in u2] == ["Dooypkiitts"]
+
+    # The unique index can now be built without error.
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE UNIQUE INDEX uq_cookbook_user_name ON cookbook (user_id, name) "
+                "WHERE user_id IS NOT NULL"
+            )
+        )
+
+
+def test_dedupe_handles_guests_and_avoids_new_collisions(tmp_path):
+    mig = _load_migration()
+    engine = _bare_cookbook_engine(tmp_path)
+    with engine.begin() as conn:
+        # Two guest dupes of "Book", plus a pre-existing "Book (2)" that the
+        # naive suffix would collide with — the helper must skip past it.
+        conn.execute(
+            sa.text(
+                "INSERT INTO cookbook (id, guest_session_id, name, created_at) VALUES "
+                "('a', 'g1', 'Book', '2026-01-01'),"
+                "('b', 'g1', 'Book', '2026-01-02'),"
+                "('c', 'g1', 'Book (2)', '2026-01-03')"
+            )
+        )
+        mig._dedupe_scope(conn, "guest_session_id")
+        names = conn.execute(
+            sa.text("SELECT name FROM cookbook WHERE guest_session_id='g1' ORDER BY created_at")
+        ).fetchall()
+
+    resolved = [r.name for r in names]
+    assert resolved[0] == "Book"  # earliest kept
+    assert resolved[2] == "Book (2)"  # the pre-existing distinct name kept
+    assert resolved[1] == "Book (3)"  # renamed past the collision
+    assert len(set(resolved)) == 3  # all unique now


### PR DESCRIPTION
## Problem

Rapid repeat **Create** clicks in the cookbook app persisted **duplicate cookbooks** — one `POST /api/collections` fired per click and nothing de-duplicated at the data layer, so each request created a distinct row (both returned `201`). Reproduced live: two concurrent identical-name POSTs → two rows, different ids.

## Fix (server side)

- **Partial unique indexes** on `Cookbook`: `(user_id, name)` and `(guest_session_id, name)`, each `WHERE <scope> IS NOT NULL`. Two partial indexes are the correct shape because exactly one of the scope columns is non-NULL per row (a plain composite `UniqueConstraint` would collapse all guest rows to `(NULL, name)`). Emitted for both Postgres (prod) and SQLite (dev/test).
- **`POST /api/collections`** now:
  - returns **409** (with the existing cookbook in the payload) on a duplicate name, caught as `IntegrityError` — previously the broad `except` turned this into a 500;
  - treats a repeated `id` / **`Idempotency-Key`** header as an **idempotent replay** (200), returning the existing cookbook instead of erroring.

## Migration safety (important)

Production already contains duplicate rows from this bug. Creating a unique index over them would fail `flask db upgrade` and **abort the deploy** (the `flask-backend-migrate` job runs before the Flask service is redeployed). So the migration **first de-duplicates by renaming** later collisions — keeps the earliest row per `(scope, name)`, suffixes the rest (`Name (2)`, `Name (3)`, …), avoiding new collisions. **No rows are deleted.**

## Tests

`tests/test_collections_api.py` + `tests/test_migration_cookbook_unique.py`:
- 409 on duplicate name (same user); only one row persisted
- same name allowed across different users and across guest vs. authenticated scope
- guest duplicate name → 409
- idempotent replay via body `id` and via `Idempotency-Key` header → 200, one row
- model-level `IntegrityError` on duplicate `(user_id, name)`
- migration de-dup helper keeps earliest, suffixes rest, skips pre-existing suffixed names

Full suite: **287 passed**. `black`/`flake8`/`mypy` clean. Migration verified up + down on fresh SQLite; `flask db heads` = single head `b7e2a9c4d1f8`.

## Ships with

Cookbook client guard PR (adamtasteslikegoodtheangularsvegancookbook#3163) + a follow-up submodule pointer bump once this lands on Backend `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qq6gVEQq5FUW7TJvtp7b77










<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

