### PR TITLE
feat(scripts): scheduled imageless-recipe repair enqueuer [KAN-141]

### DIFF
--- a/scripts/repair_missing_images.py
+++ b/scripts/repair_missing_images.py
@@ -45,19 +45,30 @@ def _is_imageless(data: dict) -> bool:
 
 
 def select_candidates(limit: int):
-    """Imageless, generation-idle recipes, most publicly visible first."""
+    """Imageless, generation-idle recipes, most publicly visible first.
+
+    Streams rows in priority order and stops as soon as ``limit`` imageless
+    candidates are collected — a ``.all()`` load would pull the whole
+    ready-recipe table into memory just to keep the first few.
+    """
     from models import Recipe
 
-    rows = (
+    stream = (
         Recipe.query.filter(Recipe.status == "ready")
         .order_by(
             Recipe.is_canonical.desc(),
             Recipe.is_public.desc(),
             Recipe.created_at.asc(),
         )
-        .all()
+        .yield_per(200)
     )
-    return [r for r in rows if _is_imageless(r.data or {})][:limit]
+    picked = []
+    for recipe in stream:
+        if _is_imageless(recipe.data or {}):
+            picked.append(recipe)
+            if len(picked) >= limit:
+                break
+    return picked
 
 
 def enqueue(recipe) -> bool:

--- a/scripts/repair_missing_images.py
+++ b/scripts/repair_missing_images.py
@@ -1,0 +1,141 @@
+"""Detect recipes with no image bytes and enqueue regeneration (KAN-141).
+
+Runs as the scheduled Cloud Run Job ``flask-backend-image-repair``: scans for
+recipes whose data blob has neither ``ai_image_data`` (base64) nor
+``ai_image_gcs`` (bucket URI) — the same "imageless" semantics as the
+/api/admin/image-audit endpoint — and enqueues each through the exact
+Pub/Sub path the SPA's regenerate button uses. The flask-backend worker does
+the actual Imagen generation; this script only detects and enqueues.
+
+Priority order (most-visible pages repaired first): canonical recipes, then
+published recipes, then everything else oldest-first. Each run enqueues at
+most ``IMAGE_REPAIR_LIMIT`` recipes (default 10) so a large backlog drains
+over successive runs instead of burning Imagen quota in one burst.
+
+Usage:
+    python scripts/repair_missing_images.py [--dry-run]
+
+Exit codes: 0 = success (including "nothing to repair"), 1 = fatal error.
+Skipped rows (queue contention, publish failure) are logged and do not fail
+the run — the next scheduled run retries them.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("image-repair")
+
+DEFAULT_LIMIT = 10
+
+
+def _is_imageless(data: dict) -> bool:
+    """True when the blob holds no actual image bytes/URI.
+
+    ``ai_image_url`` alone does not count: rows exist whose URL points at an
+    object that was never written (blank hero/OG images on the public page).
+    """
+    return not data.get("ai_image_data") and not data.get("ai_image_gcs")
+
+
+def select_candidates(limit: int):
+    """Imageless, generation-idle recipes, most publicly visible first."""
+    from models import Recipe
+
+    rows = (
+        Recipe.query.filter(Recipe.status == "ready")
+        .order_by(
+            Recipe.is_canonical.desc(),
+            Recipe.is_public.desc(),
+            Recipe.created_at.asc(),
+        )
+        .all()
+    )
+    return [r for r in rows if _is_imageless(r.data or {})][:limit]
+
+
+def enqueue(recipe) -> bool:
+    """Queue one recipe through the same path as POST /api/generate_image."""
+    from repositories import db_recipe_repository
+    from services.pubsub_service import publish_message
+
+    queued = db_recipe_repository.queue_image_generation(
+        recipe.id,
+        str(uuid.uuid4()),
+        False,
+        recipe.user_id,
+        recipe.guest_session_id,
+    )
+    if queued is None:
+        logger.warning("skip %s: not queueable (state changed under us)", recipe.id)
+        return False
+    if not queued.should_publish:
+        logger.info("skip %s: request already pending", recipe.id)
+        return False
+
+    try:
+        publish_message(
+            "image-generation",
+            {
+                "recipe_id": recipe.id,
+                "user_id": recipe.user_id,
+                "guest_session_id": recipe.guest_session_id,
+                "force_regenerate": queued.force_regenerate,
+                "image_request_id": queued.request_id,
+            },
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 - one bad publish must not kill the run
+        logger.error("publish failed for %s: %s", recipe.id, exc)
+        db_recipe_repository.release_image_generation_queue(
+            recipe.id, queued.request_id, recipe.user_id, recipe.guest_session_id
+        )
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="report candidates without enqueueing"
+    )
+    args = parser.parse_args()
+
+    limit = int(os.environ.get("IMAGE_REPAIR_LIMIT", DEFAULT_LIMIT))
+
+    from app import create_app
+
+    app = create_app()
+    with app.app_context():
+        candidates = select_candidates(limit)
+        if not candidates:
+            logger.info("No imageless recipes found — nothing to repair.")
+            return 0
+
+        logger.info("%d imageless recipe(s), limit %d this run:", len(candidates), limit)
+        for r in candidates:
+            logger.info(
+                "  %s %r (canonical=%s public=%s slug=%s)",
+                r.id,
+                r.name,
+                r.is_canonical,
+                r.is_public,
+                r.slug,
+            )
+
+        if args.dry_run:
+            logger.info("Dry run — nothing enqueued.")
+            return 0
+
+        enqueued = sum(1 for r in candidates if enqueue(r))
+        logger.info("Enqueued %d/%d image regeneration(s).", enqueued, len(candidates))
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_repair_missing_images.py
+++ b/tests/test_repair_missing_images.py
@@ -1,0 +1,105 @@
+"""Tests for scripts/repair_missing_images.py (KAN-141)."""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from scripts.repair_missing_images import _is_imageless, enqueue, select_candidates  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _recipe(name, *, data=None, status="ready", public=False, canonical=False, slug=None):
+    recipe = Recipe(
+        id=str(uuid.uuid4()),
+        name=name,
+        status=status,
+        slug=slug,
+        is_public=public,
+        is_canonical=canonical,
+        data=data if data is not None else {"name": name},
+    )
+    db.session.add(recipe)
+    return recipe
+
+
+class TestIsImageless:
+    def test_no_image_fields_is_imageless(self):
+        assert _is_imageless({}) is True
+
+    def test_url_without_bytes_is_still_imageless(self):
+        # The blank-hero case: ai_image_url points at an object never written.
+        assert _is_imageless({"ai_image_url": "/api/recipes/x/image"}) is True
+
+    def test_gcs_or_base64_counts_as_imaged(self):
+        assert _is_imageless({"ai_image_gcs": "gs://bucket/x.png"}) is False
+        assert _is_imageless({"ai_image_data": "base64..."}) is False
+
+
+class TestSelectCandidates:
+    def test_orders_canonical_then_public_then_oldest(self, app):
+        plain = _recipe("plain")
+        public = _recipe("public", public=True, slug="public-r")
+        canonical = _recipe("canonical", public=True, canonical=True, slug="canon-r")
+        _recipe("imaged", data={"name": "imaged", "ai_image_gcs": "gs://b/i.png"})
+        _recipe("busy", status="generating_image")
+        db.session.commit()
+
+        picked = select_candidates(10)
+
+        assert [r.id for r in picked] == [canonical.id, public.id, plain.id]
+
+    def test_respects_limit(self, app):
+        for i in range(5):
+            _recipe(f"r{i}")
+        db.session.commit()
+
+        assert len(select_candidates(2)) == 2
+
+
+class TestEnqueue:
+    def test_enqueues_via_pubsub_and_marks_generating(self, app, monkeypatch):
+        published = []
+        monkeypatch.setattr(
+            "services.pubsub_service.publish_message",
+            lambda topic, data: published.append((topic, data)) or "msg-1",
+        )
+        recipe = _recipe("needs image")
+        db.session.commit()
+
+        assert enqueue(recipe) is True
+
+        topic, message = published[0]
+        assert topic == "image-generation"
+        assert message["recipe_id"] == recipe.id
+        assert db.session.get(Recipe, recipe.id).status == "generating_image"
+
+    def test_publish_failure_releases_queue_and_reports_false(self, app, monkeypatch):
+        def boom(topic, data):
+            raise RuntimeError("pubsub down")
+
+        monkeypatch.setattr("services.pubsub_service.publish_message", boom)
+        recipe = _recipe("needs image")
+        db.session.commit()
+
+        assert enqueue(recipe) is False
+        assert db.session.get(Recipe, recipe.id).status == "ready"


### PR DESCRIPTION
Backend half of KAN-141 (Adam's directive): imageless recipes — **especially published, especially canonical** — get their images regenerated by a scheduled Cloud Run Job.

## What

`scripts/repair_missing_images.py`, designed to run as Cloud Run Job `flask-backend-image-repair`:

- **Detection**: a recipe is imageless when its blob has neither `ai_image_data` nor `ai_image_gcs` — same semantics as `/api/admin/image-audit`. `ai_image_url` alone does **not** count, which covers the known blank-hero/OG rows whose URL points at bytes that were never written.
- **Priority**: `is_canonical DESC, is_public DESC, created_at ASC` — most publicly visible pages repaired first (the KAN-139 columns make this a plain ORDER BY).
- **Enqueue, don't generate**: each candidate goes through the exact `queue_image_generation` + Pub/Sub `image-generation` path the SPA's regenerate button uses (owner-scoped with the row's own user/guest scope, queue released on publish failure). The flask-backend worker does the Imagen work, so the job needs no Gemini credentials.
- **Throttle**: `IMAGE_REPAIR_LIMIT` per run (default 10) — a backlog drains across runs instead of bursting Imagen quota. `--dry-run` reports without enqueueing. One bad row logs and skips; the next run retries.

## Verification

- 334/334 pytest (7 new: imageless semantics incl. URL-without-bytes, priority ordering, limit, Pub/Sub enqueue happy path, publish-failure queue release)
- black / flake8 / mypy clean

## Ships with

Cookbook cloudbuild step deploying the Job (mirrors the migrate-job pattern, deploy-only — no execute during builds) + a one-time Cloud Scheduler trigger, as a cookbook PR. Runs are inert until the scheduler exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

