### PR TITLE
fix(valkey): trust Memorystore CA in IAM client so Flask uses the shared Valkey cache

### DIFF
--- a/tests/test_valkey_auth.py
+++ b/tests/test_valkey_auth.py
@@ -1,0 +1,77 @@
+"""Regression tests for Valkey IAM client TLS trust (Memorystore CA).
+
+flask-backend silently fell back to in-process SimpleCache on every boot since
+v0.3.5: _build_client() opened the TLS connection with ssl=True but never
+trusted Memorystore's Google-managed private CA, so the handshake failed with
+CERTIFICATE_VERIFY_FAILED, create_iam_redis_client() returned None, and the
+Flask-Caching response cache degraded to a per-worker in-process SimpleCache.
+
+The fix mirrors the working Express reference (server/valkey.ts): read the CA
+PEM from VALKEY_CA_CERT and hand it to redis-py as ssl_ca_data, without ever
+disabling certificate verification.
+"""
+
+import ssl as ssl_mod
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from utils import valkey_auth  # noqa: E402
+
+# A syntactically shaped but fake PEM — the client is never actually opened.
+_FAKE_PEM = (
+    "-----BEGIN CERTIFICATE-----\n" "MIIBfakememorystorecabytes==\n" "-----END CERTIFICATE-----\n"
+)
+
+# ssl_cert_reqs values that would DISABLE or weaken verification.
+_INSECURE_CERT_REQS = (None, "none", "optional", ssl_mod.CERT_NONE, ssl_mod.CERT_OPTIONAL)
+
+
+def _capture_strictredis(monkeypatch):
+    """Patch redis.StrictRedis to capture constructor kwargs; return the dict.
+
+    Also stubs the GCP IAM token fetch so the test never touches the network.
+    """
+    captured = {}
+
+    def fake_strictredis(**kwargs):
+        captured.update(kwargs)
+        return object()  # _build_client only constructs & returns; never calls it
+
+    monkeypatch.setattr("redis.StrictRedis", fake_strictredis)
+    monkeypatch.setattr(valkey_auth, "_get_iam_token", lambda: ("sa@project.iam", "iam-token"))
+    return captured
+
+
+def test_build_client_trusts_ca_cert_from_env(monkeypatch):
+    """VALKEY_CA_CERT is passed to redis-py as ssl_ca_data, TLS still verified."""
+    captured = _capture_strictredis(monkeypatch)
+    monkeypatch.setenv("VALKEY_CA_CERT", _FAKE_PEM)
+
+    valkey_auth._build_client("10.128.0.11", 6379)
+
+    assert captured.get("ssl") is True
+    assert captured.get("ssl_ca_data") == _FAKE_PEM
+    # IAM token stays the password; host/port preserved.
+    assert captured.get("password") == "iam-token"
+    assert captured.get("host") == "10.128.0.11"
+    assert captured.get("port") == 6379
+    # Trusting the CA is the fix — verification must NOT be disabled as a shortcut.
+    assert captured.get("ssl_cert_reqs", "required") not in _INSECURE_CERT_REQS
+
+
+def test_build_client_without_ca_cert_keeps_tls_on_system_trust(monkeypatch):
+    """Absent VALKEY_CA_CERT: TLS stays on via the system trust store (no ssl_ca_data).
+
+    Guards the local/dev path so the fix stays conditional and never weakens TLS.
+    """
+    captured = _capture_strictredis(monkeypatch)
+    monkeypatch.delenv("VALKEY_CA_CERT", raising=False)
+
+    valkey_auth._build_client("10.128.0.11", 6379)
+
+    assert captured.get("ssl") is True
+    # No CA override -> None (or absent) -> redis-py uses the system trust store.
+    assert not captured.get("ssl_ca_data")
+    assert captured.get("ssl_cert_reqs", "required") not in _INSECURE_CERT_REQS

