### PR TITLE
docs(claude): warn that /sync-gbrain from Backend/ duplicates the gbrain source (KAN-130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,52 @@ root, so credentials still come from the cookbook `.env`
 `CLAUDE.md` § Startup. In a standalone checkout (no cookbook superproject) the
 wrapper exits with a clear error and the servers are simply unavailable.
 
+## GBrain code search (agent sessions)
+
+If gbrain is configured on the machine, this repo is indexed as its own source,
+`gstack-code-backend` — separate from the cookbook worktree's source and **not
+federated**. Two consequences for anyone working in here:
+
+**1. Every query needs an explicit `--source`.** `code-def`, `code-refs`,
+`code-callers`, `code-callees`, `search`, and `query` all default to the
+cookbook worktree's pinned source, which contains no Backend Python. Without
+the flag they return nothing and give no indication anything was missed:
+
+```bash
+gbrain code-def get_genai_client --source gstack-code-backend
+gbrain search "OAuth PKCE code verifier" --source gstack-code-backend
+```
+
+There is no `.gbrain-source` pin in this directory to make that automatic —
+the pin is a cookbook-worktree mechanism, and this repo is a submodule
+(a gitlink), so it does not get one.
+
+**2. Never run a bare `/sync-gbrain` from inside `Backend/`.** It does not
+no-op here. Because there is no pin, the orchestrator's code stage falls back
+to registering the cwd as a *new* federated source
+(`gstack-code-com-<hash> --path .../Backend`), duplicating the ~200 pages
+already indexed as `gstack-code-backend`. The nested-path guard does not catch
+it: `gstack-code-backend` lives in gbrain's own managed clone directory rather
+than at the `Backend/` path, so there is no path overlap to detect. Verified
+via `gstack-gbrain-sync.ts --dry-run` on 2026-07-24.
+
+Refresh this repo's index with the explicit form instead — it fast-forwards
+gbrain's managed clone from Backend `dev`:
+
+```bash
+gbrain sync --source gstack-code-backend --strategy code
+```
+
+If you want the memory + brain-sync stages while sitting in `Backend/`, run
+`gstack-gbrain-sync.ts --no-code`. From this directory, always `--dry-run`
+first and read the `would:` line before letting the code stage run.
+
+Related: the `/sync-gbrain` skill rewrites its `## GBrain Search Guidance`
+block from a fixed template asserting the worktree is pinned via
+`.gbrain-source`. That assertion is false here, so do not let the skill write
+that block into this file. The cookbook `CLAUDE.md` § GBrain Search Guidance
+carries the authoritative cross-repo version.
+
 ## Behavioral Guidelines
 
 Follow the four Karpathy principles when writing or modifying code in this project:


### PR DESCRIPTION
## Why

`Backend/CLAUDE.md` had **no gbrain section at all** (`grep -i gbrain CLAUDE.md` → nothing). An agent working in this repo had no way to learn two things that silently break code search here. Both are documented on the cookbook side only, which is the wrong place for someone whose cwd is `Backend/`.

## 1. Queries here need an explicit `--source`

This repo is indexed as its own source, `gstack-code-backend`, and it is **not federated**. `code-def` / `code-refs` / `code-callers` / `code-callees` / `search` / `query` all default to the cookbook worktree's pinned source, which holds no Backend Python. Without the flag they return nothing — and give no indication anything was missed.

There is no `.gbrain-source` pin in this directory to make it automatic: the pin is a cookbook-worktree mechanism, and this repo is a submodule gitlink.

## 2. A bare `/sync-gbrain` from `Backend/` duplicates the source

It does not no-op here. With no pin, the orchestrator's code stage falls back to registering the cwd as a **new federated source**, duplicating the ~200 pages already indexed as `gstack-code-backend`:

```
SKIP  code  would: gbrain sources add gstack-code-com-7163da53-13dc8f \
                     --path .../Backend --federated
```

The nested-path guard doesn't catch it because `gstack-code-backend` lives in gbrain's own managed clone directory rather than at the `Backend/` path — no path overlap to detect. Confirmed via `gstack-gbrain-sync.ts --dry-run` on 2026-07-24. I caught it on the `--dry-run` line and refreshed the existing source instead, so no duplicate was actually created.

The section documents the correct refresh command (`gbrain sync --source gstack-code-backend --strategy code`), the `--no-code` escape hatch for the memory/brain-sync stages, and that the `/sync-gbrain` skill's templated guidance block must **not** be written into this file — it asserts a `.gbrain-source` pin that doesn't exist here, and a verbatim write would be actively false.

## Companion PR

Cookbook [#3231](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3231) corrects the same claim on the cookbook side, where it was stated backwards ("`/sync-gbrain` … only touches this worktree's pinned source").

Per the two-step submodule flow, this needs a follow-up cookbook PR bumping the `Backend` pointer once this lands.

Docs only — no code, no CI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATxCCQEB75iMHG1V1HAgXo



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

