### PR TITLE
feat(recipes): is_canonical lock + source_slug column [KAN-139]

### DIFF
--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -69,6 +69,8 @@ def list_recipes(user_id, guest_session_id):
                             "id": recipe.id,
                             "name": recipe.name,
                             "data": recipe.data,
+                            "is_canonical": recipe.is_canonical,
+                            "source_slug": recipe.source_slug,
                             "created_at": (
                                 recipe.created_at.isoformat() if recipe.created_at else None
                             ),
@@ -127,6 +129,8 @@ def create_recipe(user_id, guest_session_id):
     except db_recipe_repository.RecipeSlugError:
         # Fixed message, not str(e): exception text must never reach clients.
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400
+    except db_recipe_repository.CanonicalRecipeError:
+        return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
     except Exception as e:
         logger.error(f"Error creating recipe: {e}")
         return jsonify({"error": "Failed to create recipe"}), 500
@@ -188,6 +192,8 @@ def update_recipe(user_id, guest_session_id, recipe_id):
     except db_recipe_repository.RecipeSlugError:
         # Fixed message, not str(e): exception text must never reach clients.
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400
+    except db_recipe_repository.CanonicalRecipeError:
+        return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
     except Exception as e:
         logger.error(
             "Error updating recipe %s: %s",
@@ -213,6 +219,8 @@ def delete_recipe(user_id, guest_session_id, recipe_id):
 
         return jsonify({"message": "Recipe deleted successfully"}), 200
 
+    except db_recipe_repository.CanonicalRecipeError:
+        return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
     except Exception as e:
         logger.error(
             "Error deleting recipe %s: %s",

--- a/migrations/versions/c8d2f6a1e9b3_add_is_canonical_and_source_slug.py
+++ b/migrations/versions/c8d2f6a1e9b3_add_is_canonical_and_source_slug.py
@@ -1,0 +1,76 @@
+"""Add is_canonical lock + source_slug reference to recipe
+
+Publish state must resolve to one DB row (KAN-139 / cookbook #3217):
+
+- ``is_canonical`` locks the recipes curated in the cookbook repo's
+  specs/canonical-recipes.json: their publish state, slug, and row cannot be
+  changed through the API (repository guards return 400) — only content
+  edits. The column is never writable via the API; this migration seeds it
+  for the approved slugs, and future curation happens by migration/script.
+- ``source_slug`` mirrors the data blob's ``sourceSlug`` key (the public
+  slug a saved copy came from) into a real column, so the server can answer
+  "was this saved from a published recipe?" without parsing JSON, and the
+  SPA gets an authoritative value instead of trusting its own blob.
+
+Revision ID: c8d2f6a1e9b3
+Revises: b7e2a9c4d1f8
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8d2f6a1e9b3"
+down_revision = "b7e2a9c4d1f8"
+branch_labels = None
+depends_on = None
+
+# specs/canonical-recipes.json v1 (cookbook repo, updated 2026-07-23).
+CANONICAL_SLUGS = (
+    "classic-vegan-margherita-pizza",
+    "vegan-cornbread",
+    "vegan-seitan-fried-chicken-and-waffles",
+    "vegan-spaghetti-and-meatballs",
+    "classic-vegan-chocolate-chip-cookies",
+    "maple-smoked-tempeh-blt",
+    "vegan-street-style-tofu-tacos",
+)
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("is_canonical", sa.Boolean(), server_default="0", nullable=False)
+        )
+        batch_op.add_column(sa.Column("source_slug", sa.String(length=255), nullable=True))
+
+    # Backfill source_slug from the JSON blob's sourceSlug key. The blob is
+    # the historical origin of the value (written by the SPA when saving a
+    # public recipe), so the column can only ever lag the blob, never lead it.
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "UPDATE recipe SET source_slug = data->>'sourceSlug' "
+            "WHERE data->>'sourceSlug' IS NOT NULL"
+        )
+    else:
+        op.execute(
+            "UPDATE recipe SET source_slug = json_extract(data, '$.sourceSlug') "
+            "WHERE json_extract(data, '$.sourceSlug') IS NOT NULL"
+        )
+
+    bind.execute(
+        sa.text("UPDATE recipe SET is_canonical = :flag WHERE slug IN :slugs").bindparams(
+            sa.bindparam("slugs", expanding=True)
+        ),
+        {"flag": True, "slugs": list(CANONICAL_SLUGS)},
+    )
+
+
+def downgrade():
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.drop_column("source_slug")
+        batch_op.drop_column("is_canonical")

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -15,6 +15,13 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     worker_claim_token = db.Column(db.String(36), nullable=True)
     slug = db.Column(db.String(255), unique=True, index=True, nullable=True)
     is_public = db.Column(db.Boolean, default=False, nullable=False, server_default="0")
+    # Canonical recipes (curated in the cookbook repo's specs/canonical-recipes.json)
+    # are locked: publish state, slug, and the row itself cannot be changed via the
+    # API — only content edits. Never writable through the API; seeded by migration.
+    is_canonical = db.Column(db.Boolean, default=False, nullable=False, server_default="0")
+    # Slug of the public recipe this row was saved from (the blob's sourceSlug,
+    # mirrored to a column so publish-state checks don't need to parse JSON).
+    source_slug = db.Column(db.String(255), nullable=True)
     # MutableDict ensures in-place JSON updates are tracked (important for SQLite dev).
     data = db.Column(MutableDict.as_mutable(GenericJSON), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
@@ -33,6 +40,8 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
             "status": self.status,
             "slug": self.slug,
             "is_public": self.is_public,
+            "is_canonical": self.is_canonical,
+            "source_slug": self.source_slug,
             "data": self.data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -42,6 +42,34 @@ class RecipeSlugError(ValueError):
     """A recipe cannot be published without a usable /r/<slug> address."""
 
 
+# Also returned verbatim by the API routes (fixed string, same rationale as
+# PUBLIC_SLUG_REQUIRED_ERROR above).
+CANONICAL_RECIPE_LOCKED_ERROR = (
+    "This is a canonical public recipe: its publish state, slug, and row are "
+    "locked. Content edits are still allowed."
+)
+
+
+class CanonicalRecipeError(ValueError):
+    """Publish-state, slug, or delete changes to a canonical recipe are locked."""
+
+
+def _guard_canonical(recipe: Recipe, recipe_data: Dict[str, Any]) -> None:
+    """Reject payloads that would unpublish or re-slug a canonical recipe.
+
+    Canonical recipes (seeded from specs/canonical-recipes.json in the
+    cookbook repo) keep their /r/<slug> URL stable forever; content edits
+    pass through untouched. Checked against the caller's raw payload, not
+    the merged blob, so only explicit intent trips the guard.
+    """
+    if not recipe.is_canonical:
+        return
+    if recipe_data.get("is_public") is False or (
+        "slug" in recipe_data and recipe_data["slug"] != recipe.slug
+    ):
+        raise CanonicalRecipeError(CANONICAL_RECIPE_LOCKED_ERROR)
+
+
 @dataclass(frozen=True)
 class WorkerRecipeUpdate:
     user_id: Optional[int]
@@ -515,8 +543,13 @@ def create_recipe(
                 )
                 return None
 
+            _guard_canonical(existing, recipe_data)
+
             merged = {**(existing.data or {}), **recipe_data, "id": recipe_id}
             _preserve_worker_metadata(existing.data or {}, merged)
+            # The is_canonical column is never writable through the API; pin
+            # the blob to the column so a payload echo can't fake a lock.
+            merged["is_canonical"] = existing.is_canonical
             if "is_public" not in recipe_data:
                 merged["is_public"] = existing.is_public
             if "slug" not in recipe_data:
@@ -532,6 +565,7 @@ def create_recipe(
                 existing.name = recipe_name
                 existing.slug = data.get("slug")
                 existing.is_public = data.get("is_public", False)
+                existing.source_slug = data.get("sourceSlug")
                 existing.data = data
                 existing.status = next_status
                 existing.updated_at = datetime.utcnow()
@@ -543,6 +577,8 @@ def create_recipe(
 
         recipe_name = recipe_data.get("name", "Unnamed Recipe")
         recipe_data_with_id = _gate_is_public({**recipe_data, "id": recipe_id}, user_id)
+        # A client cannot mint its own canonical lock.
+        recipe_data_with_id.pop("is_canonical", None)
 
         def stage_new(data: Dict[str, Any]) -> Recipe:
             recipe = Recipe(
@@ -552,6 +588,7 @@ def create_recipe(
                 name=recipe_name,
                 slug=data.get("slug"),
                 is_public=data.get("is_public", False),
+                source_slug=data.get("sourceSlug"),
                 data=data,
                 status=status,
             )
@@ -567,7 +604,7 @@ def create_recipe(
         )
         return recipe
 
-    except RecipeSlugError:
+    except (RecipeSlugError, CanonicalRecipeError):
         raise
     except Exception as e:
         logger.error("Error creating recipe: %s", sanitize_log_value(e))
@@ -613,12 +650,16 @@ def update_recipe(
             )
             return None
 
+        _guard_canonical(recipe, recipe_data)
+
         # Merge the payload into the persisted blob (and pin the id): PUT
         # accepts partial payloads such as {"is_public": true}, and replacing
         # the blob wholesale would delete ingredients/instructions at the
         # moment of publishing. Keys the payload does supply always win.
         merged = {**(recipe.data or {}), **recipe_data, "id": recipe_id}
         _preserve_worker_metadata(recipe.data or {}, merged)
+        # Never writable through the API — pin the blob to the column.
+        merged["is_canonical"] = recipe.is_canonical
 
         if "is_public" not in recipe_data:
             # The is_public column is authoritative, like slug below: a
@@ -651,6 +692,7 @@ def update_recipe(
             recipe.name = recipe_data.get("name", recipe.name)
             recipe.slug = data.get("slug")
             recipe.is_public = data["is_public"]
+            recipe.source_slug = data.get("sourceSlug")
             recipe.data = data
             if status is not None:
                 recipe.status = status
@@ -664,7 +706,7 @@ def update_recipe(
         logger.info("Updated recipe %s", sanitize_log_value(recipe_id))
         return updated
 
-    except RecipeSlugError:
+    except (RecipeSlugError, CanonicalRecipeError):
         raise
     except Exception as e:
         logger.error(
@@ -895,12 +937,22 @@ def delete_recipe(
             )
             return False
 
+        if recipe.is_canonical:
+            logger.warning(
+                "Refusing to delete canonical recipe %s (slug=%s)",
+                sanitize_log_value(recipe_id),
+                sanitize_log_value(recipe.slug),
+            )
+            raise CanonicalRecipeError(CANONICAL_RECIPE_LOCKED_ERROR)
+
         db.session.delete(recipe)
         db.session.commit()
 
         logger.info("Deleted recipe %s", sanitize_log_value(recipe_id))
         return True
 
+    except CanonicalRecipeError:
+        raise
     except Exception as e:
         logger.error(
             "Error deleting recipe %s: %s",

--- a/tests/test_canonical_lock.py
+++ b/tests/test_canonical_lock.py
@@ -1,0 +1,202 @@
+"""Tests for the is_canonical lock and source_slug column (KAN-139 / cookbook #3217).
+
+Covers:
+- Canonical recipes reject unpublish, slug change, and delete with 400
+- Canonical recipes still accept content edits
+- is_canonical is never writable through the API
+- source_slug is persisted from the payload's sourceSlug on create/update,
+  retained across partial updates, and exposed in API responses
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def user(app):
+    u = User(email="owner@example.com", name="Owner")
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+@pytest.fixture
+def logged_in(client, user):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+    return user
+
+
+def _make_canonical(owner, slug="vegan-cornbread"):
+    recipe = Recipe(
+        id=str(uuid.uuid4()),
+        user_id=owner.id,
+        name="Vegan Cornbread",
+        slug=slug,
+        is_public=True,
+        is_canonical=True,
+        data={"name": "Vegan Cornbread", "slug": slug, "is_public": True},
+    )
+    db.session.add(recipe)
+    db.session.commit()
+    return recipe
+
+
+class TestCanonicalLock:
+    def test_unpublish_canonical_returns_400_and_row_stays_public(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(f"/api/recipes/{recipe.id}", json={"is_public": False})
+
+        assert resp.status_code == 400
+        assert "canonical" in resp.get_json()["error"]
+        row = db.session.get(Recipe, recipe.id)
+        assert row.is_public is True
+        assert row.slug == "vegan-cornbread"
+
+    def test_slug_change_on_canonical_returns_400(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(f"/api/recipes/{recipe.id}", json={"slug": "vegan-cornbread-new"})
+
+        assert resp.status_code == 400
+        assert db.session.get(Recipe, recipe.id).slug == "vegan-cornbread"
+
+    def test_delete_canonical_returns_400_and_row_survives(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.delete(f"/api/recipes/{recipe.id}")
+
+        assert resp.status_code == 400
+        assert db.session.get(Recipe, recipe.id) is not None
+
+    def test_content_edit_on_canonical_is_allowed(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(
+            f"/api/recipes/{recipe.id}",
+            json={"description": "Now with maple butter.", "is_public": True},
+        )
+
+        assert resp.status_code == 200
+        row = db.session.get(Recipe, recipe.id)
+        assert row.data["description"] == "Now with maple butter."
+        assert row.is_public is True
+        assert row.slug == "vegan-cornbread"
+        assert row.is_canonical is True
+
+    def test_echoed_matching_slug_does_not_trip_the_guard(self, client, logged_in):
+        # The SPA PUTs its full blob back, including the slug it loaded.
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(
+            f"/api/recipes/{recipe.id}",
+            json={"name": "Vegan Cornbread", "slug": "vegan-cornbread", "is_public": True},
+        )
+
+        assert resp.status_code == 200
+
+    def test_delete_non_canonical_still_works(self, client, logged_in):
+        recipe = Recipe(
+            id=str(uuid.uuid4()),
+            user_id=logged_in.id,
+            name="Scratch Pad",
+            data={"name": "Scratch Pad"},
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+        resp = client.delete(f"/api/recipes/{recipe.id}")
+
+        assert resp.status_code == 200
+        assert db.session.get(Recipe, recipe.id) is None
+
+    def test_api_cannot_set_is_canonical_on_create(self, client, logged_in):
+        resp = client.post(
+            "/api/recipes",
+            json={"name": "Impostor", "is_canonical": True},
+        )
+
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["is_canonical"] is False
+        assert db.session.get(Recipe, body["id"]).is_canonical is False
+
+    def test_api_cannot_clear_is_canonical_on_update(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(
+            f"/api/recipes/{recipe.id}",
+            json={"is_canonical": False, "description": "sneaky"},
+        )
+
+        assert resp.status_code == 200
+        row = db.session.get(Recipe, recipe.id)
+        assert row.is_canonical is True
+        assert row.data["is_canonical"] is True
+
+
+class TestSourceSlug:
+    def test_source_slug_persisted_on_create(self, client, logged_in):
+        resp = client.post(
+            "/api/recipes",
+            json={"name": "Saved Copy", "sourceSlug": "vegan-cornbread"},
+        )
+
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["source_slug"] == "vegan-cornbread"
+        assert db.session.get(Recipe, body["id"]).source_slug == "vegan-cornbread"
+
+    def test_partial_update_without_source_slug_keeps_column(self, client, logged_in):
+        created = client.post(
+            "/api/recipes",
+            json={"name": "Saved Copy", "sourceSlug": "vegan-cornbread"},
+        ).get_json()
+
+        resp = client.put(
+            f"/api/recipes/{created['id']}",
+            json={"description": "tweaked"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source_slug"] == "vegan-cornbread"
+
+    def test_list_endpoint_exposes_canonical_and_source_slug(self, client, logged_in):
+        client.post("/api/recipes", json={"name": "Saved Copy", "sourceSlug": "vegan-cornbread"})
+
+        resp = client.get("/api/recipes")
+
+        assert resp.status_code == 200
+        (entry,) = resp.get_json()["recipes"]
+        assert entry["source_slug"] == "vegan-cornbread"
+        assert entry["is_canonical"] is False


### PR DESCRIPTION
Implements the Backend half of KAN-139 / cookbook [#3217](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/issues/3217): publish state resolves to **one DB row**.

## What

**One migration (`c8d2f6a1e9b3`, single head off `b7e2a9c4d1f8`) adds both columns:**

- `is_canonical BOOLEAN NOT NULL DEFAULT FALSE` — locks the recipes curated in the cookbook repo's `specs/canonical-recipes.json`. Seeded for the 7 approved slugs by the migration.
- `source_slug VARCHAR(255) NULL` — mirrors the data blob's `sourceSlug` (the public slug a saved copy came from) into a real column. Backfilled from the JSON blob (Postgres `->>` / SQLite `json_extract`).

**Endpoint guards (repository-level, so every caller gets them):**

- Unpublish, slug change, or delete of a canonical recipe → **400** with a fixed `CANONICAL_RECIPE_LOCKED_ERROR` message (no exception text leaks). Content edits pass through — canonical URL + name stay stable, the recipe itself stays curatable in place.
- `is_canonical` is never writable through the API: stripped on create, pinned to the column on update (a payload echo can't fake or clear a lock).

**source_slug persistence:** written from the payload's `sourceSlug` on create/update, retained across partial updates (the blob-merge already preserves the key), exposed in `to_dict()` and the list endpoint — so the SPA can render the greyed toggle / source View link from server truth instead of its own localStorage blob.

## Verification

- `uv run pytest` — **318 passed** (11 new in `tests/test_canonical_lock.py`: lock guards, content-edit passthrough, API-can't-set/clear canonical, source_slug create/retain/list)
- `flask db heads` — single head `c8d2f6a1e9b3` before and after
- Migration smoke-tested on SQLite: upgrade → downgrade → re-upgrade; backfill mirrors `sourceSlug`, seed flags the canonical slug, non-canonical rows untouched
- black / flake8 / mypy clean

## Ships with

Cookbook SPA follow-up (toggle greyed by default while loading + for `source_slug` copies, canonical lock indicator, repeat-save trap using server-side `source_slug`) lands as a cookbook PR with the pointer bump after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

