### PR TITLE
release: promote Backend dev→main for cookbook v0.3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,7 @@ ENTRYPOINT ["/app/datadog-init"]
 # 0-100 jitter, per gunicorn's randint(0, jitter)) so any slow memory growth is
 # reclaimed; needed because --timeout 0 (kept for long Gemini/Imagen calls)
 # otherwise means the worker never restarts on its own.
-CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 --max-requests 1000 --max-requests-jitter 100 app:app"]
+# --graceful-timeout 540 matches GENAI_HTTP_TIMEOUT_MS (config.py) so a worker
+# restart lets an in-flight Gemini/Imagen call finish instead of the 30s default
+# force-killing it mid-generation.
+CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 --graceful-timeout 540 --max-requests 1000 --max-requests-jitter 100 app:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ ENV DD_SITE=us5.datadoghq.com
 ENV DD_LOGS_ENABLED=true
 ENV DD_LOGS_INJECTION=true
 ENV DD_SOURCE=python
-ENV DD_PROFILING_ENABLED=true
+# Continuous profiler disabled: its resident-memory overhead (sampling buffers +
+# extra threads) is the largest Datadog cost in-process and isn't worth it at
+# single-user scale. APM traces (ddtrace-run) and log injection stay on.
+ENV DD_PROFILING_ENABLED=false
 ENV DD_APPSEC_ENABLED=true
 
 WORKDIR /app
@@ -43,4 +46,8 @@ ENTRYPOINT ["/app/datadog-init"]
 # Gunicorn, never `python app.py`: the __main__ path runs Werkzeug's debug
 # server (app.run(debug=True)), which must not serve production traffic.
 # Cloud Run injects PORT; 5000 matches the old local-run default.
-CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 app:app"]
+# --max-requests recycles the worker every 1000-1100 requests (1000 + a random
+# 0-100 jitter, per gunicorn's randint(0, jitter)) so any slow memory growth is
+# reclaimed; needed because --timeout 0 (kept for long Gemini/Imagen calls)
+# otherwise means the worker never restarts on its own.
+CMD ["sh", "-c", "exec ddtrace-run gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 8 --timeout 0 --max-requests 1000 --max-requests-jitter 100 app:app"]

--- a/static/css/recipe-site.css
+++ b/static/css/recipe-site.css
@@ -555,8 +555,18 @@ img {
     grid-template-columns: 1fr;
   }
 
