### PR TITLE
release: promote Backend dev → main for the KAN-155 ownership-code split [KAN-155]

### DIFF
--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -132,11 +132,20 @@ def create_recipe(user_id, guest_session_id):
 
         return jsonify(recipe.to_dict()), 201
 
-    except db_recipe_repository.RecipeOwnershipError:
+    except db_recipe_repository.RecipeOwnershipError as e:
         # KAN-155: 409, not 500. The row exists and is owned by someone else —
         # a deliberate refusal, not an internal failure. Answering 500 here is
         # what made the UI tell the user to check their connection.
-        return jsonify({"error": db_recipe_repository.RECIPE_OWNERSHIP_ERROR}), 409
+        #
+        # `code` rides alongside the fixed message so the SPA can give the right
+        # remedy: two of the three refusals are recoverable by the user (log in),
+        # and the single prose string cannot say that without being wrong for the
+        # third. e.code is a module constant, never user input or exception text
+        # — the fixed-string rule (py/stack-trace-exposure) still holds.
+        return (
+            jsonify({"error": db_recipe_repository.RECIPE_OWNERSHIP_ERROR, "code": e.code}),
+            409,
+        )
     except db_recipe_repository.RecipeSlugError:
         # Fixed message, not str(e): exception text must never reach clients.
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -77,6 +77,29 @@ RECIPE_OWNERSHIP_ERROR = (
     "cannot be saved or published from here."
 )
 
+# Machine-readable discriminators for the refusal, sent alongside the message as
+# `code` (KAN-155). One 409 was carrying three situations with opposite remedies,
+# and the client cannot tell them apart from the prose: "belongs to a different
+# account or guest session" reads as final, but two of the three are recoverable
+# by the user right now. Only the server knows which one fired — it is the only
+# party that has looked at the stored row.
+#
+#   OTHER_ACCOUNT       the row belongs to a real, different account. Final; the
+#                       acting user cannot resolve this. INV-4's core case.
+#   OTHER_GUEST_SESSION both sides are guests, different sessions. RCP-61's stale
+#                       tab: the user very likely owns this row under a session
+#                       the page no longer holds. Logging in resolves it.
+#   ORPHANED_GUEST_ROW  the row has no user_id and the caller IS authenticated —
+#                       a guest row that was never claimed at login-merge. This
+#                       is KAN-155's known-incomplete case, called out in #256 as
+#                       still failing; the repair policy is Adam's open call.
+#
+# These are a superset of the message, never a replacement: the prose stays the
+# fallback for any client that does not read `code`.
+OWNERSHIP_CODE_OTHER_ACCOUNT = "OWNERSHIP_OTHER_ACCOUNT"
+OWNERSHIP_CODE_OTHER_GUEST_SESSION = "OWNERSHIP_OTHER_GUEST_SESSION"
+OWNERSHIP_CODE_ORPHANED_GUEST_ROW = "OWNERSHIP_ORPHANED_GUEST_ROW"
+
 
 class RecipeOwnershipError(ValueError):
     """The row exists but is owned by someone else — refuse the write (KAN-155).
@@ -86,7 +109,15 @@ class RecipeOwnershipError(ValueError):
     production 2026-07-29. Do not relax the ownership test to make this stop
     firing — the defect this exception fixes is that the refusal was
     indistinguishable from a server error, not that the refusal happened.
+
+    `code` narrows WHICH refusal fired (see the OWNERSHIP_CODE_* constants). It
+    changes what the client can honestly tell the user; it does not change the
+    decision. Every code still refuses, and still writes nothing.
     """
