### PR TITLE
ci: review every push to open PRs via synchronize (TAS-3006) [KAN-183]

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,10 +36,14 @@ name: Claude Review (independent model)
 
 on:
   pull_request:
-    # Auto once per PR (opened / un-drafted) + on-demand via the `claude-review`
-    # label. Deliberately NOT `synchronize` — one review per PR keeps cost bounded;
-    # re-request by re-applying the label. To review every push, add `synchronize`.
-    types: [opened, ready_for_review, labeled]
+    # Auto on PR open / un-draft AND on every push (`synchronize`) so commits
+    # pushed after the first review are reviewed too (TAS-3006 / KAN-183) — the PR
+    # lifecycle in CLAUDE.md ("monitor it, answer every comment, loop until
+    # merged") depends on the review loop covering later pushes, not just the first.
+    # Also on-demand via the `claude-review` label. The bot's own `--fix` pushes do
+    # NOT re-trigger (the `if:` guard below skips `github.event.sender.type == 'Bot'`),
+    # and `concurrency: cancel-in-progress` collapses rapid pushes to one review.
+    types: [opened, ready_for_review, labeled, synchronize]
     branches: [main, dev, 'dev/**']
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What

Adds `synchronize` to the `pull_request` triggers of `.github/workflows/claude-review.yml` so the independent Claude review fires on **every push** to an open PR — not just the first (`opened`/`ready_for_review`) or on-demand (`claude-review` label).

## Why

The review workflow deliberately excluded `synchronize`, so commits pushed after the first review were **never reviewed** — silently. That defeats the PR review loop CLAUDE.md depends on: *monitor it, answer every comment, loop until merged*.

TAS-3006 (execution KAN-183) requires the review workflows to trigger on `synchronize` in **both** repos (cookbook + Backend). This is the Backend half; the cookbook half is a matching PR.

## Cost safety (unchanged guards)

Redundant firing stays bounded without extra logic:
- `github.event.sender.type != 'Bot'` (existing `if:` guard) — the action's own `--fix` pushes do **not** re-trigger it.
- `concurrency: cancel-in-progress` — rapid successive pushes collapse to a single review.

Still advisory / fail-open (`continue-on-error: true`); never a required check.

## Done when

A push to an open PR produces a fresh review.

_Authored by Claude on Adam's behalf_
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

