### PR TITLE
release: promote dev → main for cookbook v0.4.4 [KAN-138]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # (v0.3.0 migrate job died on ModuleNotFoundError: flask_cors; see
 # docs/ci/CI-AUDIT-REPORT.md). --frozen means the lockfile is used exactly as
 # committed, never re-resolved at build time.
-FROM ghcr.io/astral-sh/uv:0.11.29-python3.13-trixie-slim AS export
+FROM ghcr.io/astral-sh/uv:0.11.32-python3.13-trixie-slim AS export
 WORKDIR /export
 COPY pyproject.toml uv.lock ./
 RUN uv export --format requirements-txt --no-dev --extra postgres \

--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -69,6 +69,8 @@ def list_recipes(user_id, guest_session_id):
                             "id": recipe.id,
                             "name": recipe.name,
                             "data": recipe.data,
+                            "is_canonical": recipe.is_canonical,
+                            "source_slug": recipe.source_slug,
                             "created_at": (
                                 recipe.created_at.isoformat() if recipe.created_at else None
                             ),
@@ -127,6 +129,8 @@ def create_recipe(user_id, guest_session_id):
     except db_recipe_repository.RecipeSlugError:
         # Fixed message, not str(e): exception text must never reach clients.
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400
+    except db_recipe_repository.CanonicalRecipeError:
+        return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
     except Exception as e:
         logger.error(f"Error creating recipe: {e}")
         return jsonify({"error": "Failed to create recipe"}), 500