+
+    def __init__(self, message: str, code: str) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 def _resolve_origin(current_origin: Optional[str], recipe_data: Dict[str, Any]) -> Optional[str]:
@@ -606,7 +637,19 @@ def create_recipe(
                 # wrong is that returning bare None made it indistinguishable
                 # from an internal failure, so the route answered 500 and the UI
                 # blamed the user's connection for a deliberate refusal.
-                raise RecipeOwnershipError(RECIPE_OWNERSHIP_ERROR)
+                #
+                # The code narrows which refusal this is. Order matters: check
+                # the row's user_id first, because "existing.user_id is None"
+                # means something different depending on whether the CALLER is
+                # authenticated (unclaimed guest row the caller may well own) or
+                # a guest (someone else's live guest session).
+                if existing.user_id is not None:
+                    code = OWNERSHIP_CODE_OTHER_ACCOUNT
+                elif user_id is not None:
+                    code = OWNERSHIP_CODE_ORPHANED_GUEST_ROW
+                else:
+                    code = OWNERSHIP_CODE_OTHER_GUEST_SESSION
+                raise RecipeOwnershipError(RECIPE_OWNERSHIP_ERROR, code)
 
             _guard_canonical(existing, recipe_data)
 

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -627,12 +627,6 @@ def create_recipe(
                 and existing.guest_session_id == guest_session_id
             )
             if not same_owner:
-                logger.warning(
-                    "Recipe ID collision for id=%s (user_id=%s, guest_session_id=%s)",
-                    sanitize_log_value(recipe_id),
-                    sanitize_log_value(user_id),
-                    sanitize_log_value(guest_session_id),
-                )
                 # KAN-155: the refusal itself is correct and unchanged. What was
                 # wrong is that returning bare None made it indistinguishable
                 # from an internal failure, so the route answered 500 and the UI
@@ -649,6 +643,23 @@ def create_recipe(
                     code = OWNERSHIP_CODE_ORPHANED_GUEST_ROW
                 else:
                     code = OWNERSHIP_CODE_OTHER_GUEST_SESSION
+                # Classify BEFORE logging, so the log carries the discriminator.
+                # This is not just ops garnish: KAN-155's remaining open item is
+                # the ownership-repair policy (reassign orphaned guest rows at
+                # login-merge vs a one-off backfill), and choosing between those
+                # depends on how often ORPHANED_GUEST_ROW actually fires against
+                # OTHER_ACCOUNT in production. There is no staging environment
+                # (KAN-182), so this log line is the only place that question can
+                # be answered. Without the code every refusal reads identically
+                # and the data does not exist. `code` is a module constant, so it
+                # needs no sanitizing — unlike the caller-supplied values below.
+                logger.warning(
+                    "Recipe ID collision (%s) for id=%s (user_id=%s, guest_session_id=%s)",
+                    code,
+                    sanitize_log_value(recipe_id),
+                    sanitize_log_value(user_id),
+                    sanitize_log_value(guest_session_id),
+                )
                 raise RecipeOwnershipError(RECIPE_OWNERSHIP_ERROR, code)
 
             _guard_canonical(existing, recipe_data)

--- a/tests/test_recipe_ownership_publish.py
+++ b/tests/test_recipe_ownership_publish.py
@@ -165,3 +165,99 @@ def test_route_answers_409_not_500(app, owner, intruder):
         "500 here is what made the SPA blame the user's connection."
     )
     assert resp.get_json()["error"] == db_recipe_repository.RECIPE_OWNERSHIP_ERROR
+
+
+# ─── Which refusal: one 409 was carrying three situations ────────────────
+#
+# The message says "a different account or guest session", which reads as final.
+# Two of the three are recoverable by the user right now, and only the server has
+# seen the stored row — so only the server can say which fired. These tests pin
+# the discrimination, not new behaviour: every case below still refuses.
+
+
+def test_foreign_account_row_reports_other_account(app, owner, intruder):
+    """A real, different account owns it. Final — the user cannot fix this."""
+    db_recipe_repository.create_recipe(_recipe_data(), user_id=owner.id)
+
+    with pytest.raises(db_recipe_repository.RecipeOwnershipError) as excinfo:
+        db_recipe_repository.create_recipe(_recipe_data(), user_id=intruder.id)
+
+    assert excinfo.value.code == db_recipe_repository.OWNERSHIP_CODE_OTHER_ACCOUNT
+
+
+def test_other_guest_session_reports_other_guest_session(app):
+    """RCP-61's stale tab: both guests, different sessions.
+
+    The user very likely owns this row under a session the page no longer holds,
+    so 'log in and try again' is the honest remedy. Reporting this as
+    OTHER_ACCOUNT would tell them to give up on their own recipe.
+    """
+    db_recipe_repository.create_recipe(_recipe_data(), guest_session_id="guest-a")
+
+    with pytest.raises(db_recipe_repository.RecipeOwnershipError) as excinfo:
+        db_recipe_repository.create_recipe(_recipe_data(), guest_session_id="guest-b")
+
+    assert excinfo.value.code == db_recipe_repository.OWNERSHIP_CODE_OTHER_GUEST_SESSION
+
+
+def test_orphaned_guest_row_reports_orphaned_guest_row(app, owner):
+    """KAN-155's known-incomplete case, called out in #256 as still failing.
+
+    An unclaimed guest row (user_id NULL) and an AUTHENTICATED caller. Distinct
+    from OTHER_GUEST_SESSION precisely because the caller is logged in: this is
+    the row the login-merge should have claimed, and it is the case the
+    ownership-repair policy will act on. It must not be indistinguishable from
+    someone else's live guest session.
+    """
+    db_recipe_repository.create_recipe(_recipe_data(), guest_session_id="orphan-session")
+
+    with pytest.raises(db_recipe_repository.RecipeOwnershipError) as excinfo:
+        db_recipe_repository.create_recipe(_recipe_data(), user_id=owner.id)
+
+    assert excinfo.value.code == db_recipe_repository.OWNERSHIP_CODE_ORPHANED_GUEST_ROW
+
+
+def test_the_three_codes_are_distinct(app):
+    """A discriminator that collapses to one value discriminates nothing."""
+    codes = {
+        db_recipe_repository.OWNERSHIP_CODE_OTHER_ACCOUNT,
+        db_recipe_repository.OWNERSHIP_CODE_OTHER_GUEST_SESSION,
+        db_recipe_repository.OWNERSHIP_CODE_ORPHANED_GUEST_ROW,
+    }
+    assert len(codes) == 3
+
+
+def test_route_sends_the_code_alongside_the_message(app, owner, intruder):
+    """The code must reach the client — the repository knowing it is not enough."""
+    db_recipe_repository.create_recipe(_recipe_data(), user_id=owner.id)
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user_id"] = intruder.id
+
+    resp = client.post("/api/recipes", json=_recipe_data(name="Hijacked"))
+    body = resp.get_json()
+
+    assert resp.status_code == 409
+    assert body["code"] == db_recipe_repository.OWNERSHIP_CODE_OTHER_ACCOUNT
+    # The prose stays the fallback for any client that does not read `code`.
+    assert body["error"] == db_recipe_repository.RECIPE_OWNERSHIP_ERROR
+
+
+def test_every_code_still_refuses_and_writes_nothing(app, owner):
+    """INV-4 is unchanged by the split. Narrowing the signal must not soften
+    the decision — the row is untouched in all three cases."""
+    db_recipe_repository.create_recipe(_recipe_data(), guest_session_id="orphan-session")
+
+    with pytest.raises(db_recipe_repository.RecipeOwnershipError):
+        db_recipe_repository.create_recipe(
+            _recipe_data(name="Hijacked", is_public=True), user_id=owner.id
+        )
+
+    db.session.expire_all()
+    row = Recipe.query.filter_by(id="r-owned").first()
+    assert row is not None
+    assert row.name == "English Breakfast"
+    assert row.is_public is False
+    assert row.user_id is None
+    assert row.guest_session_id == "orphan-session"

--- a/tests/test_recipe_ownership_publish.py
+++ b/tests/test_recipe_ownership_publish.py
@@ -23,6 +23,7 @@ So the fix changes the **signal**, not the **decision**:
   signal — a distinct exception and a 409, never a 500.
 """
 
+import logging
 import sys
 from pathlib import Path
 
@@ -242,6 +243,27 @@ def test_route_sends_the_code_alongside_the_message(app, owner, intruder):
     assert body["code"] == db_recipe_repository.OWNERSHIP_CODE_OTHER_ACCOUNT
     # The prose stays the fallback for any client that does not read `code`.
     assert body["error"] == db_recipe_repository.RECIPE_OWNERSHIP_ERROR
+
+
+def test_the_refusal_log_carries_the_discriminator(app, owner, caplog):
+    """The log is the ONLY place the repair-policy question can be answered.
+
+    KAN-155's open item is reassign-at-login-merge vs one-off backfill, and that
+    choice depends on how often ORPHANED_GUEST_ROW fires against OTHER_ACCOUNT in
+    production. There is no staging environment (KAN-182), so prod logs are the
+    only observation channel. Before this, all three refusals logged the same
+    "Recipe ID collision" string and the data simply did not exist.
+    """
+    db_recipe_repository.create_recipe(_recipe_data(), guest_session_id="orphan-session")
+
+    with caplog.at_level(logging.WARNING, logger=db_recipe_repository.__name__):
+        with pytest.raises(db_recipe_repository.RecipeOwnershipError):
+            db_recipe_repository.create_recipe(_recipe_data(), user_id=owner.id)
+
+    assert db_recipe_repository.OWNERSHIP_CODE_ORPHANED_GUEST_ROW in caplog.text
+    # Not merely "a code appeared" — the RIGHT one. A log that always says
+    # OTHER_ACCOUNT would pass a weaker assertion and answer nothing.
+    assert db_recipe_repository.OWNERSHIP_CODE_OTHER_ACCOUNT not in caplog.text
 
 
 def test_every_code_still_refuses_and_writes_nothing(app, owner):


### PR DESCRIPTION
Promotes Backend `dev` → `main` so the cookbook pointer bump for v0.4.8 pins a SHA that exists on `main`.

## Why this is a second promotion

#258 already promoted `dev` → `main` for KAN-155 — but it merged at **19:17 UTC on 07-30**, and #259 (the three-code split) only landed on `dev` at **03:43 the next morning**. So `main` carries #256's 409-instead-of-500 fix and **not** the three ownership codes. Confirmed rather than assumed:

```
$ git merge-base --is-ancestor 9ceb360 origin/main   # #259 merge commit
  -> false

$ git show origin/main:repositories/db_recipe_repository.py | grep -c OWNERSHIP_OTHER_ACCOUNT
  0
$ git show origin/dev:repositories/db_recipe_repository.py  | grep -c OWNERSHIP_OTHER_ACCOUNT
  1
```

## Why it blocks the release rather than merely being untidy

Cookbook #3316 is already on cookbook `dev` and reads the server's `code` off the 409 body, matching exactly `OWNERSHIP_OTHER_ACCOUNT`, `OWNERSHIP_OTHER_GUEST_SESSION`, `OWNERSHIP_ORPHANED_GUEST_ROW`. Against a Backend without #259 the client degrades to its generic `'ownership'` refusal — *not* a break (the degrade path is tested), but the three specific messages that are the point of KAN-155 stay dark, and a post-release walkthrough would read as a failed fix.

Adam's corrected release order (2026-07-30) puts this promotion **before** the cookbook pointer bump precisely so the pinned SHA exists on both lanes. Skipping it would deploy a pointer to a SHA that is not on Backend `main`.

## Contents

| Commit | What |
| --- | --- |
| `a682a2a` | Splits the ownership 409 into three codes the client can act on. Classifier is exhaustive against the `same_owner` predicate; response body is a pure superset (`error` prose unchanged, `code` added), so no client breakage. |
| `e72cdda` | Logs *which* refusal fired. With no staging environment (KAN-182) this log is the only channel that can answer how often `ORPHANED_GUEST_ROW` fires against `OTHER_ACCOUNT` in production — the ratio that decides KAN-155's remaining open item (login-merge reassignment vs. one-off backfill). |

## Verification

- `flask db heads` → `e4a7b2d9c5f1 (head)`, single head, so `flask-backend-migrate` will not refuse.
- No new migrations in this range; the migrate Job is a no-op.
- #259 merged green: pytest, mypy, black+flake8, pip-audit, CodeQL (actions/python/js), Docker build.
- **No build fires on this merge** — Backend has no push-to-`main` trigger. Only the cookbook tag push reaches Cloud Build.

Next in the train: cookbook pointer bump `0de1e2b` → `73fb091` + version 0.4.8 + CHANGELOG → cookbook `dev`, then cookbook `dev` → `main`, then the `v0.4.8` tag fires the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJTYg2F4r5Bcy6aX6hW8Ga




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

