### PR TITLE
fix(backend): disable DD continuous profiler + recycle gunicorn worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ ENV DD_SITE=us5.datadoghq.com
 ENV DD_LOGS_ENABLED=true
 ENV DD_LOGS_INJECTION=true
 ENV DD_SOURCE=python
-ENV DD_PROFILING_ENABLED=true
+# Continuous profiler disabled: its resident-memory overhead (sampling buffers +
+# extra threads) is the largest Datadog cost in-process and isn't worth it at
+# single-user scale. APM traces (ddtrace-run) and log injection stay on.
+ENV DD_PROFILING_ENABLED=false
 ENV DD_APPSEC_ENABLED=true
 
 WORKDIR /app
@@ -43,4 +46,7 @@ ENTRYPOINT ["/app/datadog-init"]
 # Gunicorn, never `python app.py`: the __main__ path runs Werkzeug's debug
 # server (app.run(debug=True)), which must not serve production traffic.
 # Cloud Run injects PORT; 5000 matches the old local-run default.
-CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 app:app"]
+# --max-requests recycles the worker every ~1000 requests (±100 jitter) so any
+# slow memory growth is reclaimed; needed because --timeout 0 (kept for long
+# Gemini/Imagen calls) otherwise means the worker never restarts on its own.
+CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 --max-requests 1000 --max-requests-jitter 100 app:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ ENTRYPOINT ["/app/datadog-init"]
 # Gunicorn, never `python app.py`: the __main__ path runs Werkzeug's debug
 # server (app.run(debug=True)), which must not serve production traffic.
 # Cloud Run injects PORT; 5000 matches the old local-run default.
-# --max-requests recycles the worker every ~1000 requests (±100 jitter) so any
-# slow memory growth is reclaimed; needed because --timeout 0 (kept for long
-# Gemini/Imagen calls) otherwise means the worker never restarts on its own.
+# --max-requests recycles the worker every 1000-1100 requests (1000 + a random
+# 0-100 jitter, per gunicorn's randint(0, jitter)) so any slow memory growth is
+# reclaimed; needed because --timeout 0 (kept for long Gemini/Imagen calls)
+# otherwise means the worker never restarts on its own.
 CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 --max-requests 1000 --max-requests-jitter 100 app:app"]


### PR DESCRIPTION
## What
`flask-backend` Cloud Run sits at **~84% memory p95 (99.2% max)** of the default **512Mi** at idle. gcp-monitor telemetry (flat over 24h at ~zero traffic) shows this is a **baseline working-set high, not a leak** — gunicorn + the in-process Datadog stack + heavy google SDKs, held resident by `min-instances=1`. The real risk is the **99.2% OOM edge**.

## Changes (`Backend/Dockerfile`)
- **`DD_PROFILING_ENABLED=false`** — the continuous profiler is the largest in-process Datadog memory cost and has ~no value at single-user scale. APM traces (`ddtrace-run`) and log injection stay on. **AppSec unchanged** (`DD_APPSEC_ENABLED=true`).
- **gunicorn `--max-requests 1000 --max-requests-jitter 100`** — recycles the worker periodically so any slow memory growth is reclaimed; needed because `--timeout 0` (kept for long Gemini/Imagen calls) means it otherwise never restarts.

## Pairs with
Cookbook PR bumping the service to `--memory=1Gi` (512Mi→1Gi ⇒ util ~84%→~42%) in `cloudbuild.yaml`. Per the submodule flow, this Backend change reaches prod only when the cookbook pointer bumps to include it.

## Test plan
Config-only (Dockerfile `ENV` + gunicorn flags); no app code paths change. Verify post-deploy via gcp-monitor `check_system_health backend` that memory drops toward ~42%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

