### PR TITLE
fix(valkey): force RESP2 + retry on token refresh failure [KAN-16]

### DIFF
--- a/tests/test_valkey_auth.py
+++ b/tests/test_valkey_auth.py
@@ -1,19 +1,16 @@
-"""Regression tests for Valkey IAM client TLS trust (Memorystore CA).
+"""Regression tests for Valkey IAM authentication (Memorystore).
 
-flask-backend silently fell back to in-process SimpleCache on every boot since
-v0.3.5: _build_client() opened the TLS connection with ssl=True but never
-trusted Memorystore's Google-managed private CA, so the handshake failed with
-CERTIFICATE_VERIFY_FAILED, create_iam_redis_client() returned None, and the
-Flask-Caching response cache degraded to a per-worker in-process SimpleCache.
-
-The fix mirrors the working Express reference (server/valkey.ts): read the CA
-PEM from VALKEY_CA_CERT and hand it to redis-py as ssl_ca_data, without ever
-disabling certificate verification.
+Covers:
+- TLS CA trust (VALKEY_CA_CERT → ssl_ca_data)
+- RESP2 protocol enforcement (avoids redis-py 8.x RESP3 "default" username injection)
+- Token refresh retry with exponential backoff on failure
 """
 
 import ssl as ssl_mod
 import sys
+import time
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
@@ -75,3 +72,50 @@ def test_build_client_without_ca_cert_keeps_tls_on_system_trust(monkeypatch):
     # No CA override -> None (or absent) -> redis-py uses the system trust store.
     assert not captured.get("ssl_ca_data")
     assert captured.get("ssl_cert_reqs", "required") not in _INSECURE_CERT_REQS
+
+
+def test_build_client_forces_resp2_protocol(monkeypatch):
+    """redis-py 8.x defaults to RESP3 which injects 'default' as username.
+    Memorystore IAM auth rejects the 'default' username, causing AuthenticationError.
+    """
+    captured = _capture_strictredis(monkeypatch)
+    monkeypatch.setenv("VALKEY_CA_CERT", _FAKE_PEM)
+
+    valkey_auth._build_client("10.128.0.11", 6379)
+
+    assert captured.get("protocol") == 2, "Must force RESP2 to avoid 'default' username injection"
+
+
+def test_refresh_loop_retries_on_failure(monkeypatch):
+    """On token refresh failure, the loop should retry with backoff, not sleep 45 min."""
+    call_count = 0
+    sleeps = []
+
+    def fake_refresh():
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise ConnectionError("token refresh failed")
+        return True
+
+    monkeypatch.setattr(valkey_auth, "_refresh_token_in_place", fake_refresh)
+
+    original_sleep = time.sleep
+
+    def fake_sleep(seconds):
+        sleeps.append(seconds)
+        if len(sleeps) >= 3:
+            raise StopIteration("stop the loop")
+
+    monkeypatch.setattr(time, "sleep", fake_sleep)
+
+    try:
+        valkey_auth._refresh_loop()
+    except StopIteration:
+        pass
+
+    # First sleep is the normal 45-min interval
+    assert sleeps[0] == valkey_auth._TOKEN_REFRESH_INTERVAL
+    # After failure, retry backoff should be much shorter than 45 min
+    assert sleeps[1] == valkey_auth._RETRY_BASE  # 30s first retry
+    assert sleeps[2] == valkey_auth._RETRY_BASE * 2  # 60s second retry

--- a/tests/test_valkey_auth.py
+++ b/tests/test_valkey_auth.py
@@ -10,7 +10,6 @@ import ssl as ssl_mod
 import sys
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
@@ -99,8 +98,6 @@ def test_refresh_loop_retries_on_failure(monkeypatch):
         return True
 
     monkeypatch.setattr(valkey_auth, "_refresh_token_in_place", fake_refresh)
-
-    original_sleep = time.sleep
 
     def fake_sleep(seconds):
         sleeps.append(seconds)

--- a/utils/valkey_auth.py
+++ b/utils/valkey_auth.py
@@ -128,7 +128,11 @@ def _refresh_loop():
             time.sleep(_TOKEN_REFRESH_INTERVAL)
         else:
             backoff = min(_RETRY_BASE * (2 ** (consecutive_failures - 1)), _RETRY_MAX)
-            logger.info("Valkey token refresh retry in %ds (attempt %d)", backoff, consecutive_failures + 1)
+            logger.info(
+                "Valkey token refresh retry in %ds (attempt %d)",
+                backoff,
+                consecutive_failures + 1,
+            )
             time.sleep(backoff)
 
         try:
@@ -139,7 +143,11 @@ def _refresh_loop():
             consecutive_failures = 0
         except Exception as e:
             consecutive_failures += 1
-            logger.warning("Valkey token refresh failed (attempt %d, will retry): %s", consecutive_failures, e)
+            logger.warning(
+                "Valkey token refresh failed (attempt %d, will retry): %s",
+                consecutive_failures,
+                e,
+            )
 
 
 def get_valkey_client() -> redis.StrictRedis | None:

--- a/utils/valkey_auth.py
+++ b/utils/valkey_auth.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 # Token refresh interval (45 minutes — tokens last 60 min, refresh early)
 _TOKEN_REFRESH_INTERVAL = 45 * 60
 
+# Retry backoff after a failed token refresh (seconds). Starts at 30s,
+# doubles on each consecutive failure, capped at the normal interval.
+_RETRY_BASE = 30
+_RETRY_MAX = _TOKEN_REFRESH_INTERVAL
+
 
 def _get_iam_token():
     """Obtain a fresh IAM access token from the default service account."""
@@ -54,6 +59,10 @@ def _build_client(host: str, port: int) -> redis.StrictRedis:
     # (local/dev), so keep TLS verification on either way. Mirrors
     # server/valkey.ts (the Express side already does this correctly).
     ca_cert = os.environ.get("VALKEY_CA_CERT")
+
+    # Force RESP2 protocol: redis-py 8.x defaults to RESP3 which sends
+    # HELLO 3 AUTH default <token> — the injected "default" username is
+    # rejected by Memorystore IAM auth which expects password-only AUTH.
     return redis.StrictRedis(
         host=host,
         port=port,
@@ -61,6 +70,7 @@ def _build_client(host: str, port: int) -> redis.StrictRedis:
         ssl=True,
         ssl_ca_data=ca_cert,
         decode_responses=False,
+        protocol=2,
     )
 
 
@@ -106,16 +116,30 @@ def _refresh_token_in_place() -> bool:
 
 
 def _refresh_loop():
-    """Background thread that refreshes the Valkey token before it expires."""
+    """Background thread that refreshes the Valkey token before it expires.
+
+    On failure, retries with exponential backoff (30s, 60s, 120s, ...)
+    instead of waiting the full 45-minute interval, so the stale-token
+    window stays as short as possible.
+    """
+    consecutive_failures = 0
     while True:
-        time.sleep(_TOKEN_REFRESH_INTERVAL)
+        if consecutive_failures == 0:
+            time.sleep(_TOKEN_REFRESH_INTERVAL)
+        else:
+            backoff = min(_RETRY_BASE * (2 ** (consecutive_failures - 1)), _RETRY_MAX)
+            logger.info("Valkey token refresh retry in %ds (attempt %d)", backoff, consecutive_failures + 1)
+            time.sleep(backoff)
+
         try:
             refreshed = _refresh_token_in_place()
             if not refreshed:
                 return  # no client to manage; stop the thread
             logger.info("Valkey token refreshed in-place successfully")
+            consecutive_failures = 0
         except Exception as e:
-            logger.warning("Valkey token refresh failed (will retry next cycle): %s", e)
+            consecutive_failures += 1
+            logger.warning("Valkey token refresh failed (attempt %d, will retry): %s", consecutive_failures, e)
 
 
 def get_valkey_client() -> redis.StrictRedis | None:


### PR DESCRIPTION
## Summary

Two changes to the Valkey IAM auth path, addressing recurring
`redis.exceptions.AuthenticationError` on the image cache write path
(`SETEX vgc:img:*`) — 258 occurrences over 5 days (2026-07-20 → 2026-07-25),
clustered in bursts.

**The fix: retry on token-refresh failure.** `_refresh_loop()` caught exceptions
and then slept the full 45-minute interval. If the token was already 45+ minutes
old when a refresh failed, it expired at 60 minutes and every cache write failed
until the next cycle at t=90 — a **30-minute dead window**. Now retries with
exponential backoff (30s → 60s → 120s …), capped at the normal interval and
reset on success.

**Hardening: force RESP2.** redis-py 8.x defaults to RESP3, which sends
`HELLO 3 AUTH default <token>` on connect (`connection.py:1116` rewrites a
password-only credential to `["default", <token>]`). `protocol=2` yields a plain
`AUTH <token>`, matching what Memorystore IAM documents and what the Express
side does.

> **Corrected from the original description of this PR**, which called the RESP3
> username injection the root cause. It is not — see below. The change is kept
> because it is free and removes a latent trap, but it should not be expected to
> resolve these errors on its own.

## Why RESP3 is not the root cause

`create_iam_redis_client()` pings immediately after building the client and
returns `None` on failure:

```python
client = _build_client(host, port)
client.ping()                      # first command → on_connect_check_health → HELLO 3 AUTH default
...
except Exception as e:
    logger.error("Valkey IAM auth failed: %s — caller will fall back")
    return None
```

If Memorystore rejected the injected `default` username, that ping would fail on
**every boot**, `create_iam_redis_client()` would return `None`, there would be
no client to issue `SETEX vgc:img:*`, and these errors could not exist.
`_refresh_token_in_place()` ends with the same `client.ping()` through the same
handshake.

The errors' existence is therefore evidence the RESP3 handshake **succeeds**.
The observed shape agrees: a rejected username fails totally and constantly, not
in bursts hours apart against an otherwise-working cache.

Timing is still consistent with the redis-py 8 upgrade — `redis 7.4.0 → 8.0.1`
landed in `b83345a` (2026-07-14) and first reached production via cookbook
v0.3.9 on 2026-07-19, one day before the first burst — but the mechanism is not
the one originally claimed.

## What is still unexplained

Why `_refresh_token_in_place()` throws at all. This PR shortens the damage
window from ~30 minutes to under two; it does not identify the underlying
refresh failure. Next thread to pull is `_get_iam_token()` →
`creds.refresh(Request())`: whether the failures are transient metadata-server
timeouts, and whether the returned token's real TTL is ever shorter than the
60 minutes the 45-minute interval assumes.

**Do not close the Datadog issue on merge.** The unchecked verification box
below is what settles this.

## Changes

- `utils/valkey_auth.py`: `protocol=2` in `_build_client()`; exponential backoff
  retry in `_refresh_loop()`
- `tests/test_valkey_auth.py`: 2 regression tests (RESP2 kwarg, retry backoff)

## Test plan

- [x] `uv run pytest tests/test_valkey_auth.py` — 4/4 pass
- [x] `uv run pytest` — 309/309 pass
- [x] `protocol` verified a real kwarg, not swallowed by `**kwargs` —
      `redis/client.py:293`, reaching the pool at `:396`
- [ ] Deploy and verify Datadog error tracking shows no new AuthenticationError bursts

## Datadog evidence

Error tracking issue: `c2bdbcb8-8447-11f1-8447-da7ad0900000`
- Bursts at: Jul 20 14:31 (111), Jul 23 05:00 (35), Jul 24 23:01 (64), Jul 25 02:01 (34)
- Stack trace: `on_connect_check_health` → `read_response` → `AuthenticationError` during pool reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->