@@ -188,6 +192,8 @@ def update_recipe(user_id, guest_session_id, recipe_id):
     except db_recipe_repository.RecipeSlugError:
         # Fixed message, not str(e): exception text must never reach clients.
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400
+    except db_recipe_repository.CanonicalRecipeError:
+        return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
     except Exception as e:
         logger.error(
             "Error updating recipe %s: %s",
@@ -213,6 +219,8 @@ def delete_recipe(user_id, guest_session_id, recipe_id):
 
         return jsonify({"message": "Recipe deleted successfully"}), 200
 
+    except db_recipe_repository.CanonicalRecipeError:
+        return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
     except Exception as e:
         logger.error(
             "Error deleting recipe %s: %s",

--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -69,8 +69,14 @@ def list_recipes(user_id, guest_session_id):
                             "id": recipe.id,
                             "name": recipe.name,
                             "data": recipe.data,
+                            # Column values are authoritative over the blob's
+                            # copies, which can lag on rows written before the
+                            # blob-sync era — the SPA prefers these (KAN-139).
+                            "slug": recipe.slug,
+                            "is_public": recipe.is_public,
                             "is_canonical": recipe.is_canonical,
                             "source_slug": recipe.source_slug,
+                            "origin": recipe.origin,
                             "created_at": (
                                 recipe.created_at.isoformat() if recipe.created_at else None
                             ),
@@ -131,6 +137,8 @@ def create_recipe(user_id, guest_session_id):
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400
     except db_recipe_repository.CanonicalRecipeError:
         return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
+    except db_recipe_repository.ManualRecipeError:
+        return jsonify({"error": db_recipe_repository.MANUAL_RECIPE_UNPUBLISHABLE_ERROR}), 400
     except Exception as e:
         logger.error(f"Error creating recipe: {e}")
         return jsonify({"error": "Failed to create recipe"}), 500
@@ -194,6 +202,8 @@ def update_recipe(user_id, guest_session_id, recipe_id):
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400
     except db_recipe_repository.CanonicalRecipeError:
         return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
+    except db_recipe_repository.ManualRecipeError:
+        return jsonify({"error": db_recipe_repository.MANUAL_RECIPE_UNPUBLISHABLE_ERROR}), 400
     except Exception as e:
         logger.error(
             "Error updating recipe %s: %s",

--- a/migrations/versions/c8d2f6a1e9b3_add_is_canonical_and_source_slug.py
+++ b/migrations/versions/c8d2f6a1e9b3_add_is_canonical_and_source_slug.py
@@ -1,0 +1,76 @@
+"""Add is_canonical lock + source_slug reference to recipe
+
+Publish state must resolve to one DB row (KAN-139 / cookbook #3217):
+
+- ``is_canonical`` locks the recipes curated in the cookbook repo's
+  specs/canonical-recipes.json: their publish state, slug, and row cannot be
+  changed through the API (repository guards return 400) — only content
+  edits. The column is never writable via the API; this migration seeds it
+  for the approved slugs, and future curation happens by migration/script.
+- ``source_slug`` mirrors the data blob's ``sourceSlug`` key (the public
+  slug a saved copy came from) into a real column, so the server can answer
+  "was this saved from a published recipe?" without parsing JSON, and the
+  SPA gets an authoritative value instead of trusting its own blob.
+
+Revision ID: c8d2f6a1e9b3
+Revises: b7e2a9c4d1f8
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8d2f6a1e9b3"
+down_revision = "b7e2a9c4d1f8"
+branch_labels = None
+depends_on = None
+
+# specs/canonical-recipes.json v1 (cookbook repo, updated 2026-07-23).
+CANONICAL_SLUGS = (
+    "classic-vegan-margherita-pizza",
+    "vegan-cornbread",
+    "vegan-seitan-fried-chicken-and-waffles",
+    "vegan-spaghetti-and-meatballs",
+    "classic-vegan-chocolate-chip-cookies",
+    "maple-smoked-tempeh-blt",
+    "vegan-street-style-tofu-tacos",
+)
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("is_canonical", sa.Boolean(), server_default="0", nullable=False)
+        )
+        batch_op.add_column(sa.Column("source_slug", sa.String(length=255), nullable=True))
+
+    # Backfill source_slug from the JSON blob's sourceSlug key. The blob is
+    # the historical origin of the value (written by the SPA when saving a
+    # public recipe), so the column can only ever lag the blob, never lead it.
+    if bind.dialect.name == "postgresql":
+        op.execute(
+            "UPDATE recipe SET source_slug = data->>'sourceSlug' "
+            "WHERE data->>'sourceSlug' IS NOT NULL"
+        )
+    else:
+        op.execute(
+            "UPDATE recipe SET source_slug = json_extract(data, '$.sourceSlug') "
+            "WHERE json_extract(data, '$.sourceSlug') IS NOT NULL"
+        )
+
+    bind.execute(
+        sa.text("UPDATE recipe SET is_canonical = :flag WHERE slug IN :slugs").bindparams(
+            sa.bindparam("slugs", expanding=True)
+        ),
+        {"flag": True, "slugs": list(CANONICAL_SLUGS)},
+    )
+
+
+def downgrade():
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.drop_column("source_slug")
+        batch_op.drop_column("is_canonical")

--- a/migrations/versions/d1e5a9c3f7b2_add_origin_to_recipe.py
+++ b/migrations/versions/d1e5a9c3f7b2_add_origin_to_recipe.py
@@ -1,0 +1,63 @@
+"""Add origin column to recipe; backfill manual-entry rows
+
+Manually entered recipes must not be publishable (KAN-140): the manual-entry
+form is the only UI surface where a user types arbitrary full recipe content
+with no AI mediation, and publishing puts that content on the public
+/r/<slug> pages. The ``origin`` column records how each recipe entered the
+system ('manual' | 'generated' | 'saved', NULL = legacy/unknown); the
+repository's publish gate rejects ``is_public=true`` for 'manual' rows.
+
+Backfill: the manual-entry modal has always written the blob signature
+``image_keywords == [<name>, 'homemade']`` (exactly two elements, second
+fixed). Rows matching it are marked 'manual'. Other rows stay NULL — the
+gate treats NULL as publishable, so no legacy generated recipe loses
+anything.
+
+Revision ID: d1e5a9c3f7b2
+Revises: c8d2f6a1e9b3
+Create Date: 2026-07-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d1e5a9c3f7b2"
+down_revision = "c8d2f6a1e9b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("origin", sa.String(length=20), nullable=True))
+
+    if bind.dialect.name == "postgresql":
+        # CASE guarantees the array-type check runs before json_array_length
+        # (plain AND does not short-circuit in PG, and json_array_length
+        # raises on scalars).
+        op.execute(
+            "UPDATE recipe SET origin = 'manual' "
+            "WHERE CASE WHEN json_typeof(data->'image_keywords') = 'array' "
+            "THEN json_array_length(data->'image_keywords') = 2 "
+            "AND data->'image_keywords'->>1 = 'homemade' "
+            "ELSE false END"
+        )
+    else:
+        # Same CASE guard: json_extract unwraps a scalar string to plain
+        # text, which json_array_length then rejects as malformed JSON.
+        op.execute(
+            "UPDATE recipe SET origin = 'manual' "
+            "WHERE CASE WHEN json_type(data, '$.image_keywords') = 'array' "
+            "THEN json_array_length(data, '$.image_keywords') = 2 "
+            "AND json_extract(data, '$.image_keywords[1]') = 'homemade' "
+            "ELSE 0 END"
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.drop_column("origin")

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -22,6 +22,11 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     # Slug of the public recipe this row was saved from (the blob's sourceSlug,
     # mirrored to a column so publish-state checks don't need to parse JSON).
     source_slug = db.Column(db.String(255), nullable=True)
+    # How the recipe entered the system: 'manual' | 'generated' | 'saved'
+    # (NULL = legacy/unknown). Manually entered recipes cannot be published
+    # (KAN-140) — free-text content with no AI mediation must not reach the
+    # public /r/<slug> surface. Settable while NULL, immutable once set.
+    origin = db.Column(db.String(20), nullable=True)
     # MutableDict ensures in-place JSON updates are tracked (important for SQLite dev).
     data = db.Column(MutableDict.as_mutable(GenericJSON), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
@@ -42,6 +47,7 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
             "is_public": self.is_public,
             "is_canonical": self.is_canonical,
             "source_slug": self.source_slug,
+            "origin": self.origin,
             "data": self.data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -15,6 +15,13 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     worker_claim_token = db.Column(db.String(36), nullable=True)
     slug = db.Column(db.String(255), unique=True, index=True, nullable=True)
     is_public = db.Column(db.Boolean, default=False, nullable=False, server_default="0")
+    # Canonical recipes (curated in the cookbook repo's specs/canonical-recipes.json)
+    # are locked: publish state, slug, and the row itself cannot be changed via the
+    # API — only content edits. Never writable through the API; seeded by migration.
+    is_canonical = db.Column(db.Boolean, default=False, nullable=False, server_default="0")
+    # Slug of the public recipe this row was saved from (the blob's sourceSlug,
+    # mirrored to a column so publish-state checks don't need to parse JSON).
+    source_slug = db.Column(db.String(255), nullable=True)
     # MutableDict ensures in-place JSON updates are tracked (important for SQLite dev).
     data = db.Column(MutableDict.as_mutable(GenericJSON), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
@@ -33,6 +40,8 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
             "status": self.status,
             "slug": self.slug,
             "is_public": self.is_public,
+            "is_canonical": self.is_canonical,
+            "source_slug": self.source_slug,
             "data": self.data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ dependencies = [
     "flask-caching==2.4.1",
     "sqlalchemy>=2.0.51", # Use stable 2.0.x with Python 3.13 support
     # Google AI & Authentication
-    "google-genai==2.11.0",
+    "google-genai==2.14.0",
     "google-generativeai==0.8.6",
     "google-ai-generativelanguage==0.6.15",
-    "google-auth==2.56.0",
+    "google-auth==2.56.2",
     "google-auth-oauthlib==1.4.0",
     "google-api-python-client==2.198.0",
     "googleapis-common-protos==1.75.0",
@@ -58,7 +58,7 @@ dependencies = [
     "requests==2.34.2",
     "requests-oauthlib==2.0.0",
     "urllib3==2.7.0",
-    "certifi==2026.6.17",
+    "certifi==2026.7.22",
     "charset-normalizer==3.4.9",
     "idna==3.18",
     # Utilities
@@ -70,13 +70,13 @@ dependencies = [
     "typing-extensions==4.16.0",
     "tenacity==9.1.4",
     "websockets==16.1.1",
-    "cachetools==7.1.4",
+    "cachetools==7.1.6",
     # Cryptography & Security
     "pyasn1==0.6.4",
     "pyasn1-modules==0.4.2",
     "rsa==4.9.1",
     "flask-cors==6.0.5",
-    "pandas>=3.0.3",
+    "pandas>=3.0.5",
     "ddtrace>=4.11.1",
     "gunicorn>=26.0.0",
 ]

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -42,6 +42,34 @@ class RecipeSlugError(ValueError):
     """A recipe cannot be published without a usable /r/<slug> address."""
 
 
+# Also returned verbatim by the API routes (fixed string, same rationale as
+# PUBLIC_SLUG_REQUIRED_ERROR above).
+CANONICAL_RECIPE_LOCKED_ERROR = (
+    "This is a canonical public recipe: its publish state, slug, and row are "
+    "locked. Content edits are still allowed."
+)
+
+
+class CanonicalRecipeError(ValueError):
+    """Publish-state, slug, or delete changes to a canonical recipe are locked."""
+
+
+def _guard_canonical(recipe: Recipe, recipe_data: Dict[str, Any]) -> None:
+    """Reject payloads that would unpublish or re-slug a canonical recipe.
+
+    Canonical recipes (seeded from specs/canonical-recipes.json in the
+    cookbook repo) keep their /r/<slug> URL stable forever; content edits
+    pass through untouched. Checked against the caller's raw payload, not
+    the merged blob, so only explicit intent trips the guard.
+    """
+    if not recipe.is_canonical:
+        return
+    if recipe_data.get("is_public") is False or (
+        "slug" in recipe_data and recipe_data["slug"] != recipe.slug
+    ):
+        raise CanonicalRecipeError(CANONICAL_RECIPE_LOCKED_ERROR)
+
+
 @dataclass(frozen=True)
 class WorkerRecipeUpdate:
     user_id: Optional[int]
@@ -515,8 +543,13 @@ def create_recipe(
                 )
                 return None
 
+            _guard_canonical(existing, recipe_data)
+
             merged = {**(existing.data or {}), **recipe_data, "id": recipe_id}
             _preserve_worker_metadata(existing.data or {}, merged)
+            # The is_canonical column is never writable through the API; pin
+            # the blob to the column so a payload echo can't fake a lock.
+            merged["is_canonical"] = existing.is_canonical
             if "is_public" not in recipe_data:
                 merged["is_public"] = existing.is_public
             if "slug" not in recipe_data:
@@ -532,6 +565,7 @@ def create_recipe(
                 existing.name = recipe_name
                 existing.slug = data.get("slug")
                 existing.is_public = data.get("is_public", False)
+                existing.source_slug = data.get("sourceSlug")
                 existing.data = data
                 existing.status = next_status
                 existing.updated_at = datetime.utcnow()
@@ -543,6 +577,8 @@ def create_recipe(
 
         recipe_name = recipe_data.get("name", "Unnamed Recipe")
         recipe_data_with_id = _gate_is_public({**recipe_data, "id": recipe_id}, user_id)
+        # A client cannot mint its own canonical lock.
+        recipe_data_with_id.pop("is_canonical", None)
 
         def stage_new(data: Dict[str, Any]) -> Recipe:
             recipe = Recipe(
@@ -552,6 +588,7 @@ def create_recipe(
                 name=recipe_name,
                 slug=data.get("slug"),
                 is_public=data.get("is_public", False),
+                source_slug=data.get("sourceSlug"),
                 data=data,
                 status=status,
             )
@@ -567,7 +604,7 @@ def create_recipe(
         )
         return recipe
 
-    except RecipeSlugError:
+    except (RecipeSlugError, CanonicalRecipeError):
         raise
     except Exception as e:
         logger.error("Error creating recipe: %s", sanitize_log_value(e))
@@ -613,12 +650,16 @@ def update_recipe(
             )
             return None
 
+        _guard_canonical(recipe, recipe_data)
+
         # Merge the payload into the persisted blob (and pin the id): PUT
         # accepts partial payloads such as {"is_public": true}, and replacing
         # the blob wholesale would delete ingredients/instructions at the
         # moment of publishing. Keys the payload does supply always win.
         merged = {**(recipe.data or {}), **recipe_data, "id": recipe_id}
         _preserve_worker_metadata(recipe.data or {}, merged)
+        # Never writable through the API — pin the blob to the column.
+        merged["is_canonical"] = recipe.is_canonical
 
         if "is_public" not in recipe_data:
             # The is_public column is authoritative, like slug below: a
@@ -651,6 +692,7 @@ def update_recipe(
             recipe.name = recipe_data.get("name", recipe.name)
             recipe.slug = data.get("slug")
             recipe.is_public = data["is_public"]
+            recipe.source_slug = data.get("sourceSlug")
             recipe.data = data
             if status is not None:
                 recipe.status = status
@@ -664,7 +706,7 @@ def update_recipe(
         logger.info("Updated recipe %s", sanitize_log_value(recipe_id))
         return updated
 
-    except RecipeSlugError:
+    except (RecipeSlugError, CanonicalRecipeError):
         raise
     except Exception as e:
         logger.error(
@@ -895,12 +937,22 @@ def delete_recipe(
             )
             return False
 
+        if recipe.is_canonical:
+            logger.warning(
+                "Refusing to delete canonical recipe %s (slug=%s)",
+                sanitize_log_value(recipe_id),
+                sanitize_log_value(recipe.slug),
+            )
+            raise CanonicalRecipeError(CANONICAL_RECIPE_LOCKED_ERROR)
+
         db.session.delete(recipe)
         db.session.commit()
 
         logger.info("Deleted recipe %s", sanitize_log_value(recipe_id))
         return True
 
+    except CanonicalRecipeError:
+        raise
     except Exception as e:
         logger.error(
             "Error deleting recipe %s: %s",

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -54,6 +54,48 @@ class CanonicalRecipeError(ValueError):
     """Publish-state, slug, or delete changes to a canonical recipe are locked."""
 
 
+# Also returned verbatim by the API routes (fixed string, same rationale as
+# PUBLIC_SLUG_REQUIRED_ERROR above).
+MANUAL_RECIPE_UNPUBLISHABLE_ERROR = (
+    "Manually entered recipes cannot be published. Only generated recipes "
+    "can have a public page."
+)
+
+# 'manual' gates publishing; the others exist so curation can query by
+# provenance. NULL = legacy/unknown, treated as publishable.
+_ALLOWED_ORIGINS = frozenset({"manual", "generated", "saved"})
+
+
+class ManualRecipeError(ValueError):
+    """Manually entered recipes cannot be published (KAN-140)."""
+
+
+def _resolve_origin(current_origin: Optional[str], recipe_data: Dict[str, Any]) -> Optional[str]:
+    """Column value for origin: settable while NULL, immutable once set.
+
+    Once a recipe is labeled, a later payload cannot relabel it — otherwise
+    a 'manual' recipe could launder itself into 'generated' and slip past
+    the publish gate. Unknown labels are dropped rather than stored.
+    """
+    if current_origin:
+        return current_origin
+    candidate = recipe_data.get("origin")
+    return candidate if candidate in _ALLOWED_ORIGINS else None
+
+
+def _gate_manual_publish(origin: Optional[str], recipe_data: Dict[str, Any]) -> None:
+    """Reject publication of manually entered recipes (KAN-140).
+
+    The manual-entry form is free-text content with no AI mediation; the
+    public /r/<slug> surface must not become an open publishing endpoint.
+    Raises (a 400 at the API) instead of silently forcing the flag off, so
+    the SPA's revert-and-toast path fires rather than diverging from the
+    server state.
+    """
+    if origin == "manual" and recipe_data.get("is_public") is True:
+        raise ManualRecipeError(MANUAL_RECIPE_UNPUBLISHABLE_ERROR)
+
+
 def _guard_canonical(recipe: Recipe, recipe_data: Dict[str, Any]) -> None:
     """Reject payloads that would unpublish or re-slug a canonical recipe.
 
@@ -558,6 +600,12 @@ def create_recipe(
                 else:
                     merged.pop("slug", None)
             recipe_data_with_id = _gate_is_public(merged, user_id)
+            next_origin = _resolve_origin(existing.origin, recipe_data)
+            _gate_manual_publish(next_origin, recipe_data_with_id)
+            if next_origin is not None:
+                recipe_data_with_id["origin"] = next_origin
+            else:
+                recipe_data_with_id.pop("origin", None)
             recipe_name = recipe_data.get("name", existing.name)
             next_status = existing.status if existing.status in _ACTIVE_RECIPE_STATUSES else status
 
@@ -566,6 +614,7 @@ def create_recipe(
                 existing.slug = data.get("slug")
                 existing.is_public = data.get("is_public", False)
                 existing.source_slug = data.get("sourceSlug")
+                existing.origin = next_origin
                 existing.data = data
                 existing.status = next_status
                 existing.updated_at = datetime.utcnow()
@@ -579,6 +628,12 @@ def create_recipe(
         recipe_data_with_id = _gate_is_public({**recipe_data, "id": recipe_id}, user_id)
         # A client cannot mint its own canonical lock.
         recipe_data_with_id.pop("is_canonical", None)
+        origin_value = _resolve_origin(None, recipe_data)
+        _gate_manual_publish(origin_value, recipe_data_with_id)
+        if origin_value is not None:
+            recipe_data_with_id["origin"] = origin_value
+        else:
+            recipe_data_with_id.pop("origin", None)
 
         def stage_new(data: Dict[str, Any]) -> Recipe:
             recipe = Recipe(
@@ -589,6 +644,7 @@ def create_recipe(
                 slug=data.get("slug"),
                 is_public=data.get("is_public", False),
                 source_slug=data.get("sourceSlug"),
+                origin=origin_value,
                 data=data,
                 status=status,
             )
@@ -604,7 +660,7 @@ def create_recipe(
         )
         return recipe
 
-    except (RecipeSlugError, CanonicalRecipeError):
+    except (RecipeSlugError, CanonicalRecipeError, ManualRecipeError):
         raise
     except Exception as e:
         logger.error("Error creating recipe: %s", sanitize_log_value(e))
@@ -688,11 +744,19 @@ def update_recipe(
             else:
                 recipe_data_with_id.pop("slug", None)
 
+        next_origin = _resolve_origin(recipe.origin, recipe_data)
+        _gate_manual_publish(next_origin, recipe_data_with_id)
+        if next_origin is not None:
+            recipe_data_with_id["origin"] = next_origin
+        else:
+            recipe_data_with_id.pop("origin", None)
+
         def stage_update(data: Dict[str, Any]) -> Recipe:
             recipe.name = recipe_data.get("name", recipe.name)
             recipe.slug = data.get("slug")
             recipe.is_public = data["is_public"]
             recipe.source_slug = data.get("sourceSlug")
+            recipe.origin = next_origin
             recipe.data = data
             if status is not None:
                 recipe.status = status
@@ -706,7 +770,7 @@ def update_recipe(
         logger.info("Updated recipe %s", sanitize_log_value(recipe_id))
         return updated
 
-    except (RecipeSlugError, CanonicalRecipeError):
+    except (RecipeSlugError, CanonicalRecipeError, ManualRecipeError):
         raise
     except Exception as e:
         logger.error(

--- a/scripts/repair_missing_images.py
+++ b/scripts/repair_missing_images.py
@@ -45,19 +45,30 @@ def _is_imageless(data: dict) -> bool:
 
 
 def select_candidates(limit: int):
-    """Imageless, generation-idle recipes, most publicly visible first."""
+    """Imageless, generation-idle recipes, most publicly visible first.
+
+    Streams rows in priority order and stops as soon as ``limit`` imageless
+    candidates are collected — a ``.all()`` load would pull the whole
+    ready-recipe table into memory just to keep the first few.
+    """
     from models import Recipe
 
-    rows = (
+    stream = (
         Recipe.query.filter(Recipe.status == "ready")
         .order_by(
             Recipe.is_canonical.desc(),
             Recipe.is_public.desc(),
             Recipe.created_at.asc(),
         )
-        .all()
+        .yield_per(200)
     )
-    return [r for r in rows if _is_imageless(r.data or {})][:limit]
+    picked = []
+    for recipe in stream:
+        if _is_imageless(recipe.data or {}):
+            picked.append(recipe)
+            if len(picked) >= limit:
+                break
+    return picked
 
 
 def enqueue(recipe) -> bool:

--- a/scripts/repair_missing_images.py
+++ b/scripts/repair_missing_images.py
@@ -1,0 +1,141 @@
+"""Detect recipes with no image bytes and enqueue regeneration (KAN-141).
+
+Runs as the scheduled Cloud Run Job ``flask-backend-image-repair``: scans for
+recipes whose data blob has neither ``ai_image_data`` (base64) nor
+``ai_image_gcs`` (bucket URI) — the same "imageless" semantics as the
+/api/admin/image-audit endpoint — and enqueues each through the exact
+Pub/Sub path the SPA's regenerate button uses. The flask-backend worker does
+the actual Imagen generation; this script only detects and enqueues.
+
+Priority order (most-visible pages repaired first): canonical recipes, then
+published recipes, then everything else oldest-first. Each run enqueues at
+most ``IMAGE_REPAIR_LIMIT`` recipes (default 10) so a large backlog drains
+over successive runs instead of burning Imagen quota in one burst.
+
+Usage:
+    python scripts/repair_missing_images.py [--dry-run]
+
+Exit codes: 0 = success (including "nothing to repair"), 1 = fatal error.
+Skipped rows (queue contention, publish failure) are logged and do not fail
+the run — the next scheduled run retries them.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("image-repair")
+
+DEFAULT_LIMIT = 10
+
+
+def _is_imageless(data: dict) -> bool:
+    """True when the blob holds no actual image bytes/URI.
+
+    ``ai_image_url`` alone does not count: rows exist whose URL points at an
+    object that was never written (blank hero/OG images on the public page).
+    """
+    return not data.get("ai_image_data") and not data.get("ai_image_gcs")
+
+
+def select_candidates(limit: int):
+    """Imageless, generation-idle recipes, most publicly visible first."""
+    from models import Recipe
+
+    rows = (
+        Recipe.query.filter(Recipe.status == "ready")
+        .order_by(
+            Recipe.is_canonical.desc(),
+            Recipe.is_public.desc(),
+            Recipe.created_at.asc(),
+        )
+        .all()
+    )
+    return [r for r in rows if _is_imageless(r.data or {})][:limit]
+
+
+def enqueue(recipe) -> bool:
+    """Queue one recipe through the same path as POST /api/generate_image."""
+    from repositories import db_recipe_repository
+    from services.pubsub_service import publish_message
+
+    queued = db_recipe_repository.queue_image_generation(
+        recipe.id,
+        str(uuid.uuid4()),
+        False,
+        recipe.user_id,
+        recipe.guest_session_id,
+    )
+    if queued is None:
+        logger.warning("skip %s: not queueable (state changed under us)", recipe.id)
+        return False
+    if not queued.should_publish:
+        logger.info("skip %s: request already pending", recipe.id)
+        return False
+
+    try:
+        publish_message(
+            "image-generation",
+            {
+                "recipe_id": recipe.id,
+                "user_id": recipe.user_id,
+                "guest_session_id": recipe.guest_session_id,
+                "force_regenerate": queued.force_regenerate,
+                "image_request_id": queued.request_id,
+            },
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 - one bad publish must not kill the run
+        logger.error("publish failed for %s: %s", recipe.id, exc)
+        db_recipe_repository.release_image_generation_queue(
+            recipe.id, queued.request_id, recipe.user_id, recipe.guest_session_id
+        )
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="report candidates without enqueueing"
+    )
+    args = parser.parse_args()
+
+    limit = int(os.environ.get("IMAGE_REPAIR_LIMIT", DEFAULT_LIMIT))
+
+    from app import create_app
+
+    app = create_app()
+    with app.app_context():
+        candidates = select_candidates(limit)
+        if not candidates:
+            logger.info("No imageless recipes found — nothing to repair.")
+            return 0
+
+        logger.info("%d imageless recipe(s), limit %d this run:", len(candidates), limit)
+        for r in candidates:
+            logger.info(
+                "  %s %r (canonical=%s public=%s slug=%s)",
+                r.id,
+                r.name,
+                r.is_canonical,
+                r.is_public,
+                r.slug,
+            )
+
+        if args.dry_run:
+            logger.info("Dry run — nothing enqueued.")
+            return 0
+
+        enqueued = sum(1 for r in candidates if enqueue(r))
+        logger.info("Enqueued %d/%d image regeneration(s).", enqueued, len(candidates))
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_canonical_lock.py
+++ b/tests/test_canonical_lock.py
@@ -1,0 +1,202 @@
+"""Tests for the is_canonical lock and source_slug column (KAN-139 / cookbook #3217).
+
+Covers:
+- Canonical recipes reject unpublish, slug change, and delete with 400
+- Canonical recipes still accept content edits
+- is_canonical is never writable through the API
+- source_slug is persisted from the payload's sourceSlug on create/update,
+  retained across partial updates, and exposed in API responses
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def user(app):
+    u = User(email="owner@example.com", name="Owner")
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+@pytest.fixture
+def logged_in(client, user):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+    return user
+
+
+def _make_canonical(owner, slug="vegan-cornbread"):
+    recipe = Recipe(
+        id=str(uuid.uuid4()),
+        user_id=owner.id,
+        name="Vegan Cornbread",
+        slug=slug,
+        is_public=True,
+        is_canonical=True,
+        data={"name": "Vegan Cornbread", "slug": slug, "is_public": True},
+    )
+    db.session.add(recipe)
+    db.session.commit()
+    return recipe
+
+
+class TestCanonicalLock:
+    def test_unpublish_canonical_returns_400_and_row_stays_public(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(f"/api/recipes/{recipe.id}", json={"is_public": False})
+
+        assert resp.status_code == 400
+        assert "canonical" in resp.get_json()["error"]
+        row = db.session.get(Recipe, recipe.id)
+        assert row.is_public is True
+        assert row.slug == "vegan-cornbread"
+
+    def test_slug_change_on_canonical_returns_400(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(f"/api/recipes/{recipe.id}", json={"slug": "vegan-cornbread-new"})
+
+        assert resp.status_code == 400
+        assert db.session.get(Recipe, recipe.id).slug == "vegan-cornbread"
+
+    def test_delete_canonical_returns_400_and_row_survives(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.delete(f"/api/recipes/{recipe.id}")
+
+        assert resp.status_code == 400
+        assert db.session.get(Recipe, recipe.id) is not None
+
+    def test_content_edit_on_canonical_is_allowed(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(
+            f"/api/recipes/{recipe.id}",
+            json={"description": "Now with maple butter.", "is_public": True},
+        )
+
+        assert resp.status_code == 200
+        row = db.session.get(Recipe, recipe.id)
+        assert row.data["description"] == "Now with maple butter."
+        assert row.is_public is True
+        assert row.slug == "vegan-cornbread"
+        assert row.is_canonical is True
+
+    def test_echoed_matching_slug_does_not_trip_the_guard(self, client, logged_in):
+        # The SPA PUTs its full blob back, including the slug it loaded.
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(
+            f"/api/recipes/{recipe.id}",
+            json={"name": "Vegan Cornbread", "slug": "vegan-cornbread", "is_public": True},
+        )
+
+        assert resp.status_code == 200
+
+    def test_delete_non_canonical_still_works(self, client, logged_in):
+        recipe = Recipe(
+            id=str(uuid.uuid4()),
+            user_id=logged_in.id,
+            name="Scratch Pad",
+            data={"name": "Scratch Pad"},
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+        resp = client.delete(f"/api/recipes/{recipe.id}")
+
+        assert resp.status_code == 200
+        assert db.session.get(Recipe, recipe.id) is None
+
+    def test_api_cannot_set_is_canonical_on_create(self, client, logged_in):
+        resp = client.post(
+            "/api/recipes",
+            json={"name": "Impostor", "is_canonical": True},
+        )
+
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["is_canonical"] is False
+        assert db.session.get(Recipe, body["id"]).is_canonical is False
+
+    def test_api_cannot_clear_is_canonical_on_update(self, client, logged_in):
+        recipe = _make_canonical(logged_in)
+
+        resp = client.put(
+            f"/api/recipes/{recipe.id}",
+            json={"is_canonical": False, "description": "sneaky"},
+        )
+
+        assert resp.status_code == 200
+        row = db.session.get(Recipe, recipe.id)
+        assert row.is_canonical is True
+        assert row.data["is_canonical"] is True
+
+
+class TestSourceSlug:
+    def test_source_slug_persisted_on_create(self, client, logged_in):
+        resp = client.post(
+            "/api/recipes",
+            json={"name": "Saved Copy", "sourceSlug": "vegan-cornbread"},
+        )
+
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["source_slug"] == "vegan-cornbread"
+        assert db.session.get(Recipe, body["id"]).source_slug == "vegan-cornbread"
+
+    def test_partial_update_without_source_slug_keeps_column(self, client, logged_in):
+        created = client.post(
+            "/api/recipes",
+            json={"name": "Saved Copy", "sourceSlug": "vegan-cornbread"},
+        ).get_json()
+
+        resp = client.put(
+            f"/api/recipes/{created['id']}",
+            json={"description": "tweaked"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.get_json()["source_slug"] == "vegan-cornbread"
+
+    def test_list_endpoint_exposes_canonical_and_source_slug(self, client, logged_in):
+        client.post("/api/recipes", json={"name": "Saved Copy", "sourceSlug": "vegan-cornbread"})
+
+        resp = client.get("/api/recipes")
+
+        assert resp.status_code == 200
+        (entry,) = resp.get_json()["recipes"]
+        assert entry["source_slug"] == "vegan-cornbread"
+        assert entry["is_canonical"] is False

--- a/tests/test_manual_origin_gate.py
+++ b/tests/test_manual_origin_gate.py
@@ -1,0 +1,144 @@
+"""Tests for the origin column and manual-entry publish gate (KAN-140).
+
+Covers:
+- Manually entered recipes cannot be published (400 on create and update)
+- origin is settable while NULL, immutable once set (no relabel laundering)
+- Unknown origin labels are dropped, not stored
+- origin is exposed in to_dict and the list endpoint
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def logged_in(client, app):
+    user = User(email="owner@example.com", name="Owner")
+    db.session.add(user)
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+    return user
+
+
+class TestManualPublishGate:
+    def test_create_manual_and_public_returns_400(self, client, logged_in):
+        resp = client.post(
+            "/api/recipes",
+            json={"name": "Handwritten", "origin": "manual", "is_public": True},
+        )
+
+        assert resp.status_code == 400
+        assert "Manually entered" in resp.get_json()["error"]
+        assert Recipe.query.count() == 0
+
+    def test_create_manual_private_persists_origin(self, client, logged_in):
+        resp = client.post("/api/recipes", json={"name": "Handwritten", "origin": "manual"})
+
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["origin"] == "manual"
+        assert db.session.get(Recipe, body["id"]).origin == "manual"
+
+    def test_publishing_a_manual_recipe_later_returns_400(self, client, logged_in):
+        created = client.post(
+            "/api/recipes", json={"name": "Handwritten", "origin": "manual"}
+        ).get_json()
+
+        resp = client.put(f"/api/recipes/{created['id']}", json={"is_public": True})
+
+        assert resp.status_code == 400
+        assert "Manually entered" in resp.get_json()["error"]
+        row = db.session.get(Recipe, created["id"])
+        assert row.is_public is False
+
+    def test_manual_origin_cannot_be_laundered_to_generated(self, client, logged_in):
+        created = client.post(
+            "/api/recipes", json={"name": "Handwritten", "origin": "manual"}
+        ).get_json()
+
+        relabel = client.put(
+            f"/api/recipes/{created['id']}", json={"origin": "generated", "notes": "tweak"}
+        )
+        assert relabel.status_code == 200
+        assert relabel.get_json()["origin"] == "manual"
+
+        publish = client.put(f"/api/recipes/{created['id']}", json={"is_public": True})
+        assert publish.status_code == 400
+
+    def test_generated_recipe_still_publishes(self, client, logged_in):
+        resp = client.post(
+            "/api/recipes",
+            json={"name": "AI Chili", "origin": "generated", "is_public": True},
+        )
+
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["is_public"] is True
+        assert body["origin"] == "generated"
+
+    def test_legacy_null_origin_still_publishes(self, client, logged_in):
+        resp = client.post("/api/recipes", json={"name": "Old Row", "is_public": True})
+
+        assert resp.status_code == 201
+        assert resp.get_json()["is_public"] is True
+        assert resp.get_json()["origin"] is None
+
+    def test_unknown_origin_label_is_dropped(self, client, logged_in):
+        resp = client.post("/api/recipes", json={"name": "Weird", "origin": "admin"})
+
+        assert resp.status_code == 201
+        assert resp.get_json()["origin"] is None
+
+    def test_null_origin_can_adopt_manual_label(self, client, logged_in):
+        recipe = Recipe(
+            id=str(uuid.uuid4()),
+            user_id=logged_in.id,
+            name="Legacy Manual",
+            data={"name": "Legacy Manual"},
+        )
+        db.session.add(recipe)
+        db.session.commit()
+
+        resp = client.put(f"/api/recipes/{recipe.id}", json={"origin": "manual"})
+
+        assert resp.status_code == 200
+        assert resp.get_json()["origin"] == "manual"
+
+    def test_list_endpoint_exposes_origin(self, client, logged_in):
+        client.post("/api/recipes", json={"name": "Handwritten", "origin": "manual"})
+
+        resp = client.get("/api/recipes")
+
+        assert resp.status_code == 200
+        (entry,) = resp.get_json()["recipes"]
+        assert entry["origin"] == "manual"

--- a/tests/test_repair_missing_images.py
+++ b/tests/test_repair_missing_images.py
@@ -1,0 +1,105 @@
+"""Tests for scripts/repair_missing_images.py (KAN-141)."""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from scripts.repair_missing_images import _is_imageless, enqueue, select_candidates  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _recipe(name, *, data=None, status="ready", public=False, canonical=False, slug=None):
+    recipe = Recipe(
+        id=str(uuid.uuid4()),
+        name=name,
+        status=status,
+        slug=slug,
+        is_public=public,
+        is_canonical=canonical,
+        data=data if data is not None else {"name": name},
+    )
+    db.session.add(recipe)
+    return recipe
+
+
+class TestIsImageless:
+    def test_no_image_fields_is_imageless(self):
+        assert _is_imageless({}) is True
+
+    def test_url_without_bytes_is_still_imageless(self):
+        # The blank-hero case: ai_image_url points at an object never written.
+        assert _is_imageless({"ai_image_url": "/api/recipes/x/image"}) is True
+
+    def test_gcs_or_base64_counts_as_imaged(self):
+        assert _is_imageless({"ai_image_gcs": "gs://bucket/x.png"}) is False
+        assert _is_imageless({"ai_image_data": "base64..."}) is False
+
+
+class TestSelectCandidates:
+    def test_orders_canonical_then_public_then_oldest(self, app):
+        plain = _recipe("plain")
+        public = _recipe("public", public=True, slug="public-r")
+        canonical = _recipe("canonical", public=True, canonical=True, slug="canon-r")
+        _recipe("imaged", data={"name": "imaged", "ai_image_gcs": "gs://b/i.png"})
+        _recipe("busy", status="generating_image")
+        db.session.commit()
+
+        picked = select_candidates(10)
+
+        assert [r.id for r in picked] == [canonical.id, public.id, plain.id]
+
+    def test_respects_limit(self, app):
+        for i in range(5):
+            _recipe(f"r{i}")
+        db.session.commit()
+
+        assert len(select_candidates(2)) == 2
+
+
+class TestEnqueue:
+    def test_enqueues_via_pubsub_and_marks_generating(self, app, monkeypatch):
+        published = []
+        monkeypatch.setattr(
+            "services.pubsub_service.publish_message",
+            lambda topic, data: published.append((topic, data)) or "msg-1",
+        )
+        recipe = _recipe("needs image")
+        db.session.commit()
+
+        assert enqueue(recipe) is True
+
+        topic, message = published[0]
+        assert topic == "image-generation"
+        assert message["recipe_id"] == recipe.id
+        assert db.session.get(Recipe, recipe.id).status == "generating_image"
+
+    def test_publish_failure_releases_queue_and_reports_false(self, app, monkeypatch):
+        def boom(topic, data):
+            raise RuntimeError("pubsub down")
+
+        monkeypatch.setattr("services.pubsub_service.publish_message", boom)
+        recipe = _recipe("needs image")
+        db.session.commit()
+
+        assert enqueue(recipe) is False
+        assert db.session.get(Recipe, recipe.id).status == "ready"

--- a/uv.lock
+++ b/uv.lock
@@ -136,20 +136,20 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.1.4"
+version = "7.1.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/af/861ebc2e318a5c3300e3eb63bc4d30f3d70a46d13b360093728ac0705eed/cachetools-7.1.6.tar.gz", hash = "sha256:c7a79e7f30ba9943c1cefd08cc36f006aaae086e017af9166f1d59d6170c47e1", size = 40572, upload-time = "2026-07-23T22:47:53.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f2/2086ba18a925a73586c4d4e61d25f4a6058e56fd00d77ce8f1d361ab4c9b/cachetools-7.1.6-py3-none-any.whl", hash = "sha256:2c12e255780330af28b91bb7fb96cce4c766f04e38396b9a24510190a5827096", size = 16954, upload-time = "2026-07-23T22:47:52.397Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -474,15 +474,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.56.0"
+version = "2.56.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/66/b4ba60005743e01933e22b4f62313e063f7460458b7d8a358427b4930013/google_auth-2.56.0.tar.gz", hash = "sha256:f90fa030b569a92654b9d690665a073841df33d57487be53db583a9a0867a553", size = 364629, upload-time = "2026-07-13T19:09:57.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/33/dbc946a407401b975f0719658f18e664ece2109f79ffd1ff3bf226c205f4/google_auth-2.56.2.tar.gz", hash = "sha256:e28f103ca8091fb7012b99c44243d7366c29863713b8e34a220c3322b7a07051", size = 365820, upload-time = "2026-07-21T21:53:28.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/7d/cd3e187f14ce832e419e70709bfcc40cb0dc11517d5d03c9d3919bcc3101/google_auth-2.56.0-py3-none-any.whl", hash = "sha256:6e88c10217e07a92bfd01cac8ee99e32ccfb08414c3102e6c5b8d58f37a0d1e0", size = 257976, upload-time = "2026-07-13T19:09:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/88/63/50636aae68c9bf17c891c7eb18b49baa9bd6b31d2a97b8de4813a9fc8d1c/google_auth-2.56.2-py3-none-any.whl", hash = "sha256:c8270ea95b2697b74e3d8438ae9c5b898e38b623b915c7b5c5635921e7de68a6", size = 258588, upload-time = "2026-07-21T21:53:26.399Z" },
 ]
 
 [package.optional-dependencies]
@@ -581,7 +581,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "2.11.0"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -595,9 +595,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/01/e7b5f3aac89200c78318ed7643401e7f5ed3131b0cd353c07483606b1e61/google_genai-2.11.0.tar.gz", hash = "sha256:4c5e524d24b145c96be327f9a7f8f04b0fe4efee0533877795e9848afed01749", size = 622366, upload-time = "2026-07-09T17:49:43.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/df/4f820054c99f29f2fe3de4a8a7c9534dd795302e4a07483a0cb07c3a29b6/google_genai-2.14.0.tar.gz", hash = "sha256:a9d1f4f362d76280f1be1340fcb3c86e63dbca128f6a4ae09d86ab47ff7148e8", size = 641055, upload-time = "2026-07-22T21:35:44.717Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/ef/d296c23390160a8b0b1dafb36dd3cb36a39ed40c81cd27e04e6233334186/google_genai-2.11.0-py3-none-any.whl", hash = "sha256:5bc8186100e1d34d691fbe0cba392b7e04e98d286ca952323a6672d054accf95", size = 984162, upload-time = "2026-07-09T17:49:42.15Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/86/5ac5fb53e44cca4a6607fb917eb331fa237c65a103b9ec2e8e8acc8a42db/google_genai-2.14.0-py3-none-any.whl", hash = "sha256:ae7172cdd35695189b516b33a878e4132e5daa2dbc03a5b44cddfa8a82fad664", size = 1030738, upload-time = "2026-07-22T21:35:42.785Z" },
 ]
 
 [[package]]
@@ -1032,30 +1032,23 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "3.0.3"
+version = "3.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
     { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
-    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
-    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
-    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
-    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/7b95c4a0025227d6f118c4039b423412ac6a982db02864166185d812fbc7/pandas-3.0.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c1c05a767fe8e5b4fe9e1c29806829c582052eaedb9120a3da83ba3f69e24a5b", size = 10385742, upload-time = "2026-07-22T22:18:29.346Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0c/dc78fd8c4da477b4b5e8ad37295af352190d21ef63a9ee1bc071753074cc/pandas-3.0.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b86765f268b56f7e665b93bce9d5df69dee7f99e595cf8fb839483ab315942a3", size = 9932067, upload-time = "2026-07-22T22:18:31.833Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/71/3592c055cf44df9808550f9368ceda80ff2b224d355ef73fe251dcda1802/pandas-3.0.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c597ecf5616b5c420372c1d4d4c00dbbfba7398bea857dcc984347e1ea48417b", size = 10466756, upload-time = "2026-07-22T22:18:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/70/4363150359f95b4cb4bcbb34ca23572bb5495749a621a8f3d5a1ddfd293c/pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b11c36e218331d0387cbe3a0a5f75162357a1d92d57b2b08a336ff94b19b2be", size = 10938525, upload-time = "2026-07-22T22:18:36.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d0/317e7a0c67c0e69fa905a0161409397a7dc2d46ff611f6ca4803352c042b/pandas-3.0.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cf52e1f61d229496da17dc7ab54acdee627357e7008fd4fecba3d0ba2937fa58", size = 11489303, upload-time = "2026-07-22T22:18:39.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/36dade89b49e4f9d5cbdbe863772581f98c0c6d78fc39ad4c557f6f2e17e/pandas-3.0.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db172144bb56422bd157812f3b021eacc255451470b31e2c633c349490a1cfee", size = 11989004, upload-time = "2026-07-22T22:18:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ba/18c4ec8a746e177da05a9e7a7963781d8ea195780724f854601b6ebd6b78/pandas-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:0d298e951f23016ce4699951d044ae6418dbc91bf68cefca0f77666fcbb4e5c6", size = 9826896, upload-time = "2026-07-22T22:18:44.539Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ec/28a57266b753799a87b8bc79e7887ac6fd981b8c6d2978a0b7e7b6bd708c/pandas-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:66266d3442a5e8b3c90274c2b8b230bee42dd1c286bc822cc2f9f2c7e12b883e", size = 9094790, upload-time = "2026-07-22T22:18:47.468Z" },
 ]
 
 [[package]]
@@ -1530,8 +1523,8 @@ requires-dist = [
     { name = "anyio", specifier = "==4.14.2" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.5.1" },
     { name = "blinker", specifier = "==1.9.0" },
-    { name = "cachetools", specifier = "==7.1.4" },
-    { name = "certifi", specifier = "==2026.6.17" },
+    { name = "cachetools", specifier = "==7.1.6" },
+    { name = "certifi", specifier = "==2026.7.22" },
     { name = "charset-normalizer", specifier = "==3.4.9" },
     { name = "ddtrace", specifier = ">=4.11.1" },
     { name = "distro", specifier = "==1.9.0" },
@@ -1543,11 +1536,11 @@ requires-dist = [
     { name = "flask-sqlalchemy", specifier = "==3.1.1" },
     { name = "google-ai-generativelanguage", specifier = "==0.6.15" },
     { name = "google-api-python-client", specifier = "==2.198.0" },
-    { name = "google-auth", specifier = "==2.56.0" },
+    { name = "google-auth", specifier = "==2.56.2" },
     { name = "google-auth-oauthlib", specifier = "==1.4.0" },
     { name = "google-cloud-pubsub", specifier = ">=2.19.0" },
     { name = "google-cloud-storage", specifier = "==3.13.0" },
-    { name = "google-genai", specifier = "==2.11.0" },
+    { name = "google-genai", specifier = "==2.14.0" },
     { name = "google-generativeai", specifier = "==0.8.6" },
     { name = "googleapis-common-protos", specifier = "==1.75.0" },
     { name = "gunicorn", specifier = ">=26.0.0" },
@@ -1558,7 +1551,7 @@ requires-dist = [
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0" },
-    { name = "pandas", specifier = ">=3.0.3" },
+    { name = "pandas", specifier = ">=3.0.5" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9.12" },
     { name = "pyasn1", specifier = "==0.6.4" },
     { name = "pyasn1-modules", specifier = "==0.4.2" },


### PR DESCRIPTION
Backend promotion for the cookbook v0.4.4 release train (KAN-138 flow).

Carries since last promotion:
- #239 — is_canonical lock + source_slug column [KAN-139] (migration `c8d2f6a1e9b3`: seeds the 7 canonical slugs, backfills source_slug from the blob)
- #240 — origin column + manual-entry publish gate [KAN-140] (migration `d1e5a9c3f7b2`: manual backfill via image_keywords signature)
- #241 — scheduled imageless-recipe repair enqueuer [KAN-141]
- #242 / #244 — Dependabot: uv image bump + python-production group (5 updates)

Alembic single head verified: `d1e5a9c3f7b2`. Cookbook dev pins `50cdbbb` (this dev tip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bbWZQcxjKcTvetjQphtkA

[KAN-139]: https://tasteslikegood.atlassian.net/browse/KAN-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-140]: https://tasteslikegood.atlassian.net/browse/KAN-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-141]: https://tasteslikegood.atlassian.net/browse/KAN-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