+  /* On phones the 16/9 hero image is only ~190px tall while the title wraps
+     to 2–3 lines, so the bottom-anchored absolute overlay grows taller than
+     the image and its top (eyebrow + first title line) is clipped by the
+     hero's overflow:hidden. Stack the title block BELOW the image instead —
+     normal flow, surface background, inherited dark text — mirroring the
+     no-image .public-recipe-title-block path so nothing is ever clipped. */
   .public-recipe-hero-overlay {
+    position: static;
     padding: var(--space-4);
+    color: inherit;
+    background: var(--bg-surface);
+    border-top: var(--ar-border);
   }
 
   .public-recipe-toolbar {

--- a/tests/test_valkey_auth.py
+++ b/tests/test_valkey_auth.py
@@ -1,0 +1,77 @@
+"""Regression tests for Valkey IAM client TLS trust (Memorystore CA).
+
+flask-backend silently fell back to in-process SimpleCache on every boot since
+v0.3.5: _build_client() opened the TLS connection with ssl=True but never
+trusted Memorystore's Google-managed private CA, so the handshake failed with
+CERTIFICATE_VERIFY_FAILED, create_iam_redis_client() returned None, and the
+Flask-Caching response cache degraded to a per-worker in-process SimpleCache.
+
+The fix mirrors the working Express reference (server/valkey.ts): read the CA
+PEM from VALKEY_CA_CERT and hand it to redis-py as ssl_ca_data, without ever
+disabling certificate verification.
+"""
+
+import ssl as ssl_mod
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from utils import valkey_auth  # noqa: E402
+
+# A syntactically shaped but fake PEM — the client is never actually opened.
+_FAKE_PEM = (
+    "-----BEGIN CERTIFICATE-----\n" "MIIBfakememorystorecabytes==\n" "-----END CERTIFICATE-----\n"
+)
+
+# ssl_cert_reqs values that would DISABLE or weaken verification.
+_INSECURE_CERT_REQS = (None, "none", "optional", ssl_mod.CERT_NONE, ssl_mod.CERT_OPTIONAL)
+
+
+def _capture_strictredis(monkeypatch):
+    """Patch redis.StrictRedis to capture constructor kwargs; return the dict.
+
+    Also stubs the GCP IAM token fetch so the test never touches the network.
+    """
+    captured = {}
+
+    def fake_strictredis(**kwargs):
+        captured.update(kwargs)
+        return object()  # _build_client only constructs & returns; never calls it
+
+    monkeypatch.setattr("redis.StrictRedis", fake_strictredis)
+    monkeypatch.setattr(valkey_auth, "_get_iam_token", lambda: ("sa@project.iam", "iam-token"))
+    return captured
+
+
+def test_build_client_trusts_ca_cert_from_env(monkeypatch):
+    """VALKEY_CA_CERT is passed to redis-py as ssl_ca_data, TLS still verified."""
+    captured = _capture_strictredis(monkeypatch)
+    monkeypatch.setenv("VALKEY_CA_CERT", _FAKE_PEM)
+
+    valkey_auth._build_client("10.128.0.11", 6379)
+
+    assert captured.get("ssl") is True
+    assert captured.get("ssl_ca_data") == _FAKE_PEM
+    # IAM token stays the password; host/port preserved.
+    assert captured.get("password") == "iam-token"
+    assert captured.get("host") == "10.128.0.11"
+    assert captured.get("port") == 6379
+    # Trusting the CA is the fix — verification must NOT be disabled as a shortcut.
+    assert captured.get("ssl_cert_reqs", "required") not in _INSECURE_CERT_REQS
+
+
+def test_build_client_without_ca_cert_keeps_tls_on_system_trust(monkeypatch):
+    """Absent VALKEY_CA_CERT: TLS stays on via the system trust store (no ssl_ca_data).
+
+    Guards the local/dev path so the fix stays conditional and never weakens TLS.
+    """
+    captured = _capture_strictredis(monkeypatch)
+    monkeypatch.delenv("VALKEY_CA_CERT", raising=False)
+
+    valkey_auth._build_client("10.128.0.11", 6379)
+
+    assert captured.get("ssl") is True
+    # No CA override -> None (or absent) -> redis-py uses the system trust store.
+    assert not captured.get("ssl_ca_data")
+    assert captured.get("ssl_cert_reqs", "required") not in _INSECURE_CERT_REQS

--- a/utils/valkey_auth.py
+++ b/utils/valkey_auth.py
@@ -9,6 +9,7 @@ Ref: https://cloud.google.com/memorystore/docs/valkey/manage-iam-auth
 """
 
 import logging
+import os
 import threading
 import time
 
@@ -44,11 +45,21 @@ def _build_client(host: str, port: int) -> redis.StrictRedis:
         logger.info("Creating Valkey client with fresh IAM token (sa=%s)", email)
     else:
         logger.info("Creating Valkey client with fresh IAM token (user credentials)")
+
+    # Memorystore server certs chain to a Google-managed private CA that the
+    # container's default trust store can't verify. Trust it explicitly via the
+    # VALKEY_CA_CERT PEM (from Secret Manager); without it the TLS handshake
+    # fails CERTIFICATE_VERIFY_FAILED and the caller silently degrades to an
+    # in-process backend. ssl_ca_data=None means "use the system trust store"
+    # (local/dev), so keep TLS verification on either way. Mirrors
+    # server/valkey.ts (the Express side already does this correctly).
+    ca_cert = os.environ.get("VALKEY_CA_CERT")
     return redis.StrictRedis(
         host=host,
         port=port,
         password=token,
         ssl=True,
+        ssl_ca_data=ca_cert,
         decode_responses=False,
     )
 
@@ -56,10 +67,10 @@ def _build_client(host: str, port: int) -> redis.StrictRedis:
 def _refresh_token_in_place() -> bool:
     """Refresh the IAM token on the EXISTING client's connection pool.
 
-    This is critical because Flask-Session and Flask-Caching hold references
-    to the original client object. Creating a new client doesn't help — we
-    must update the password on the pool they're already using, then drop
-    stale connections so new ones authenticate with the fresh token.
+    This is critical because Flask-Caching holds a reference to the original
+    client object. Creating a new client doesn't help — we must update the
+    password on the pool it is already using, then drop stale connections so
+    new ones authenticate with the fresh token.
 
     Returns:
         bool: True if a client was present and successfully refreshed,


### PR DESCRIPTION
## Backend dev → main promotion for cookbook v0.3.9

Advances Backend `main` (`178c403`) to the current `dev` tip (`18a303a`). The
earlier promotion attempt (#223) merged into `release/0_3_9_Backend` rather than
`main`; this is the real dev→main promotion, and it now includes the
graceful-timeout follow-up.

### Net-new to main since v0.3.8
- **#220** `fix(backend)` — disable the Datadog continuous profiler + recycle
  gunicorn workers (`--max-requests`) for OOM headroom.
- **#221** `fix(public)` — stop clipping the recipe hero eyebrow/title on mobile (RCP-45).
- **#222** `fix(valkey)` — trust the Memorystore CA in the IAM client so Flask
  uses the shared Valkey response cache instead of falling back to per-worker
  `SimpleCache` on `CERTIFICATE_VERIFY_FAILED`.
- **#224** `fix(backend)` — gunicorn `--graceful-timeout 540` (matches
  `GENAI_HTTP_TIMEOUT_MS`) so a worker restart lets an in-flight Gemini/Imagen
  call finish instead of the 30s default force-killing it (Copilot follow-up to #220).

### Notes
- **No new Alembic migration** — single head unchanged, `flask-backend-migrate`
  is a no-op this release.
- Pairs with the cookbook v0.3.9 release. Merge this **first** (merge commit —
  squash disabled by ruleset), then bump the cookbook submodule pointer to
  `18a303a` and ship the cookbook dev→main release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

