### PR TITLE
fix(public): UX/nav/dead-links audit fixes (cookbook #3164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ tests/                          # pytest
 recipe_schema.json              # canonical recipe shape
 ```
 
+### Legacy Flask HTML surface is DEV-ONLY
+
+The original server-rendered HTML UI — `/` and `/recipe/<filename>` (`recipes_bp.py`), `/generate_recipe` (`generation_bp.py`), the `/auth/*` pages, and the templates extending `templates/base.html` (`index.html`, `generate_recipe.html`, `recipe.html`, `profile.html`, `json_viewer.html`) — is **never reachable in production**: the Express proxy only forwards `/api/*`, `/r/<slug>`, `/browse`, `/sitemap.xml`, and `/static/*` to Flask. These pages exist only when running Flask directly on :5000 for local development. The production-facing SSR pages live under `templates/public/` (`base_public.html`); the app-level 404/500 error pages extend the public base for that reason. Do not add production features to the legacy surface, and do not link production pages to its routes. Deleting it entirely is a tracked follow-up (cookbook #3164).
+
 ### Authentication
 
 Gemini credential handling lives in `services/gemini_service.py:get_genai_client(session_credentials)`: it prefers caller-supplied user OAuth credentials, falls back to the server `GOOGLE_API_KEY`, and returns `None` if neither works — it never reads the Flask session itself. Today both live generation call sites (`services/image_service.py` and the Pub/Sub worker in `blueprints/worker_api_bp.py`) pass `None`, so generation runs on the server key; only model refresh (`blueprints/api_bp.py` → `refresh_models_from_api`) forwards `session.get("credentials")`. Preserve that preference order.

--- a/app.py
+++ b/app.py
@@ -40,6 +40,31 @@ from utils.session_utils import get_or_create_session_id
 logger = setup_logging()
 
 
+def _register_image_cache_hygiene(app):
+    """Strip CORS headers from the public recipe-image endpoint.
+
+    Recipe images are consumed same-origin through the Express proxy and
+    must be cacheable by shared caches (CDN/browser). Flask-CORS decorates
+    every response app-wide, which stamped Access-Control-Allow-Origin
+    (reflecting whatever dev origin was allowed) + Vary onto image bytes and
+    defeated caching (cookbook #3164). Must be called BEFORE CORS(app):
+    Flask runs app-level after_request functions in reverse registration
+    order, so this runs after Flask-CORS has added its headers.
+    """
+
+    @app.after_request
+    def strip_cors_from_recipe_images(response):
+        if request.endpoint == "generation_api.serve_recipe_image":
+            for header in (
+                "Access-Control-Allow-Origin",
+                "Access-Control-Allow-Credentials",
+                "Access-Control-Expose-Headers",
+                "Vary",
+            ):
+                response.headers.pop(header, None)
+        return response
+
+
 def create_app(**config_overrides):
     """
     Application factory for creating the Flask app.
@@ -233,25 +258,8 @@ def create_app(**config_overrides):
         ]
     )
 
-    # Recipe images are consumed same-origin through the Express proxy and
-    # must be cacheable by shared caches (CDN/browser). Flask-CORS decorates
-    # every response app-wide, which stamped Access-Control-Allow-Origin
-    # (reflecting whatever dev origin was allowed) + Vary onto image bytes and
-    # defeated caching (cookbook #3164). Strip CORS headers from that endpoint.
-    # Registered BEFORE CORS(app) on purpose: Flask runs app-level
-    # after_request functions in reverse registration order, so this runs
-    # after Flask-CORS has added its headers.
-    @app.after_request
-    def strip_cors_from_recipe_images(response):
-        if request.endpoint == "generation_api.serve_recipe_image":
-            for header in (
-                "Access-Control-Allow-Origin",
-                "Access-Control-Allow-Credentials",
-                "Access-Control-Expose-Headers",
-                "Vary",
-            ):
-                response.headers.pop(header, None)
-        return response
+    # Must stay before CORS(app) — see _register_image_cache_hygiene.
+    _register_image_cache_hygiene(app)
 
     CORS(
         app,

--- a/app.py
+++ b/app.py
@@ -233,6 +233,26 @@ def create_app(**config_overrides):
         ]
     )
 
+    # Recipe images are consumed same-origin through the Express proxy and
+    # must be cacheable by shared caches (CDN/browser). Flask-CORS decorates
+    # every response app-wide, which stamped Access-Control-Allow-Origin
+    # (reflecting whatever dev origin was allowed) + Vary onto image bytes and
+    # defeated caching (cookbook #3164). Strip CORS headers from that endpoint.
+    # Registered BEFORE CORS(app) on purpose: Flask runs app-level
+    # after_request functions in reverse registration order, so this runs
+    # after Flask-CORS has added its headers.
+    @app.after_request
+    def strip_cors_from_recipe_images(response):
+        if request.endpoint == "generation_api.serve_recipe_image":
+            for header in (
+                "Access-Control-Allow-Origin",
+                "Access-Control-Allow-Credentials",
+                "Access-Control-Expose-Headers",
+                "Vary",
+            ):
+                response.headers.pop(header, None)
+        return response
+
     CORS(
         app,
         origins=cors_origins,
@@ -252,6 +272,14 @@ def create_app(**config_overrides):
         """
         # Skip session creation for static files to avoid unnecessary overhead
         if request.endpoint and "static" in request.endpoint:
+            return None
+
+        # Skip the recipe-image endpoint: touching the session there attached
+        # Set-Cookie + Vary: Cookie to every image response, making the
+        # public, cacheable images uncacheable by any shared cache (cookbook
+        # #3164). Private-image access control still reads the existing
+        # session cookie inside the endpoint itself.
+        if request.endpoint == "generation_api.serve_recipe_image":
             return None
 
         # Ensure session has an ID for tracking

--- a/blueprints/generation_api_bp.py
+++ b/blueprints/generation_api_bp.py
@@ -227,6 +227,25 @@ def get_recipe_status(recipe_id):
     return jsonify({"status": recipe.status, "recipe": recipe.data}), 200
 
 
+def _image_mimetype(image_bytes: bytes) -> str:
+    """Sniff the real image type from the bytes' magic numbers.
+
+    Imagen has produced JPEG bytes for recipes while this endpoint hardcoded
+    ``image/png`` — a mismatch that breaks strict crawlers/CDNs and the
+    audit's content-type check (cookbook #3164). Defaults to PNG for
+    unrecognized payloads (the endpoint's historical behavior).
+    """
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if image_bytes[:4] == b"RIFF" and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    if image_bytes.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    return "image/png"
+
+
 @generation_api_bp.route("/recipes/<recipe_id>/image", methods=["GET"])
 def serve_recipe_image(recipe_id):
     """
@@ -238,6 +257,13 @@ def serve_recipe_image(recipe_id):
     Access rules:
         - If the recipe is public (``is_public=True``) anyone may fetch the image.
         - Otherwise the recipe must belong to the current user or guest session.
+
+    Response hygiene (cookbook #3164): public-recipe responses are meant to be
+    CDN/browser cacheable, so this endpoint is exempted from the app-wide
+    session touch (no ``Set-Cookie``/``Vary: Cookie`` — see
+    ``ensure_session_id`` in app.py) and CORS headers are stripped in
+    ``create_app`` (images are consumed same-origin through the Express
+    proxy; ACAO on them defeated shared caching).
     """
     # Public recipes bypass ownership scoping so unauthenticated SSR pages
     # and crawlers can still load the image.
@@ -266,7 +292,7 @@ def serve_recipe_image(recipe_id):
     if cached_bytes is not None:
         return Response(
             cached_bytes,
-            mimetype="image/png",
+            mimetype=_image_mimetype(cached_bytes),
             headers={"Cache-Control": http_cache_control},
         )
 
@@ -296,7 +322,7 @@ def serve_recipe_image(recipe_id):
 
     return Response(
         image_bytes,
-        mimetype="image/png",
+        mimetype=_image_mimetype(image_bytes),
         headers={"Cache-Control": http_cache_control},
     )
 

--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -73,11 +73,19 @@ def _minutes_to_iso_duration(value: Any) -> str | None:
 
 
 def _recipe_image_url(recipe: Recipe) -> str | None:
+    """URL of an image the site can actually serve, or ``None`` to omit it.
+
+    A recipe row can carry an ``ai_image_url`` whose bytes were never
+    persisted (the /api/recipes/<id>/image endpoint then 404s). Trusting that
+    field produced dead hero images and dead ``og:image`` URLs on live
+    recipe pages (cookbook #3164). Derive the page media from the signal the
+    image endpoint actually serves from (real GCS/base64 bytes), else an
+    external stock image — never from the unverified ``ai_image_url``.
+    The same gate feeds the Pinterest share button, so the pin media and the
+    page media can never disagree.
+    """
     data = recipe.data or {}
-    ai_image_url = data.get("ai_image_url")
-    if ai_image_url:
-        return _absolute_url(ai_image_url)
-    if data.get("ai_image_data") or data.get("ai_image_gcs"):
+    if data.get("ai_image_gcs") or data.get("ai_image_data"):
         return _canonical_url("generation_api.serve_recipe_image", recipe_id=recipe.id)
     return _absolute_url(data.get("stock_image_url"))
 
@@ -212,23 +220,11 @@ def _recipe_json_ld(recipe: Recipe, canonical_url: str, image_url: str | None) -
     return cleaned
 
 
-def _pinnable_image_url(recipe: Recipe) -> str | None:
-    """URL of an image Pinterest can actually fetch, or ``None`` to hide the button.
-
-    A recipe row can carry an ``ai_image_url`` whose bytes were never
-    persisted (the /api/recipes/<id>/image endpoint then 404s), which makes
-    ``_recipe_image_url`` return a dead link. Pinning that produces a broken
-    pin — and a run of broken pins to a fresh domain is exactly what trips
-    Pinterest's new-account spam heuristics. Derive the pin media from the
-    signal the image endpoint actually serves from (real GCS/base64 bytes),
-    else an external stock image — the shared URL is the value that passed
-    the gate, so the two can never disagree (a stale ``ai_image_url`` next
-    to a valid stock image must pin the stock image, not the dead link).
-    """
-    data = recipe.data or {}
-    if data.get("ai_image_gcs") or data.get("ai_image_data"):
-        return _canonical_url("generation_api.serve_recipe_image", recipe_id=recipe.id)
-    return _absolute_url(data.get("stock_image_url"))
+# Pinterest pin media uses the same byte-gated URL as the page itself
+# (see _recipe_image_url): pinning a dead link creates broken pins, and a
+# run of broken pins to a fresh domain trips Pinterest's new-account spam
+# heuristics (Backend #203/#204).
+_pinnable_image_url = _recipe_image_url
 
 
 def _pinterest_share_url(canonical_url: str, image_url: str | None, recipe_name: str) -> str:
@@ -301,7 +297,6 @@ def show_public_recipe(slug):
             else None
         ),
         spa_save_url=f"{_public_base_url()}/?save={recipe.slug}#kitchen",
-        save_to_cookbook_url=f"{_public_base_url()}/#kitchen",
     )
 
 

--- a/scripts/unpublish_slugs.py
+++ b/scripts/unpublish_slugs.py
@@ -51,6 +51,13 @@ def unpublish_slugs(app, slugs):
                 print(f"ALREADY   {slug} — is_public was already False")
                 continue
             recipe.is_public = False
+            # The recipes API returns recipe.data verbatim and full saves write
+            # data["is_public"] back to the column (db_recipe_repository.py:534,
+            # 653), so a column-only unpublish would show stale is_public: true
+            # in the SPA and get silently republished by the next save. Keep the
+            # blob in sync, same as scripts/gate_guest_public_recipes.py.
+            if isinstance(recipe.data, dict) and recipe.data.get("is_public"):
+                recipe.data["is_public"] = False
             unpublished.append(slug)
             print(f"UNPUBLISH {slug} — is_public set to False (recipe id {recipe.id})")
         db.session.commit()

--- a/scripts/unpublish_slugs.py
+++ b/scripts/unpublish_slugs.py
@@ -1,0 +1,77 @@
+"""Unpublish public recipes by slug (idempotent, reversible).
+
+Sets ``is_public = False`` on each recipe whose slug is passed as an
+argument. Unpublishing removes the recipe from /browse, /r/<slug> (404) and
+the sitemap automatically; nothing is deleted, so a recipe is re-published
+by flipping ``is_public`` back (e.g. via the SPA publish toggle).
+
+Written for the cookbook #3164 audit to retire junk/test slugs and the two
+recipes whose ``ai_image_url`` has no persisted bytes (dead hero/og:image).
+Re-publish those two only after their images are backfilled.
+
+Usage (local, against the DATABASE_URL in .env / SQLite dev DB):
+
+    uv run python scripts/unpublish_slugs.py slug-one slug-two ...
+
+In production, run inside a one-off Cloud Run job or ``flask shell``
+environment with the production ``DATABASE_URL``:
+
+    python scripts/unpublish_slugs.py slug-one slug-two ...
+
+The script is idempotent: already-private and unknown slugs are reported and
+skipped, and the exit code is 0 as long as every requested slug was either
+unpublished now or already private. Unknown slugs exit 1 so typos are loud.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+
+
+def unpublish_slugs(app, slugs):
+    """Set is_public=False for each slug. Returns (unpublished, already, missing)."""
+    unpublished: list[str] = []
+    already_private: list[str] = []
+    missing: list[str] = []
+
+    with app.app_context():
+        for slug in slugs:
+            recipe = Recipe.query.filter(Recipe.slug == slug).first()
+            if recipe is None:
+                missing.append(slug)
+                print(f"MISSING   {slug} — no recipe with this slug")
+                continue
+            if not recipe.is_public:
+                already_private.append(slug)
+                print(f"ALREADY   {slug} — is_public was already False")
+                continue
+            recipe.is_public = False
+            unpublished.append(slug)
+            print(f"UNPUBLISH {slug} — is_public set to False (recipe id {recipe.id})")
+        db.session.commit()
+
+    print(
+        f"Done: {len(unpublished)} unpublished, "
+        f"{len(already_private)} already private, {len(missing)} missing."
+    )
+    return unpublished, already_private, missing
+
+
+def main(argv):
+    slugs = [slug for slug in argv if slug.strip()]
+    if not slugs:
+        print("Usage: python scripts/unpublish_slugs.py <slug> [<slug> ...]", file=sys.stderr)
+        return 2
+
+    app = create_app()
+    _, _, missing = unpublish_slugs(app, slugs)
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,6 +1,12 @@
-{% extends "base.html" %}
+{% extends "public/base_public.html" %}
 
-{% block title %}404 - Page Not Found | TastesLikeGood.com{% endblock %}
+{# Rendered by the app-level 404 handler (app.py), so it must extend the
+   PUBLIC base: in production only /r/<slug>, /browse, /sitemap.xml and
+   /api/* reach Flask through Express, and the legacy base.html CTAs
+   (/ and /generate_recipe) are never proxied — they silently landed
+   visitors on the SPA shell (cookbook #3164). #}
+
+{% block title %}404 - Page Not Found · TastesLikeGood.org{% endblock %}
 
 {% block content %}
 <div class="error-page">
@@ -9,8 +15,8 @@
     <p>It might have been moved, deleted, or you may have mistyped the URL.</p>
 
     <div class="error-actions">
-        <a href="{{ url_for('recipes.index') }}" class="button">Go to Home</a>
-        <a href="{{ url_for('generation.generate_recipe') }}" class="button">Generate a Recipe</a>
+        <a href="{{ url_for('public.browse_public_recipes') }}" class="button">Browse recipes</a>
+        <a href="/#kitchen" class="button">Open the cookbook app</a>
     </div>
 </div>
 
@@ -45,7 +51,7 @@
     .error-actions .button {
         display: inline-block;
         padding: 0.75rem 1.5rem;
-        background-color: #4CAF50;
+        background-color: #4caf50;
         color: white;
         text-decoration: none;
         border-radius: 4px;

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,6 +1,10 @@
-{% extends "base.html" %}
+{% extends "public/base_public.html" %}
 
-{% block title %}500 - Internal Server Error | TastesLikeGood.com{% endblock %}
+{# Rendered by the app-level exception handler (app.py) — extends the PUBLIC
+   base for the same reason as 404.html: the legacy base.html links routes
+   Express never proxies in production (cookbook #3164). #}
+
+{% block title %}500 - Internal Server Error · TastesLikeGood.org{% endblock %}
 
 {% block content %}
 <div class="error-page">
@@ -9,8 +13,8 @@
     <p>We've been notified of the issue and are working to fix it.</p>
 
     <div class="error-actions">
-        <a href="{{ url_for('recipes.index') }}" class="button">Go to Home</a>
-        <a href="javascript:history.back()" class="button secondary">Go Back</a>
+        <a href="{{ url_for('public.browse_public_recipes') }}" class="button">Browse recipes</a>
+        <a href="/#kitchen" class="button secondary">Open the cookbook app</a>
     </div>
 </div>
 
@@ -45,7 +49,7 @@
     .error-actions .button {
         display: inline-block;
         padding: 0.75rem 1.5rem;
-        background-color: #4CAF50;
+        background-color: #4caf50;
         color: white;
         text-decoration: none;
         border-radius: 4px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,9 +1,21 @@
 <!doctype html>
+{#
+  LEGACY / DEV-ONLY SURFACE — never reachable in production.
+
+  This base (and the pages extending it: index.html, generate_recipe.html,
+  recipe.html, profile.html, the /auth/* pages) is Flask's original HTML UI.
+  In production the Express proxy only forwards /api/*, /r/<slug>, /browse,
+  /sitemap.xml and /static/* to Flask, so the routes linked below
+  (/, /generate_recipe, /auth/*) exist only when running Flask directly on
+  :5000 for local development. The production-facing SSR pages extend
+  templates/public/base_public.html instead. Deleting this surface is a
+  tracked follow-up (cookbook #3164); do not add new production features here.
+#}
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>{% block title %}TastesLikeGood.com{% endblock %}</title>
+        <title>{% block title %}TastesLikeGood.org{% endblock %}</title>
         <link
             rel="icon"
             href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🥗</text></svg>"

--- a/templates/public/base_public.html
+++ b/templates/public/base_public.html
@@ -65,9 +65,8 @@
                 </div>
                 <div class="public-modal-actions">
                     <a href="/#kitchen" class="public-modal-button public-modal-button--primary"
-                        >Continue as guest</a
+                        >Open my kitchen</a
                     >
-                    <a href="/#kitchen" class="public-modal-button">Open my kitchen</a>
                     <button type="button" class="public-modal-button" data-close-modal>Stay here</button>
                 </div>
             </div>

--- a/templates/public/browse.html
+++ b/templates/public/browse.html
@@ -31,7 +31,11 @@
     <ul class="public-browse-list">
         {% for recipe in recipes %}
         {% set data = recipe.data or {} %}
-        {% set image_src = data.ai_image_url or (url_for('generation_api.serve_recipe_image', recipe_id=recipe.id) if (data.ai_image_data or data.ai_image_gcs) else data.stock_image_url) %}
+        {# Byte-gated, host-relative image URL — mirrors public_bp._recipe_image_url.
+           A stored ai_image_url is never trusted here: its bytes may not exist
+           (dead card image) and it may carry an absolute host that diverges
+           from the relative URLs on sibling cards (cookbook #3164). #}
+        {% set image_src = (url_for('generation_api.serve_recipe_image', recipe_id=recipe.id) if (data.ai_image_data or data.ai_image_gcs) else data.stock_image_url) %}
         <li class="public-browse-item">
             <a href="{{ url_for('public.show_public_recipe', slug=recipe.slug) }}">
                 {% if image_src %}

--- a/templates/public/recipe.html
+++ b/templates/public/recipe.html
@@ -73,8 +73,9 @@
                     Save to your cookbook
                 </a>
                 {# Only offer the Pinterest pin when the recipe has a fetchable
-                   image (see public_bp._pinnable_image_url). Pinning a recipe
-                   whose image 404s creates a broken pin. #}
+                   image (see public_bp._recipe_image_url — the same byte-gate
+                   feeds the hero/og:image). Pinning a recipe whose image 404s
+                   creates a broken pin. #}
                 {% if pinterest_share_url %}
                 <a href="{{ pinterest_share_url }}" target="_blank" rel="noopener noreferrer" class="public-recipe-action-link" aria-label="Share {{ recipe.name }} on Pinterest">
                     Save to Pinterest

--- a/tests/test_public_ux_audit.py
+++ b/tests/test_public_ux_audit.py
@@ -1,0 +1,283 @@
+"""Tests for the cookbook #3164 public UX / dead-links audit fixes.
+
+Covers:
+- image endpoint content-type matches the served bytes (JPEG-as-PNG fix)
+- anonymous public-image responses carry no Set-Cookie / CORS / Vary headers
+  and keep Cache-Control: public (CDN-cacheable)
+- _recipe_image_url ignores a stale ai_image_url with no persisted bytes
+  (no og:image / hero <img> instead of a dead 404 URL)
+- 404/500 error pages render from the public base with .org branding and
+  CTAs that exist in production (/browse, /#kitchen)
+- scripts/unpublish_slugs.py is idempotent and reversible
+"""
+
+import base64
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from scripts.unpublish_slugs import unpublish_slugs  # noqa: E402
+
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"fake-jpeg-payload"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-png-payload"
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.delenv("FRONTEND_URL", raising=False)
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_recipe(name, slug, *, public=True, data=None):
+    return Recipe(
+        id=str(uuid.uuid4()),
+        user_id=None,
+        name=name,
+        slug=slug,
+        is_public=public,
+        data=data or {"name": name, "description": f"{name} description"},
+    )
+
+
+def _add_public_image_recipe(app, image_bytes=JPEG_BYTES):
+    with app.app_context():
+        recipe = _make_recipe(
+            "Imageful",
+            f"imageful-{uuid.uuid4().hex[:8]}",
+            data={
+                "name": "Imageful",
+                "ai_image_data": base64.b64encode(image_bytes).decode("ascii"),
+            },
+        )
+        db.session.add(recipe)
+        db.session.commit()
+        return recipe.id
+
+
+# ── image endpoint hygiene ────────────────────────────────────────────
+
+
+def test_image_content_type_matches_jpeg_bytes(app, client):
+    recipe_id = _add_public_image_recipe(app, JPEG_BYTES)
+
+    resp = client.get(f"/api/recipes/{recipe_id}/image")
+
+    assert resp.status_code == 200
+    assert resp.mimetype == "image/jpeg"
+    assert resp.data == JPEG_BYTES
+
+
+def test_image_content_type_matches_png_bytes(app, client):
+    recipe_id = _add_public_image_recipe(app, PNG_BYTES)
+
+    resp = client.get(f"/api/recipes/{recipe_id}/image")
+
+    assert resp.status_code == 200
+    assert resp.mimetype == "image/png"
+
+
+def test_public_image_response_is_shared_cacheable(app, client):
+    """No Set-Cookie, no Vary, no CORS headers, Cache-Control: public."""
+    recipe_id = _add_public_image_recipe(app)
+
+    resp = client.get(
+        f"/api/recipes/{recipe_id}/image",
+        headers={"Origin": "https://www.tasteslikegood.org"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["Cache-Control"] == "public, max-age=86400"
+    assert "Set-Cookie" not in resp.headers
+    assert "Vary" not in resp.headers
+    assert "Access-Control-Allow-Origin" not in resp.headers
+    assert "Access-Control-Allow-Credentials" not in resp.headers
+
+
+def test_cors_still_applies_to_other_api_endpoints(app, client):
+    """The CORS strip is scoped to the image endpoint only."""
+    with app.app_context():
+        recipe = _make_recipe("Json Public", "json-public")
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get(
+        "/api/recipes/public/json-public",
+        headers={"Origin": "https://www.tasteslikegood.org"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers.get("Access-Control-Allow-Origin") == "https://www.tasteslikegood.org"
+
+
+# ── stale ai_image_url guard ──────────────────────────────────────────
+
+
+def test_stale_ai_image_url_without_bytes_emits_no_og_image_or_hero(app, client):
+    with app.app_context():
+        recipe = _make_recipe(
+            "Ghost Image",
+            "ghost-image",
+            data={
+                "name": "Ghost Image",
+                "description": "ai_image_url recorded but bytes never persisted.",
+                "ai_image_url": "/api/recipes/00000000-dead-dead-dead-000000000000/image",
+            },
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/ghost-image")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "og:image" not in body
+    assert "public-recipe-image-wrap" not in body  # no hero <img>
+    assert '<meta name="twitter:card" content="summary">' in body
+
+
+def test_stale_ai_image_url_falls_back_to_stock_image(app, client):
+    with app.app_context():
+        recipe = _make_recipe(
+            "Stocky",
+            "stocky",
+            data={
+                "name": "Stocky",
+                "ai_image_url": "/api/recipes/00000000-dead-dead-dead-000000000000/image",
+                "stock_image_url": "https://img.example/stock.jpg",
+            },
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+    resp = client.get("/r/stocky")
+    body = resp.get_data(as_text=True)
+
+    assert '<meta property="og:image" content="https://img.example/stock.jpg">' in body
+
+
+def test_browse_card_ignores_stale_ai_image_url(app, client):
+    with app.app_context():
+        db.session.add(
+            _make_recipe(
+                "Ghost Card",
+                "ghost-card",
+                data={
+                    "name": "Ghost Card",
+                    "ai_image_url": "/api/recipes/00000000-dead-dead-dead-000000000000/image",
+                },
+            )
+        )
+        db.session.commit()
+
+    resp = client.get("/browse")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert "Ghost Card" in body
+    assert "00000000-dead-dead-dead-000000000000" not in body
+
+
+# ── error pages ───────────────────────────────────────────────────────
+
+
+def test_404_page_renders_from_public_base_with_org_branding(client):
+    resp = client.get("/r/this-slug-does-not-exist")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 404
+    assert "TastesLikeGood.org" in body
+    assert "TastesLikeGood.com" not in body
+    assert 'href="/browse"' in body
+    assert 'href="/#kitchen"' in body
+    # Legacy dev-only routes must not be offered as CTAs.
+    assert "/generate_recipe" not in body
+    # Public-base chrome proves the re-parenting.
+    assert "public-shell" in body
+
+
+def test_500_page_renders_from_public_base_with_org_branding(app):
+    from flask import abort  # noqa: F401
+
+    @app.route("/test/boom")
+    def boom():
+        raise RuntimeError("boom")
+
+    client = app.test_client()
+    resp = client.get("/test/boom")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 500
+    assert "TastesLikeGood.org" in body
+    assert "TastesLikeGood.com" not in body
+    assert 'href="/browse"' in body
+    assert "/generate_recipe" not in body
+
+
+# ── unpublish script ──────────────────────────────────────────────────
+
+
+def test_unpublish_slugs_is_idempotent_and_reversible(app):
+    with app.app_context():
+        db.session.add_all(
+            [
+                _make_recipe("Junk One", "junk-one"),
+                _make_recipe("Junk Two", "junk-two"),
+                _make_recipe("Keeper", "keeper"),
+            ]
+        )
+        db.session.commit()
+
+    unpublished, already, missing = unpublish_slugs(app, ["junk-one", "junk-two", "nope"])
+    assert sorted(unpublished) == ["junk-one", "junk-two"]
+    assert already == []
+    assert missing == ["nope"]
+
+    # Second run: nothing left to do, still safe.
+    unpublished2, already2, missing2 = unpublish_slugs(app, ["junk-one", "junk-two"])
+    assert unpublished2 == []
+    assert sorted(already2) == ["junk-one", "junk-two"]
+    assert missing2 == []
+
+    with app.app_context():
+        assert Recipe.query.filter_by(slug="junk-one").one().is_public is False
+        assert Recipe.query.filter_by(slug="keeper").one().is_public is True
+        # Reversible: flip back and the recipe is public again.
+        recipe = Recipe.query.filter_by(slug="junk-one").one()
+        recipe.is_public = True
+        db.session.commit()
+        assert Recipe.query.filter_by(slug="junk-one").one().is_public is True
+
+
+def test_unpublished_recipes_leave_browse_and_sitemap(app, client):
+    with app.app_context():
+        db.session.add(_make_recipe("Junk Three", "junk-three"))
+        db.session.commit()
+
+    assert client.get("/r/junk-three").status_code == 200
+
+    unpublish_slugs(app, ["junk-three"])
+
+    assert client.get("/r/junk-three").status_code == 404
+    assert "junk-three" not in client.get("/browse").get_data(as_text=True)
+    assert b"junk-three" not in client.get("/sitemap.xml").data

--- a/tests/test_public_ux_audit.py
+++ b/tests/test_public_ux_audit.py
@@ -269,6 +269,29 @@ def test_unpublish_slugs_is_idempotent_and_reversible(app):
         assert Recipe.query.filter_by(slug="junk-one").one().is_public is True
 
 
+def test_unpublish_slugs_syncs_the_data_blob(app):
+    # The recipes API returns recipe.data verbatim and a later full save
+    # writes data["is_public"] back to the column, so the blob must be
+    # unpublished together with the column or the recipe silently
+    # republishes on the next save.
+    with app.app_context():
+        db.session.add(
+            _make_recipe(
+                "Blob Junk",
+                "blob-junk",
+                data={"name": "Blob Junk", "is_public": True},
+            )
+        )
+        db.session.commit()
+
+    unpublish_slugs(app, ["blob-junk"])
+
+    with app.app_context():
+        recipe = Recipe.query.filter_by(slug="blob-junk").one()
+        assert recipe.is_public is False
+        assert recipe.data["is_public"] is False
+
+
 def test_unpublished_recipes_leave_browse_and_sitemap(app, client):
     with app.app_context():
         db.session.add(_make_recipe("Junk Three", "junk-three"))


### PR DESCRIPTION
Backend half of the tiered audit in cookbook issue adamtasteslikegood/tasteslikegoodtheangularsvegancookbook#3164 (spec archived in the cookbook repo). The cookbook half (Express redirects, favicon, robots.txt Allow rule, SPA browse link, crawl script) ships separately; the cookbook submodule pointer bump happens after this PR merges.

## What changed

**Critical tier**
- **No-image guard (item 1):** `_recipe_image_url` no longer trusts a stale `ai_image_url` whose bytes were never persisted — the page media is derived from the same signal the image endpoint serves from (GCS/base64 bytes), else the stock image. A recipe with no servable image now emits no `og:image` and no hero `<img>` instead of a 404 URL. `_pinnable_image_url` becomes an alias of the same gate, so pin media and page media can never disagree.
- **/browse cards (items 1+2):** cards use the same byte-gate with host-relative `url_for` URLs — fixes both the dead card image and the one absolute-host card among relative siblings.

**High tier**
- **Error pages (item 5):** `404.html`/`500.html` re-parented onto `public/base_public.html`; CTAs now point at `/browse` and `/#kitchen` (the old CTAs `/` and `/generate_recipe` are never proxied by Express in production); titles say `.org`.
- **Image endpoint hygiene (item 6):** content-type is sniffed from the bytes' magic numbers (Imagen JPEG bytes were served as `image/png`); the app-wide session touch is skipped for `GET /api/recipes/<id>/image` so anonymous image responses carry **no `Set-Cookie` and no `Vary: Cookie`**; CORS headers are stripped from image responses (they're consumed same-origin through Express — `Access-Control-Allow-Origin` + `Vary` made every image uncacheable by shared caches). Public images keep exactly `Cache-Control: public, max-age=86400`; private images stay `private, no-store`.
- **Unpublish script (item 8):** new idempotent, reversible `scripts/unpublish_slugs.py` (slugs as args, sets `is_public=False` in app context, exit 1 on unknown slugs). **Not run against production in this PR** — running it there (5 junk slugs + the 2 imageless recipes) is Adam's operator step. The 2 cornbread slugs are untouched per the issue decision.

**Medium tier**
- **Dev-only surface documented (items 10+11):** comment block in `templates/base.html` + CLAUDE.md section stating the legacy Flask HTML surface (`/`, `/generate_recipe`, `/auth/*` pages, `base.html` templates) is local-dev only and never proxied in production; `base.html` title fixed `.com` → `.org`. Deletion remains a tracked follow-up.
- **Dead code (item 12):** removed the never-rendered `save_to_cookbook_url` template variable; deduped the two identical `/#kitchen` modal links in `base_public.html`.

## Tests

`tests/test_public_ux_audit.py` (+11): JPEG/PNG content-type sniffing, shared-cacheability of anonymous image responses (no Set-Cookie/Vary/ACAO), CORS still active on other API endpoints, stale-`ai_image_url` guard (page + browse card + stock fallback), 404/500 public-base rendering, unpublish script idempotency and browse/sitemap removal.

Full suite: **288 passed** (`uv run pytest`). `black --check` and `mypy` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReC11ynX32TSFGz9bzooF3






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

