### PR TITLE
release: promote Backend dev → main for KAN-155 ownership refusal [KAN-155]

### DIFF
--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -132,6 +132,11 @@ def create_recipe(user_id, guest_session_id):
 
         return jsonify(recipe.to_dict()), 201
 
+    except db_recipe_repository.RecipeOwnershipError:
+        # KAN-155: 409, not 500. The row exists and is owned by someone else —
+        # a deliberate refusal, not an internal failure. Answering 500 here is
+        # what made the UI tell the user to check their connection.
+        return jsonify({"error": db_recipe_repository.RECIPE_OWNERSHIP_ERROR}), 409
     except db_recipe_repository.RecipeSlugError:
         # Fixed message, not str(e): exception text must never reach clients.
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -70,6 +70,25 @@ class ManualRecipeError(ValueError):
     """Manually entered recipes cannot be published (KAN-140)."""
 
 
+# Also returned verbatim by the API routes (fixed string, same rationale as
+# PUBLIC_SLUG_REQUIRED_ERROR above).
+RECIPE_OWNERSHIP_ERROR = (
+    "This recipe belongs to a different account or guest session, so it "
+    "cannot be saved or published from here."
+)
+
+
+class RecipeOwnershipError(ValueError):
+    """The row exists but is owned by someone else — refuse the write (KAN-155).
+
+    This refusal is deliberate and load-bearing: it is what stops one account's
+    write from landing on another account's row. See KAN-181 INV-4, verified in
+    production 2026-07-29. Do not relax the ownership test to make this stop
+    firing — the defect this exception fixes is that the refusal was
+    indistinguishable from a server error, not that the refusal happened.
+    """
+
+
 def _resolve_origin(current_origin: Optional[str], recipe_data: Dict[str, Any]) -> Optional[str]:
     """Column value for origin: settable while NULL, immutable once set.
 
@@ -583,7 +602,11 @@ def create_recipe(
                     sanitize_log_value(user_id),
                     sanitize_log_value(guest_session_id),
                 )
-                return None
+                # KAN-155: the refusal itself is correct and unchanged. What was
+                # wrong is that returning bare None made it indistinguishable
+                # from an internal failure, so the route answered 500 and the UI
+                # blamed the user's connection for a deliberate refusal.
+                raise RecipeOwnershipError(RECIPE_OWNERSHIP_ERROR)
 
             _guard_canonical(existing, recipe_data)
 
@@ -660,7 +683,7 @@ def create_recipe(
         )
         return recipe
 
-    except (RecipeSlugError, CanonicalRecipeError, ManualRecipeError):
+    except (RecipeSlugError, CanonicalRecipeError, ManualRecipeError, RecipeOwnershipError):
         raise
     except Exception as e:
         logger.error("Error creating recipe: %s", sanitize_log_value(e))

--- a/scripts/whois_recipe_row.py
+++ b/scripts/whois_recipe_row.py
@@ -7,9 +7,11 @@ supply to an agent: who actually owns the row in production.
 
 There are exactly two dispositions, and they are opposite:
 
-* ``user`` — the row belongs to a real, separately-registered account. Distinct
-  Google emails are distinct users even when the display names match; that is
-  intentional and is **not** a duplicate-account defect. The refusal is
+* ``user`` — the row belongs to a real, separately-registered account. **The
+  Google email is the identity. ``User.name`` is a display convenience and
+  carries no identity meaning for any user.** Two accounts sharing a name are
+  two different people as far as this system is concerned, and one person may
+  hold several accounts; neither is a duplicate-account defect. The refusal is
   correct, there is nothing to repair, and reassigning the row would be the
   cross-account write KAN-155's own risk register exists to prevent.
 * ``orphaned guest`` — ``user_id IS NULL``. This is the only repairable case:
@@ -72,8 +74,8 @@ def describe(recipe_id):
             lines.append(
                 "DISPOSITION       : owned by a registered account. If this email differs "
                 "from the acting user's, the refusal is CORRECT and there is nothing to "
-                "repair — separate emails are separate users by policy, matching display "
-                "names notwithstanding."
+                "repair. Identity is the Google email; the name above is display-only and "
+                "means nothing for ownership — never compare names to decide this."
             )
     else:
         lines.append(

--- a/scripts/whois_recipe_row.py
+++ b/scripts/whois_recipe_row.py
@@ -1,0 +1,114 @@
+"""Report who owns a recipe row. READ-ONLY — this script never writes (KAN-155).
+
+KAN-155 refuses a write when the target row is owned by another account or
+guest session. That refusal is correct (KAN-181 INV-4). Deciding whether a
+*specific* refusal is also *repairable* needs one fact the application cannot
+supply to an agent: who actually owns the row in production.
+
+There are exactly two dispositions, and they are opposite:
+
+* ``user`` — the row belongs to a real, separately-registered account. Distinct
+  Google emails are distinct users even when the display names match; that is
+  intentional and is **not** a duplicate-account defect. The refusal is
+  correct, there is nothing to repair, and reassigning the row would be the
+  cross-account write KAN-155's own risk register exists to prevent.
+* ``orphaned guest`` — ``user_id IS NULL``. This is the only repairable case:
+  the guest→user merge at OAuth login never claimed the row server-side.
+
+Usage (local, against the DATABASE_URL in .env):
+
+    uv run python scripts/whois_recipe_row.py <recipe-id> [<recipe-id> ...]
+
+In production, run inside a one-off Cloud Run job or a ``flask shell``
+environment carrying the production ``DATABASE_URL``:
+
+    python scripts/whois_recipe_row.py 62ccf6fc-d097-4a1c-8412-afa53c16faeb
+
+Exit codes: 0 when every requested id was found, 1 when any was missing (so a
+typo is loud rather than silently reported as "no owner").
+
+Safety: the only database verbs used are SELECT, via read-only ORM queries.
+There is no commit, no flush, no attribute assignment on any loaded row.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+
+def describe(recipe_id):
+    """Return a human-readable ownership report for one recipe id, or None."""
+    recipe = Recipe.query.filter(Recipe.id == recipe_id).first()
+    if recipe is None:
+        return None
+
+    lines = [
+        f"id                : {recipe.id}",
+        f"name              : {recipe.name!r}",
+        f"slug              : {recipe.slug!r}",
+        f"is_public         : {recipe.is_public}",
+        f"is_canonical      : {getattr(recipe, 'is_canonical', None)}",
+        f"origin            : {getattr(recipe, 'origin', None)}",
+        f"source_slug       : {getattr(recipe, 'source_slug', None)}",
+        f"created_at        : {recipe.created_at}",
+        f"updated_at        : {recipe.updated_at}",
+        f"user_id           : {recipe.user_id}",
+        f"guest_session_id  : {recipe.guest_session_id}",
+    ]
+
+    if recipe.user_id is not None:
+        owner = User.query.filter(User.id == recipe.user_id).first()
+        if owner is None:
+            lines.append("owner             : user_id set but no matching user row (dangling)")
+            lines.append("DISPOSITION       : dangling owner — needs a decision, not a reassign")
+        else:
+            lines.append(f"owner email       : {owner.email}")
+            lines.append(f"owner name        : {owner.name!r}")
+            lines.append(
+                "DISPOSITION       : owned by a registered account. If this email differs "
+                "from the acting user's, the refusal is CORRECT and there is nothing to "
+                "repair — separate emails are separate users by policy, matching display "
+                "names notwithstanding."
+            )
+    else:
+        lines.append(
+            "DISPOSITION       : orphaned guest row. This is the repairable case — the "
+            "guest→user merge at OAuth login never claimed it server-side."
+        )
+
+    return "\n".join(lines)
+
+
+def main(argv):
+    recipe_ids = argv[1:]
+    if not recipe_ids:
+        print(__doc__)
+        return 1
+
+    app = create_app()
+    missing = []
+
+    with app.app_context():
+        for recipe_id in recipe_ids:
+            print("=" * 72)
+            report = describe(recipe_id)
+            if report is None:
+                missing.append(recipe_id)
+                print(f"id                : {recipe_id}\nNOT FOUND")
+            else:
+                print(report)
+        print("=" * 72)
+
+    if missing:
+        print(f"\n{len(missing)} id(s) not found: {', '.join(missing)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_recipe_ownership_publish.py
+++ b/tests/test_recipe_ownership_publish.py
@@ -1,0 +1,167 @@
+"""KAN-155 — the ownership refusal must be legible, and must stay a refusal.
+
+Two tests, and the second is the load-bearing one.
+
+``create_recipe()`` refuses to write when the target row is owned by another
+account or guest session. That refusal is **correct** — Adam walked the full
+save → publish → unpublish → republish cycle in production on 2026-07-29 and
+confirmed it (KAN-181, INV-4: "the refusal is correct, do not loosen it"). What
+was broken is that the refusal returned a bare ``None``, which the route turned
+into ``500 {"error": "Failed to create recipe"}``, which the SPA turned into
+"Publishing failed to sync to the server. Check your connection and try again."
+The user was told their network was at fault for a deliberate permission
+decision.
+
+So the fix changes the **signal**, not the **decision**:
+
+* ``test_foreign_account_row_is_still_refused`` pins the decision. It passes
+  before and after the fix and **fails if ``same_owner`` is ever loosened**.
+  Without this test, "publish now succeeds" and "publish is now correct" are
+  indistinguishable, and the obvious way to make KAN-155's symptom disappear is
+  to ship a privilege escalation on recipe rows.
+* ``test_ownership_refusal_is_distinguishable_from_server_error`` pins the
+  signal — a distinct exception and a 409, never a 500.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app
+from extensions import db
+from models.recipe import Recipe
+from models.user import User
+from repositories import db_recipe_repository
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def owner(app):
+    u = User(email="owner@example.com", name="Owner")
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+@pytest.fixture
+def intruder(app):
+    u = User(email="someone-else@example.com", name="Someone Else")
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _recipe_data(recipe_id="r-owned", **overrides):
+    data = {"id": recipe_id, "name": "English Breakfast", "slug": "english-breakfast"}
+    data.update(overrides)
+    return data
+
+
+# ─── The decision: must not change ───────────────────────────────────────
+
+
+def test_foreign_account_row_is_still_refused(app, owner, intruder):
+    """KAN-181 INV-4. A different authenticated account cannot write the row.
+
+    This is the test that must keep passing. If a future change relaxes
+    ``same_owner`` so that KAN-155's toast goes away, this fails — which is the
+    entire point. A green suite without this assertion cannot tell "publish
+    works" apart from "publish works on other people's recipes".
+    """
+    created = db_recipe_repository.create_recipe(_recipe_data(), user_id=owner.id)
+    assert created is not None
+    assert created.user_id == owner.id
+
+    with pytest.raises(db_recipe_repository.RecipeOwnershipError):
+        db_recipe_repository.create_recipe(
+            _recipe_data(name="Hijacked", is_public=True), user_id=intruder.id
+        )
+
+    # The refusal is not cosmetic: nothing was written. Read the row straight
+    # off the model rather than through get_recipe_by_id(), which scopes by
+    # owner and would mask a write by returning None for the wrong reason.
+    db.session.expire_all()
+    row = Recipe.query.filter_by(id="r-owned").first()
+    assert row is not None
+    assert row.user_id == owner.id
+    assert row.name == "English Breakfast"
+    assert row.is_public is False
+
+
+def test_guest_session_row_is_refused_for_a_different_guest(app):
+    """Same decision on the guest path — a guest cannot write another guest's row."""
+    created = db_recipe_repository.create_recipe(
+        _recipe_data(recipe_id="r-guest"), user_id=None, guest_session_id="session-a"
+    )
+    assert created is not None
+
+    with pytest.raises(db_recipe_repository.RecipeOwnershipError):
+        db_recipe_repository.create_recipe(
+            _recipe_data(recipe_id="r-guest", name="Hijacked"),
+            user_id=None,
+            guest_session_id="session-b",
+        )
+
+
+def test_owner_can_still_write_their_own_row(app, owner):
+    """The refusal must not have become indiscriminate."""
+    db_recipe_repository.create_recipe(_recipe_data(), user_id=owner.id)
+    updated = db_recipe_repository.create_recipe(
+        _recipe_data(name="English Breakfast, revised"), user_id=owner.id
+    )
+    assert updated is not None
+    assert updated.name == "English Breakfast, revised"
+
+
+# ─── The signal: this is what KAN-155 changes ────────────────────────────
+
+
+def test_ownership_refusal_is_distinguishable_from_server_error(app, owner, intruder):
+    """Fails on pre-KAN-155 code, where the refusal was a bare ``None``.
+
+    ``RecipeOwnershipError`` must also survive ``create_recipe``'s own
+    ``except Exception`` handler — that handler swallows into ``return None``,
+    and a new exception type that is not on the re-raise allowlist would be
+    silently converted back into the very failure mode this fixes.
+    """
+    db_recipe_repository.create_recipe(_recipe_data(), user_id=owner.id)
+
+    with pytest.raises(db_recipe_repository.RecipeOwnershipError) as excinfo:
+        db_recipe_repository.create_recipe(_recipe_data(), user_id=intruder.id)
+
+    # Fixed string — no exception internals may reach a client
+    # (CodeQL py/stack-trace-exposure), same rule as the sibling errors.
+    assert str(excinfo.value) == db_recipe_repository.RECIPE_OWNERSHIP_ERROR
+
+
+def test_route_answers_409_not_500(app, owner, intruder):
+    """The route must not report a deliberate refusal as an internal failure."""
+    db_recipe_repository.create_recipe(_recipe_data(), user_id=owner.id)
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user_id"] = intruder.id
+
+    resp = client.post("/api/recipes", json=_recipe_data(name="Hijacked"))
+
+    assert resp.status_code == 409, (
+        "A row owned by another account is a conflict, not a server error. "
+        "500 here is what made the SPA blame the user's connection."
+    )
+    assert resp.get_json()["error"] == db_recipe_repository.RECIPE_OWNERSHIP_ERROR


### PR DESCRIPTION
Train step 3 of 5. **No build fires from this merge** — Backend has no trigger on `main`. This is a lane move so that the cookbook pointer bump (step 4) can pin a SHA that is actually on Backend `main`; the deploy happens at the cookbook tag in step 5.

## Payload — 5 commits, all KAN-155

```
8f90115  fix(recipes): make the ownership refusal legible, not a 500 [KAN-155] (#256)
9f0ee0b  chore(sync): back-sync main → dev, clear the lane before KAN-155 [KAN-155] (#255)
21556da  chore(scripts): identity is the Google email, for every user [KAN-155]
839f5d1  chore(scripts): read-only ownership report for a recipe row [KAN-155]
18f1b4a  fix(recipes): make the ownership refusal legible, not a 500 [KAN-155]
```

Net change: `RecipeOwnershipError` + a fixed public message, `create_recipe()` raising instead of returning bare `None` (and added to its own re-raise allowlist, without which the broad `except Exception` swallows it straight back), `POST /api/recipes` answering **409** instead of 500, five tests, and one read-only diagnostic script.

**The ownership decision is unchanged.** KAN-181 INV-4 holds exactly: a row owned by another account or guest session is still refused, and still writes nothing. What changed is that the refusal stopped masquerading as a server error — the SPA was telling users to check their connection over a deliberate permission decision.

## Pre-promotion checks

| Check | Result |
|---|---|
| `rev-list --count origin/dev..origin/main` | **0** — `main` is not ahead; the #255 back-sync cleared it |
| `uv run flask db heads` | **single head `e4a7b2d9c5f1`** — no migration in this payload, no branched-head risk |
| Open Backend PRs | none |
| Unmerged branch refs (`chore/remove-legacy-agents-md-KAN-153`, `feat/image-repair-job-KAN-141`, `chore/enhance-claude-md`) | all **0 commits / 0 content diff** vs `dev` — merged leftovers, nothing unshipped left behind |
| Local `dev` vs `origin/dev` | identical at `8f90115` |
| #256 review coverage | re-reviewed on its actual HEAD `21556da` after KAN-183 staleness was caught; "No changes needed", script independently confirmed read-only |

## Known-incomplete, stated deliberately

Publishing an **orphaned guest row** merged to the acting user at OAuth login still fails. Determining the true owner of the production row needs prod DB access (`scripts/whois_recipe_row.py`, read-only, ships here), and the repair policy depends on what that returns.

Per Adam's ruling 2026-07-30: **identity is the Google email, `User.name` is display-only for any user.** A row owned by another registered account is therefore a *correct* refusal with nothing to repair — reassigning would be a cross-account write. Only an orphaned guest row (`user_id IS NULL`) is repairable.

KAN-155 must not be closed as done on the strength of this promotion alone.

Refs KAN-181, KAN-183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJTYg2F4r5Bcy6aX6hW8Ga

[KAN-155]: https://tasteslikegood.atlassian.net/browse/KAN-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-155]: https://tasteslikegood.atlassian.net/browse/KAN-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-155]: https://tasteslikegood.atlassian.net/browse/KAN-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-155]: https://tasteslikegood.atlassian.net/browse/KAN-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-155]: https://tasteslikegood.atlassian.net/browse/KAN-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