--- a/utils/valkey_auth.py
+++ b/utils/valkey_auth.py
@@ -9,6 +9,7 @@ Ref: https://cloud.google.com/memorystore/docs/valkey/manage-iam-auth
 """
 
 import logging
+import os
 import threading
 import time
 
@@ -44,11 +45,21 @@ def _build_client(host: str, port: int) -> redis.StrictRedis:
         logger.info("Creating Valkey client with fresh IAM token (sa=%s)", email)
     else:
         logger.info("Creating Valkey client with fresh IAM token (user credentials)")
+
+    # Memorystore server certs chain to a Google-managed private CA that the
+    # container's default trust store can't verify. Trust it explicitly via the
+    # VALKEY_CA_CERT PEM (from Secret Manager); without it the TLS handshake
+    # fails CERTIFICATE_VERIFY_FAILED and the caller silently degrades to an
+    # in-process backend. ssl_ca_data=None means "use the system trust store"
+    # (local/dev), so keep TLS verification on either way. Mirrors
+    # server/valkey.ts (the Express side already does this correctly).
+    ca_cert = os.environ.get("VALKEY_CA_CERT")
     return redis.StrictRedis(
         host=host,
         port=port,
         password=token,
         ssl=True,
+        ssl_ca_data=ca_cert,
         decode_responses=False,
     )
 
@@ -56,10 +67,10 @@ def _build_client(host: str, port: int) -> redis.StrictRedis:
 def _refresh_token_in_place() -> bool:
     """Refresh the IAM token on the EXISTING client's connection pool.
 
-    This is critical because Flask-Session and Flask-Caching hold references
-    to the original client object. Creating a new client doesn't help — we
-    must update the password on the pool they're already using, then drop
-    stale connections so new ones authenticate with the fresh token.
+    This is critical because Flask-Caching holds a reference to the original
+    client object. Creating a new client doesn't help — we must update the
+    password on the pool it is already using, then drop stale connections so
+    new ones authenticate with the fresh token.
 
     Returns:
         bool: True if a client was present and successfully refreshed,


### PR DESCRIPTION
## Problem (root cause proven from Datadog, `service:flask-backend`)

Since v0.3.5, flask-backend has silently failed to use Valkey for its response cache, falling back to in-process `SimpleCache` on **every boot**. Each startup logs:

```
INFO  valkey_auth: Creating Valkey client with fresh IAM token (sa=…-compute@developer.gserviceaccount.com)
ERROR valkey_auth: Valkey IAM auth failed: Error 1 connecting to 10.128.0.11:6379. [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain — caller will fall back
WARNING app: Response cache: in-memory SimpleCache fallback — configured Valkey/Redis is unavailable
```

`VALKEY_HOST`/IAM are configured correctly and the IAM token works — the **TLS handshake** fails because Memorystore's Google-managed CA cert isn't in the container's default trust store.

## Root cause

`utils/valkey_auth.py::_build_client()` built the client with `ssl=True` but **no** `ssl_ca_certs`/`ssl_ca_data`, and nothing in the Backend read `VALKEY_CA_CERT`. The Express side (`server/valkey.ts:118-132`) does this correctly via `tlsOptions.ca = process.env.VALKEY_CA_CERT` — which is why Express rate limiting works but the Flask cache doesn't.

## Fix

Read `VALKEY_CA_CERT` (PEM string, already in Secret Manager) and pass it to redis-py as `ssl_ca_data`. `ssl_ca_data=None` ⇒ system trust store (local/dev), so **TLS verification stays enabled either way — it is never disabled**.

## Scope

`create_iam_redis_client` feeds **only** Flask-Caching (`app.py:145` → `CACHE_REDIS_HOST`); there is **no Flask-Session wiring** in this repo (`flask-session` isn't a dependency). The degraded `SimpleCache` is **per-gunicorn-worker / per-instance**, so cached image bytes piled up in each worker's heap instead of shared Valkey — the ~58 MiB seen in the Datadog heap flame graph.

_(Corrected from the initial revision, which mentioned Flask-Session — that came from a stale `_refresh_token_in_place` docstring, now fixed. Thanks to Copilot's review for the catch.)_

## Companion change (required)

The code is a safe no-op until the secret is mounted on the Flask deploy. Cookbook PR **adamtasteslikegoodtheangularsvegancookbook#3176** adds `VALKEY_CA_CERT=VALKEY_CA_CERT:latest` to the *Deploy Flask Backend* `--set-secrets` in `cloudbuild.yaml` and (once this merges) bumps the submodule pointer to this commit.

## Testing

- New `tests/test_valkey_auth.py` (2 tests): `VALKEY_CA_CERT` → `ssl_ca_data` with verification kept on; absent → system trust store, still verified.
- Full suite: **307 passed**. `black` / `flake8` / `mypy` clean.

## Verify after deploy

flask-backend logs show `Valkey connection OK at 10.128.0.11:6379` + `Response cache: Valkey/Redis backend` instead of the SSL error; the ~58 MiB of per-worker image bytes move to shared Valkey and memory-util p95 drops from ~82%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)