### PR TITLE
fix(public): stop clipping the hero eyebrow/title on mobile (RCP-45)

### DIFF
--- a/static/css/recipe-site.css
+++ b/static/css/recipe-site.css
@@ -555,8 +555,18 @@ img {
     grid-template-columns: 1fr;
   }
 
+  /* On phones the 16/9 hero image is only ~190px tall while the title wraps
+     to 2–3 lines, so the bottom-anchored absolute overlay grows taller than
+     the image and its top (eyebrow + first title line) is clipped by the
+     hero's overflow:hidden. Stack the title block BELOW the image instead —
+     normal flow, surface background, inherited dark text — mirroring the
+     no-image .public-recipe-title-block path so nothing is ever clipped. */
   .public-recipe-hero-overlay {
+    position: static;
     padding: var(--space-4);
+    color: inherit;
+    background: var(--bg-surface);
+    border-top: var(--ar-border);
   }
 
   .public-recipe-toolbar {


### PR DESCRIPTION
## What

On the public recipe page (`/r/<slug>`), the hero image + title clips on mobile: the **"← Browse all recipes" eyebrow and the first line of the title are cut off** at the top.

## Root cause

The hero renders the title block as a **bottom-anchored absolute overlay** (`.public-recipe-hero-overlay { position: absolute; inset: auto 0 0 0 }`) inside `.public-recipe-hero { overflow: hidden }`, layered over a `16 / 9` image.

- **Desktop:** the image is ~600px tall, so the overlay comfortably fits over its lower portion. Works as designed.
- **Mobile (~375px):** the image is only **~190px** tall, but the title wraps to 2–3 lines, so the overlay content is **taller than the image**. Being bottom-anchored, it grows *upward* past the hero's top edge — and `overflow: hidden` clips whatever pokes out the top (the eyebrow + first title line).

## Fix

Scoped entirely to the existing `@media (max-width: 768px)` block: drop the overlay on mobile. Set `.public-recipe-hero-overlay { position: static }` so the title block flows **below** the image in normal flow — surface background, inherited dark text, and a `border-top` separator — mirroring the existing no-image `.public-recipe-title-block` treatment. **Desktop (>768px) is unchanged.**

## Verification

Rendered before/after at a true **375px** layout (headless Chrome, layout probe measuring the overlay's top vs the hero's top):

| | overlay top | hero top | eyebrow | result |
|---|---|---|---|---|
| **before** | `-6px` | `45px` | `y=10` (35px **above** hero top) | **`CLIPPED=true`** — eyebrow + 1st title line cut off |
| **after** | `256px` (= image bottom) | `45px` | `y=273` (in bounds) | **`CLIPPED=false`** — image on top, full title block below |

Before: eyebrow gone, title jammed against the top edge overlapping the image.
After: image on top, then eyebrow + full title + description below it, nothing clipped, reads as intentional.

## Ships via

Backend `dev` merge → cookbook submodule pointer-bump PR (production deploys the pinned Backend SHA). No migration, no schema change — CSS only.

Refs: RCP-45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

