### PR TITLE
feat(recipes): origin column + manual-entry publish gate [KAN-140]

### DIFF
--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -69,8 +69,14 @@ def list_recipes(user_id, guest_session_id):
                             "id": recipe.id,
                             "name": recipe.name,
                             "data": recipe.data,
+                            # Column values are authoritative over the blob's
+                            # copies, which can lag on rows written before the
+                            # blob-sync era — the SPA prefers these (KAN-139).
+                            "slug": recipe.slug,
+                            "is_public": recipe.is_public,
                             "is_canonical": recipe.is_canonical,
                             "source_slug": recipe.source_slug,
+                            "origin": recipe.origin,
                             "created_at": (
                                 recipe.created_at.isoformat() if recipe.created_at else None
                             ),
@@ -131,6 +137,8 @@ def create_recipe(user_id, guest_session_id):
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400
     except db_recipe_repository.CanonicalRecipeError:
         return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
+    except db_recipe_repository.ManualRecipeError:
+        return jsonify({"error": db_recipe_repository.MANUAL_RECIPE_UNPUBLISHABLE_ERROR}), 400
     except Exception as e:
         logger.error(f"Error creating recipe: {e}")
         return jsonify({"error": "Failed to create recipe"}), 500
@@ -194,6 +202,8 @@ def update_recipe(user_id, guest_session_id, recipe_id):
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400
     except db_recipe_repository.CanonicalRecipeError:
         return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
