### PR TITLE
docs(claude): drop point-in-time page count from gbrain warning (KAN-130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,8 +248,9 @@ the pin is a cookbook-worktree mechanism, and this repo is a submodule
 **2. Never run a bare `/sync-gbrain` from inside `Backend/`.** It does not
 no-op here. Because there is no pin, the orchestrator's code stage falls back
 to registering the cwd as a *new* federated source
-(`gstack-code-com-<hash> --path .../Backend`), duplicating the ~200 pages
-already indexed as `gstack-code-backend`. The nested-path guard does not catch
+(`gstack-code-com-<hash> --path .../Backend`), re-indexing the whole repo
+alongside the pages already held by `gstack-code-backend`. The nested-path
+guard does not catch
 it: `gstack-code-backend` lives in gbrain's own managed clone directory rather
 than at the `Backend/` path, so there is no path overlap to detect. Verified
 via `gstack-gbrain-sync.ts --dry-run` on 2026-07-24.


### PR DESCRIPTION
Follow-up to #234, which merged before this review comment came in.

## What

The gbrain section added in #234 said a stray `/sync-gbrain` would duplicate "the ~200 pages already indexed as `gstack-code-backend`". Review feedback on the companion cookbook PR ([#3231 review](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3231#discussion_r3645231949)) flagged the hardcoded count as a point-in-time metric that goes stale on every re-index.

That's correct, and it's observable: during the session that produced these docs, the sibling source `gstack-code-575c47df-9dc431` moved from 296 to 297 pages between two commands.

The sentence now describes the duplication by source name rather than by size, so it stays true regardless of how many pages are indexed:

> …re-indexing the whole repo alongside the pages already held by `gstack-code-backend`.

The `2026-07-24` verification date stays — that one is deliberately a point-in-time stamp, so a reader can judge how old the `--dry-run` evidence is.

Docs only, one sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATxCCQEB75iMHG1V1HAgXo



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

