### PR TITLE
release: promote dev → main for cookbook v0.4.6 [KAN-138]

### DIFF
--- a/migrations/versions/e4a7b2d9c5f1_promote_orange_chicken_to_canonical.py
+++ b/migrations/versions/e4a7b2d9c5f1_promote_orange_chicken_to_canonical.py
@@ -1,0 +1,56 @@
+"""Promote the orange-chicken seitan recipe to canonical
+
+Adds ``vegan-orange-chicken-style-seitan-with-white-rice`` to the canonical
+set curated in the cookbook repo's specs/canonical-recipes.json (KAN-158).
+
+Two reasons, both Adam's call:
+
+- It is the set's first Asian/takeout-style entry, and it already earns its
+  keep — a partial-slug Google query returns it as the top result with its
+  hero image intact, so the public page is both indexed and rendering.
+- ``is_canonical`` is the durability guarantee the promotion is really for.
+  The repository guards (``_guard_canonical``) reject unpublish, re-slug, and
+  delete for canonical rows, so the public /r/<slug> page survives the SPA
+  copy being deleted later — which is exactly how a linked, indexed page
+  would otherwise go 404 after inbound links exist.
+
+Content edits still pass the guard; only publish state, slug, and row
+deletion are locked.
+
+Follows the same pattern as c8d2f6a1e9b3: curation happens by migration, and
+the column is never writable through the API.
+
+Revision ID: e4a7b2d9c5f1
+Revises: d1e5a9c3f7b2
+Create Date: 2026-07-25 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e4a7b2d9c5f1"
+down_revision = "d1e5a9c3f7b2"
+branch_labels = None
+depends_on = None
+
+# specs/canonical-recipes.json v1 (cookbook repo, updated 2026-07-25) — the
+# single slug this revision adds on top of the seven seeded by c8d2f6a1e9b3.
+PROMOTED_SLUG = "vegan-orange-chicken-style-seitan-with-white-rice"
+
+
+def upgrade():
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("UPDATE recipe SET is_canonical = :flag WHERE slug = :slug"),
+        {"flag": True, "slug": PROMOTED_SLUG},
+    )
+
+
+def downgrade():
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("UPDATE recipe SET is_canonical = :flag WHERE slug = :slug"),
+        {"flag": False, "slug": PROMOTED_SLUG},
+    )


### PR DESCRIPTION
## What

Promotes Backend `dev` → `main` so the cookbook v0.4.6 release can pin `main`'s own SHA.

Two commits:

| commit | PR | what |
|---|---|---|
| `8306b13` | [#251](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/251) | `chore(db)`: promote orange-chicken seitan recipe to canonical [KAN-158] |
| `ff8fc6a` | [#250](https://github.com/adamtasteslikegood/tasteslikegood.com/pull/250) | `chore(sync)`: back-sync `main` → `dev` after the v0.4.5 promotion (no product change) |

## Migration

`8306b13` adds `e4a7b2d9c5f1_promote_orange_chicken_to_canonical.py`, chaining onto the prior sole head `d1e5a9c3f7b2`.

**Alembic head count after this promotion: exactly 1** (`e4a7b2d9c5f1`), so `flask db upgrade` in the `flask-backend-migrate` Cloud Run Job applies it and exits clean rather than refusing on branched heads.

That claim is now machine-checked rather than asserted: the cookbook side gained a required `Backend — single Alembic head` gate in [#3285](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/pull/3285) (KAN-138), which runs on every PR instead of only on the release-train cron.

## Why this goes first

The cookbook release pins whatever SHA the submodule points at when the tag fires. Promoting here first means the cookbook can pin `main`'s own SHA rather than a dev-side commit that merely has the same tree — which is what v0.3.9 shipped and what leaves "which Backend commit is in production?" unanswerable from a single ref.

## Sequencing

1. **This PR** → Backend `main`
2. Cookbook: re-pin submodule to Backend `main`'s new SHA, bump to v0.4.6, CHANGELOG names that SHA → cookbook `dev`
3. Cookbook `dev` → `main` — merging that fires `release.yml`, which tags `v0.4.6` and triggers Cloud Build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqwHC5WeVAtgosDb469Foy

[KAN-158]: https://tasteslikegood.atlassian.net/browse/KAN-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