+    except db_recipe_repository.ManualRecipeError:
+        return jsonify({"error": db_recipe_repository.MANUAL_RECIPE_UNPUBLISHABLE_ERROR}), 400
     except Exception as e:
         logger.error(
             "Error updating recipe %s: %s",

--- a/migrations/versions/d1e5a9c3f7b2_add_origin_to_recipe.py
+++ b/migrations/versions/d1e5a9c3f7b2_add_origin_to_recipe.py
@@ -1,0 +1,63 @@
+"""Add origin column to recipe; backfill manual-entry rows
+
+Manually entered recipes must not be publishable (KAN-140): the manual-entry
+form is the only UI surface where a user types arbitrary full recipe content
+with no AI mediation, and publishing puts that content on the public
+/r/<slug> pages. The ``origin`` column records how each recipe entered the
+system ('manual' | 'generated' | 'saved', NULL = legacy/unknown); the
+repository's publish gate rejects ``is_public=true`` for 'manual' rows.
+
+Backfill: the manual-entry modal has always written the blob signature
+``image_keywords == [<name>, 'homemade']`` (exactly two elements, second
+fixed). Rows matching it are marked 'manual'. Other rows stay NULL — the
+gate treats NULL as publishable, so no legacy generated recipe loses
+anything.
+
+Revision ID: d1e5a9c3f7b2
+Revises: c8d2f6a1e9b3
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d1e5a9c3f7b2"
+down_revision = "c8d2f6a1e9b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("origin", sa.String(length=20), nullable=True))
+
+    if bind.dialect.name == "postgresql":
+        # CASE guarantees the array-type check runs before json_array_length
+        # (plain AND does not short-circuit in PG, and json_array_length
+        # raises on scalars).
+        op.execute(
+            "UPDATE recipe SET origin = 'manual' "
+            "WHERE CASE WHEN json_typeof(data->'image_keywords') = 'array' "
+            "THEN json_array_length(data->'image_keywords') = 2 "
+            "AND data->'image_keywords'->>1 = 'homemade' "
+            "ELSE false END"
+        )
+    else:
+        # Same CASE guard: json_extract unwraps a scalar string to plain
+        # text, which json_array_length then rejects as malformed JSON.
+        op.execute(
+            "UPDATE recipe SET origin = 'manual' "
+            "WHERE CASE WHEN json_type(data, '$.image_keywords') = 'array' "
+            "THEN json_array_length(data, '$.image_keywords') = 2 "
+            "AND json_extract(data, '$.image_keywords[1]') = 'homemade' "
+            "ELSE 0 END"
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.drop_column("origin")

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -22,6 +22,11 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     # Slug of the public recipe this row was saved from (the blob's sourceSlug,
     # mirrored to a column so publish-state checks don't need to parse JSON).
     source_slug = db.Column(db.String(255), nullable=True)
+    # How the recipe entered the system: 'manual' | 'generated' | 'saved'
+    # (NULL = legacy/unknown). Manually entered recipes cannot be published
+    # (KAN-140) — free-text content with no AI mediation must not reach the
+    # public /r/<slug> surface. Settable while NULL, immutable once set.
+    origin = db.Column(db.String(20), nullable=True)
     # MutableDict ensures in-place JSON updates are tracked (important for SQLite dev).
     data = db.Column(MutableDict.as_mutable(GenericJSON), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
@@ -42,6 +47,7 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
             "is_public": self.is_public,
             "is_canonical": self.is_canonical,
             "source_slug": self.source_slug,
+            "origin": self.origin,
             "data": self.data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -54,6 +54,48 @@ class CanonicalRecipeError(ValueError):
     """Publish-state, slug, or delete changes to a canonical recipe are locked."""
 
 
+# Also returned verbatim by the API routes (fixed string, same rationale as
+# PUBLIC_SLUG_REQUIRED_ERROR above).
+MANUAL_RECIPE_UNPUBLISHABLE_ERROR = (
+    "Manually entered recipes cannot be published. Only generated recipes "
+    "can have a public page."
+)
+
+# 'manual' gates publishing; the others exist so curation can query by
+# provenance. NULL = legacy/unknown, treated as publishable.
+_ALLOWED_ORIGINS = frozenset({"manual", "generated", "saved"})
+
+
+class ManualRecipeError(ValueError):
+    """Manually entered recipes cannot be published (KAN-140)."""
+
+
+def _resolve_origin(current_origin: Optional[str], recipe_data: Dict[str, Any]) -> Optional[str]:
+    """Column value for origin: settable while NULL, immutable once set.
+
+    Once a recipe is labeled, a later payload cannot relabel it — otherwise
+    a 'manual' recipe could launder itself into 'generated' and slip past
+    the publish gate. Unknown labels are dropped rather than stored.
+    """
+    if current_origin:
+        return current_origin
+    candidate = recipe_data.get("origin")
+    return candidate if candidate in _ALLOWED_ORIGINS else None
+
+
+def _gate_manual_publish(origin: Optional[str], recipe_data: Dict[str, Any]) -> None:
+    """Reject publication of manually entered recipes (KAN-140).
+
+    The manual-entry form is free-text content with no AI mediation; the
+    public /r/<slug> surface must not become an open publishing endpoint.
+    Raises (a 400 at the API) instead of silently forcing the flag off, so
+    the SPA's revert-and-toast path fires rather than diverging from the
+    server state.
+    """
+    if origin == "manual" and recipe_data.get("is_public") is True:
+        raise ManualRecipeError(MANUAL_RECIPE_UNPUBLISHABLE_ERROR)
+
+
 def _guard_canonical(recipe: Recipe, recipe_data: Dict[str, Any]) -> None:
     """Reject payloads that would unpublish or re-slug a canonical recipe.
 
@@ -558,6 +600,12 @@ def create_recipe(
                 else:
                     merged.pop("slug", None)
             recipe_data_with_id = _gate_is_public(merged, user_id)
+            next_origin = _resolve_origin(existing.origin, recipe_data)
+            _gate_manual_publish(next_origin, recipe_data_with_id)
+            if next_origin is not None:
+                recipe_data_with_id["origin"] = next_origin
+            else:
+                recipe_data_with_id.pop("origin", None)
             recipe_name = recipe_data.get("name", existing.name)
             next_status = existing.status if existing.status in _ACTIVE_RECIPE_STATUSES else status
 
@@ -566,6 +614,7 @@ def create_recipe(
                 existing.slug = data.get("slug")
                 existing.is_public = data.get("is_public", False)
                 existing.source_slug = data.get("sourceSlug")
+                existing.origin = next_origin
                 existing.data = data
                 existing.status = next_status
                 existing.updated_at = datetime.utcnow()
@@ -579,6 +628,12 @@ def create_recipe(
         recipe_data_with_id = _gate_is_public({**recipe_data, "id": recipe_id}, user_id)
         # A client cannot mint its own canonical lock.
         recipe_data_with_id.pop("is_canonical", None)
+        origin_value = _resolve_origin(None, recipe_data)
+        _gate_manual_publish(origin_value, recipe_data_with_id)
+        if origin_value is not None:
+            recipe_data_with_id["origin"] = origin_value
+        else:
+            recipe_data_with_id.pop("origin", None)
 
         def stage_new(data: Dict[str, Any]) -> Recipe:
             recipe = Recipe(
@@ -589,6 +644,7 @@ def create_recipe(
                 slug=data.get("slug"),
                 is_public=data.get("is_public", False),
                 source_slug=data.get("sourceSlug"),
+                origin=origin_value,
                 data=data,
                 status=status,
             )
@@ -604,7 +660,7 @@ def create_recipe(
         )
         return recipe
 
-    except (RecipeSlugError, CanonicalRecipeError):
+    except (RecipeSlugError, CanonicalRecipeError, ManualRecipeError):
         raise
     except Exception as e:
         logger.error("Error creating recipe: %s", sanitize_log_value(e))
@@ -688,11 +744,19 @@ def update_recipe(
             else:
                 recipe_data_with_id.pop("slug", None)
 
+        next_origin = _resolve_origin(recipe.origin, recipe_data)
+        _gate_manual_publish(next_origin, recipe_data_with_id)
+        if next_origin is not None:
+            recipe_data_with_id["origin"] = next_origin
+        else:
+            recipe_data_with_id.pop("origin", None)
+
         def stage_update(data: Dict[str, Any]) -> Recipe:
             recipe.name = recipe_data.get("name", recipe.name)
             recipe.slug = data.get("slug")
             recipe.is_public = data["is_public"]
             recipe.source_slug = data.get("sourceSlug")
+            recipe.origin = next_origin
             recipe.data = data
             if status is not None:
                 recipe.status = status
@@ -706,7 +770,7 @@ def update_recipe(
         logger.info("Updated recipe %s", sanitize_log_value(recipe_id))
         return updated
 
-    except (RecipeSlugError, CanonicalRecipeError):
+    except (RecipeSlugError, CanonicalRecipeError, ManualRecipeError):
         raise
     except Exception as e:
         logger.error(

--- a/tests/test_manual_origin_gate.py
+++ b/tests/test_manual_origin_gate.py
@@ -1,0 +1,144 @@
+"""Tests for the origin column and manual-entry publish gate (KAN-140).
+
+Covers:
+- Manually entered recipes cannot be published (400 on create and update)
+- origin is settable while NULL, immutable once set (no relabel laundering)
+- Unknown origin labels are dropped, not stored
+- origin is exposed in to_dict and the list endpoint
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def logged_in(client, app):
+    user = User(email="owner@example.com", name="Owner")
+    db.session.add(user)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+    return user
+
+
+class TestManualPublishGate:
+    def test_create_manual_and_public_returns_400(self, client, logged_in):
+        resp = client.post(
+            "/api/recipes",
+            json={"name": "Handwritten", "origin": "manual", "is_public": True},
+        )
+
+        assert resp.status_code == 400
+        assert "Manually entered" in resp.get_json()["error"]
+        assert Recipe.query.count() == 0
+
+    def test_create_manual_private_persists_origin(self, client, logged_in):
+        resp = client.post("/api/recipes", json={"name": "Handwritten", "origin": "manual"})
+
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["origin"] == "manual"
+        assert db.session.get(Recipe, body["id"]).origin == "manual"
+
+    def test_publishing_a_manual_recipe_later_returns_400(self, client, logged_in):
+        created = client.post(
+            "/api/recipes", json={"name": "Handwritten", "origin": "manual"}
+        ).get_json()
+
+        resp = client.put(f"/api/recipes/{created['id']}", json={"is_public": True})
+
+        assert resp.status_code == 400
+        assert "Manually entered" in resp.get_json()["error"]
+        row = db.session.get(Recipe, created["id"])
+        assert row.is_public is False
+
+    def test_manual_origin_cannot_be_laundered_to_generated(self, client, logged_in):
+        created = client.post(
+            "/api/recipes", json={"name": "Handwritten", "origin": "manual"}
+        ).get_json()
+
+        relabel = client.put(
+            f"/api/recipes/{created['id']}", json={"origin": "generated", "notes": "tweak"}
+        )
+        assert relabel.status_code == 200
+        assert relabel.get_json()["origin"] == "manual"
+
+        publish = client.put(f"/api/recipes/{created['id']}", json={"is_public": True})
+        assert publish.status_code == 400
+
+    def test_generated_recipe_still_publishes(self, client, logged_in):
+        resp = client.post(
+            "/api/recipes",
+            json={"name": "AI Chili", "origin": "generated", "is_public": True},
+        )
+
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["is_public"] is True
+        assert body["origin"] == "generated"
+
+    def test_legacy_null_origin_still_publishes(self, client, logged_in):
+        resp = client.post("/api/recipes", json={"name": "Old Row", "is_public": True})
+
+        assert resp.status_code == 201
+        assert resp.get_json()["is_public"] is True
+        assert resp.get_json()["origin"] is None
+
+    def test_unknown_origin_label_is_dropped(self, client, logged_in):
+        resp = client.post("/api/recipes", json={"name": "Weird", "origin": "admin"})
+
+        assert resp.status_code == 201
+        assert resp.get_json()["origin"] is None
+
+    def test_null_origin_can_adopt_manual_label(self, client, logged_in):
+        recipe = Recipe(
+            id=str(uuid.uuid4()),
+            user_id=logged_in.id,
+            name="Legacy Manual",
+            data={"name": "Legacy Manual"},
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+        resp = client.put(f"/api/recipes/{recipe.id}", json={"origin": "manual"})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["origin"] == "manual"
+
+    def test_list_endpoint_exposes_origin(self, client, logged_in):
+        client.post("/api/recipes", json={"name": "Handwritten", "origin": "manual"})
+
+        resp = client.get("/api/recipes")
+
+        assert resp.status_code == 200
+        (entry,) = resp.get_json()["recipes"]
+        assert entry["origin"] == "manual"


### PR DESCRIPTION
Backend half of KAN-140 (Adam's directive from the notes-abuse walkthrough, live-verified on /r/vegan-zucchini-poppers): **manually entered recipes must not be publishable**. Ships in the same release wave as the KAN-139 migration — `d1e5a9c3f7b2` chains directly off `c8d2f6a1e9b3`, single head verified.

## What

- **`origin VARCHAR(20) NULL`** on recipe: `'manual' | 'generated' | 'saved'`, NULL = legacy/unknown (publishable, nothing regresses). Settable while NULL, **immutable once set** — a manual row can't relabel itself `generated` to launder past the gate. Unknown labels are dropped, not stored.
- **Publish gate**: `is_public: true` on an `origin='manual'` row raises `ManualRecipeError` → **400** with a fixed client-safe message (mirrors the canonical-lock pattern; deliberately not a silent force-off like the guest gate, so the SPA's new revert+toast path from KAN-104 fires instead of diverging from server state).
- **Backfill**: rows carrying the manual-entry blob signature (`image_keywords == [<name>, 'homemade']` — the shape manual-entry-modal has always written) are marked `'manual'`. JSON access is CASE-guarded on both dialects: PG `json_array_length` raises on scalars (and `AND` doesn't short-circuit), SQLite `json_extract` unwraps strings to malformed-JSON input — the smoke test plants a scalar `image_keywords` row to prove both survive.
- `origin` exposed in `to_dict()` and the list endpoint for the SPA + curation queries.

**Known limit (accepted):** origin is client-declared for raw API callers — same trust model as the guest publish gate. This closes the UI loop and enables provenance queries; it is not a hard security boundary.

## Verification

- `uv run pytest` — **327 passed** (9 new in `tests/test_manual_origin_gate.py`: create/update 400s, immutability/laundering, NULL-adopt, unknown-label drop, generated + legacy still publish, list exposure)
- Migration smoke-tested upgrade → downgrade → re-upgrade on SQLite: manual signature flagged, generated + scalar-keyword rows untouched
- `flask db heads` = `d1e5a9c3f7b2` (single), black/flake8/mypy clean

## Ships with

Cookbook SPA follow-up (manual-entry stamps `origin: 'manual'`, publish toggle disabled for manual recipes, **notes editor removed for published recipes** per Adam's 'removal == best for now' call) + pointer bump, as a cookbook PR after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

