### PR TITLE
fix(backend): 540s gunicorn graceful-timeout so worker restarts don't kill in-flight generations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,7 @@ ENTRYPOINT ["/app/datadog-init"]
 # 0-100 jitter, per gunicorn's randint(0, jitter)) so any slow memory growth is
 # reclaimed; needed because --timeout 0 (kept for long Gemini/Imagen calls)
 # otherwise means the worker never restarts on its own.
-CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 --max-requests 1000 --max-requests-jitter 100 app:app"]
+# --graceful-timeout 540 matches GENAI_HTTP_TIMEOUT_MS (config.py) so a worker
+# restart lets an in-flight Gemini/Imagen call finish instead of the 30s default
+# force-killing it mid-generation.
+CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 --graceful-timeout 540 --max-requests 1000 --max-requests-jitter 100 app:app"]


### PR DESCRIPTION
## What

Adds `--graceful-timeout 540` to the gunicorn CMD in `Dockerfile`.

## Why

The worker runs `--timeout 0` so long Gemini/Imagen calls (up to
`GENAI_HTTP_TIMEOUT_MS` = 540s, `config.py`) are never cut off mid-request.
But gunicorn's `graceful-timeout` still defaults to **30s**, so on a worker
restart (SIGTERM on deploy, or an arbiter-driven restart) an in-flight
generation is force-killed after 30s. Sizing `--graceful-timeout` to match
`GENAI_HTTP_TIMEOUT_MS` lets the draining worker finish the current call.

Addresses Copilot review feedback on the #220 max-requests recycling
([PR #223 comment](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/223#discussion_r3610421169)).

## Notes

- No schema change, no new migration.
- Intended to land in Backend `dev` and ride into the v0.3.9 promotion (#223),
  which moves the pinned SHA past `9c830b0` — cookbook submodule pointer bump
  updates accordingly.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

