### PR TITLE
fix(auth): run the duplicate-recipe check on guest→login merge [KAN-186]

### DIFF
--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -62,8 +62,41 @@ def _dedupe_cookbook_name(name, taken):
         n += 1
 
 
+def _recipe_identity_keys(recipe):
+    """Return the slugs that identify which public recipe a row was saved from.
+
+    Mirrors the client-side duplicate check (INV-1) in the cookbook SPA
+    (``src/services/ssr-entry.service.ts``), which matches a candidate against
+    ``r.sourceSlug === slug || r.slug === slug``. Both columns are consulted for
+    the same reason: a row saved from ``/r/<slug>`` carries the public slug in
+    ``source_slug``, while a row that *is* the published copy carries it in
+    ``slug``. Empty values never match — ``None == None`` must not make two
+    unrelated locally-authored recipes look like the same recipe.
+    """
+    return {value for value in (recipe.source_slug, recipe.slug) if value}
+
+
 def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
     """Reassign a guest session's recipes and cookbooks to an authenticated user.
+
+    Recipes are carried over **one row at a time, through a duplicate check**
+    (KAN-186). A recipe saved during a guest session frequently duplicates one
+    the account already owns: the user opens a public recipe, clicks "add to
+    cookbook" before auth resolves, then logs in. Reassigning unconditionally
+    silently created a second row, and publish-time confirmation (INV-3) is the
+    last line of defense rather than the first — by the time it fires the
+    duplicate already exists. Guest rows that match an owned recipe are dropped
+    in favour of the copy the account already has, which is what a duplicate
+    authenticated save does today.
+
+    Two guards on that deletion, both deliberate:
+
+    * A **public** guest row is reassigned rather than deleted. Deleting it
+      would take a live public page down; a duplicate row is the lesser harm
+      and remains visible to the user to resolve.
+    * Cookbook membership is **remapped, not dropped**. ``Cookbook.recipe_ids``
+      is a JSON list of ids, so deleting a row without rewriting the lists that
+      reference it would merge a cookbook full of dangling ids.
 
     Cookbook names are unique per owner (``uq_cookbook_user_name``), so a guest
     cookbook whose name already exists under the target user would collide on
@@ -83,10 +116,38 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
 
     for attempt in range(max_retries):
         try:
-            Recipe.query.filter_by(user_id=None, guest_session_id=guest_session_id).update(
-                {"user_id": user.id, "guest_session_id": None},
-                synchronize_session=False,
-            )
+            owned_by_key = {}
+            for owned in Recipe.query.filter_by(user_id=user.id).all():
+                for key in _recipe_identity_keys(owned):
+                    # First writer wins: if the account somehow already holds two
+                    # rows for the same public recipe, resolve to one of them
+                    # rather than picking arbitrarily on each merge.
+                    owned_by_key.setdefault(key, owned.id)
+
+            guest_recipes = Recipe.query.filter_by(
+                user_id=None, guest_session_id=guest_session_id
+            ).all()
+
+            # Guest recipe id -> the already-owned recipe id it resolves to.
+            remapped = {}
+            for recipe in guest_recipes:
+                existing_id = next(
+                    (
+                        owned_by_key[key]
+                        for key in _recipe_identity_keys(recipe)
+                        if key in owned_by_key
+                    ),
+                    None,
+                )
+                if existing_id is not None and not recipe.is_public:
+                    remapped[recipe.id] = existing_id
+                    db.session.delete(recipe)
+                    continue
+
+                recipe.user_id = user.id
+                recipe.guest_session_id = None
+                for key in _recipe_identity_keys(recipe):
+                    owned_by_key.setdefault(key, recipe.id)
 
             guest_cookbooks = Cookbook.query.filter_by(
                 user_id=None, guest_session_id=guest_session_id
@@ -97,6 +158,8 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                     for row in db.session.query(Cookbook.name).filter_by(user_id=user.id).all()
                 }
                 for cb in guest_cookbooks:
+                    if remapped:
+                        cb.recipe_ids = _remap_recipe_ids(cb.recipe_ids, remapped)
                     cb.name = _dedupe_cookbook_name(cb.name, taken)
                     cb.user_id = user.id
                     cb.guest_session_id = None
@@ -110,6 +173,20 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
             db.session.rollback()
             if attempt == max_retries - 1:
                 raise
+
+
+def _remap_recipe_ids(recipe_ids, remapped):
+    """Point a cookbook's recipe list at surviving rows, preserving order.
+
+    De-duplicates as it goes: a guest cookbook that held both the guest copy and
+    the account's existing copy must not end up listing the survivor twice.
+    """
+    result = []
+    for recipe_id in recipe_ids or []:
+        resolved = remapped.get(recipe_id, recipe_id)
+        if resolved not in result:
+            result.append(resolved)
+    return result
 
 
 def credentials_to_dict(credentials):

--- a/tests/test_guest_merge_dedup.py
+++ b/tests/test_guest_merge_dedup.py
@@ -1,0 +1,218 @@
+"""Guest→login merge runs the duplicate-recipe check (KAN-186 / RCP-61).
+
+A recipe saved during a guest session frequently duplicates one the account
+already owns: the user opens a public recipe, clicks "add to cookbook" before
+auth resolves, then logs in. The merge used to reassign every guest row with a
+single bulk UPDATE, so the account silently gained a second copy; publish-time
+confirmation (INV-3) only caught it after the duplicate row already existed.
+
+Acceptance from KAN-186, one test each:
+- a guest row duplicating an owned recipe does NOT create a second row
+- a guest row genuinely new to the account still merges over
+- ownership-refusal behaviour (INV-4 / same_owner) is untouched
+
+Plus the two guards the fix introduces: public guest rows are reassigned rather
+than deleted, and cookbook membership is remapped instead of left dangling.
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from blueprints.auth_api_bp import _merge_guest_session_into_user  # noqa: E402
+from extensions import db  # noqa: E402
+from models.cookbook import Cookbook  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+GUEST_SESSION = "guest-session-abc"
+
+
+@pytest.fixture
+def app():
+    flask_app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def user(app):
+    row = User(email="adam@example.com", name="Adam")
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def _recipe(name, *, owner=None, guest=None, source_slug=None, slug=None, public=False):
+    row = Recipe(
+        id=str(uuid.uuid4()),
+        user_id=owner.id if owner else None,
+        guest_session_id=guest,
+        name=name,
+        source_slug=source_slug,
+        slug=slug,
+        is_public=public,
+        data={"name": name},
+    )
+    db.session.add(row)
+    return row
+
+
+def _cookbook(name, recipe_ids, *, guest=None, owner=None):
+    row = Cookbook(
+        id=str(uuid.uuid4()),
+        user_id=owner.id if owner else None,
+        guest_session_id=guest,
+        name=name,
+        recipe_ids=recipe_ids,
+    )
+    db.session.add(row)
+    return row
+
+
+def test_duplicate_guest_recipe_does_not_create_a_second_row(app, user):
+    """The KAN-186 repro: same public recipe, saved as guest, then logged in."""
+    owned = _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    db.session.commit()
+    owned_id = owned.id
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    rows = Recipe.query.filter_by(user_id=user.id).all()
+    assert len(rows) == 1, "merge created a duplicate row"
+    assert rows[0].id == owned_id, "merge kept the guest copy instead of the owned one"
+    assert Recipe.query.filter_by(guest_session_id=GUEST_SESSION).count() == 0
+
+
+def test_new_guest_recipe_still_merges_over(app, user):
+    """The other half of the acceptance — no over-matching."""
+    _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    _recipe("Lentil Soup", guest=GUEST_SESSION, source_slug="hearty-lentil-soup")
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    names = sorted(r.name for r in Recipe.query.filter_by(user_id=user.id).all())
+    assert names == ["Lentil Soup", "Pizza Dough"]
+
+
+def test_locally_authored_recipes_are_not_matched_on_null_slugs(app, user):
+    """Two recipes with no slugs at all are not "the same recipe".
+
+    Guards the obvious way to get this wrong: keying on ``source_slug`` without
+    excluding ``None`` makes every locally-authored guest recipe collide with
+    every locally-authored owned one, and the merge silently eats them.
+    """
+    _recipe("My Own Recipe", owner=user)
+    _recipe("A Different Recipe", guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    assert Recipe.query.filter_by(user_id=user.id).count() == 2
+
+
+def test_slug_matches_source_slug_across_the_pair(app, user):
+    """INV-1 matches sourceSlug OR slug; the server check mirrors both."""
+    _recipe("Pizza Dough", owner=user, slug="vegan-fried-pizza-dough", public=True)
+    _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    assert Recipe.query.filter_by(user_id=user.id).count() == 1
+
+
+def test_public_guest_duplicate_is_reassigned_not_deleted(app, user):
+    """Deleting a published row would take a live public page down."""
+    _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    _recipe(
+        "Pizza Dough",
+        guest=GUEST_SESSION,
+        source_slug="vegan-fried-pizza-dough",
+        slug="vegan-fried-pizza-dough-2",
+        public=True,
+    )
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    rows = Recipe.query.filter_by(user_id=user.id).all()
+    assert len(rows) == 2, "a live public page was deleted as a duplicate"
+    assert {r.slug for r in rows} == {None, "vegan-fried-pizza-dough-2"}
+
+
+def test_cookbook_membership_is_remapped_to_the_surviving_row(app, user):
+    """Cookbook.recipe_ids is a JSON id list — it must not keep a dangling id."""
+    owned = _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    guest_dupe = _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    guest_new = _recipe("Lentil Soup", guest=GUEST_SESSION, source_slug="hearty-lentil-soup")
+    db.session.commit()
+    owned_id, guest_dupe_id, guest_new_id = owned.id, guest_dupe.id, guest_new.id
+
+    _cookbook("Weeknight", [guest_dupe_id, guest_new_id], guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    cb = Cookbook.query.filter_by(user_id=user.id).one()
+    assert cb.recipe_ids == [owned_id, guest_new_id]
+    live_ids = {r.id for r in Recipe.query.filter_by(user_id=user.id).all()}
+    assert set(cb.recipe_ids) <= live_ids, "cookbook references a deleted recipe"
+
+
+def test_remap_does_not_list_the_survivor_twice(app, user):
+    """A guest cookbook holding both copies must not end up with a duplicate id."""
+    owned = _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    guest_dupe = _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    db.session.commit()
+    owned_id, guest_dupe_id = owned.id, guest_dupe.id
+
+    _cookbook("Weeknight", [owned_id, guest_dupe_id], guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    cb = Cookbook.query.filter_by(user_id=user.id).one()
+    assert cb.recipe_ids == [owned_id]
+
+
+def test_another_users_rows_are_never_touched(app, user):
+    """INV-4 / same_owner is untouched: the merge only ever reads guest rows."""
+    other = User(email="someone-else@example.com", name="Someone Else")
+    db.session.add(other)
+    db.session.commit()
+
+    _recipe("Pizza Dough", owner=other, source_slug="vegan-fried-pizza-dough")
+    _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    assert Recipe.query.filter_by(user_id=other.id).count() == 1, "another account lost a row"
+    assert Recipe.query.filter_by(user_id=user.id).count() == 1, "guest row did not merge"
+
+
+def test_cookbook_name_collision_still_renames(app, user):
+    """The pre-existing uq_cookbook_user_name behaviour must survive the change."""
+    _cookbook("Weeknight", [], owner=user)
+    _cookbook("Weeknight", [], guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    names = sorted(cb.name for cb in Cookbook.query.filter_by(user_id=user.id).all())
+    assert names == ["Weeknight", "Weeknight (2)"]


### PR DESCRIPTION
## What

`_merge_guest_session_into_user` carried guest recipes over with a single bulk `UPDATE`. It now walks the rows one at a time through a duplicate check keyed on `source_slug` / `slug`, and a guest row that matches a recipe the account already owns resolves to the existing copy instead of creating a second one.

Sprint 5 item **S1** (`KAN-186` ↔ `RCP-61`), the single-lane item per charter risk R1.

## Why

Adam's repro, 2026-07-30/31: a tab sitting on a public recipe, wifi reconnects, **Add to cookbook** clicked before auth resolves → a guest-owned copy is created → logging in merges it into an account that already had that recipe. The account silently gains a duplicate.

Publish-time confirmation (INV-3) was the only thing catching it, and it is the *last* line of defense — by the time it fires the duplicate row already exists, and confirming past it turns a duplicate **row** into a duplicate **published page** (`…-2` slug).

## The reuse framing in the ticket does not hold — worth a reviewer's attention

KAN-186 proposed routing the merge through *"the same duplicate-detection check (INV-1)"* to avoid *"adding a second dedup implementation."* Right instinct, but INV-1 is **client-side TypeScript** — `src/services/ssr-entry.service.ts:40-48`, matching in memory over `currentUser().savedRecipes`. The merge is server-side SQL during the OAuth callback, when the SPA is not running. There is no shared module, and no server-side duplicate-recipe check existed at all.

So this **is** a second implementation of the same rule. Only the matching signal is shared (`source_slug`, falling back to `slug` — exactly INV-1's `r.sourceSlug === slug || r.slug === slug`). Whether the SPA should later defer to the server verdict is an open design call; Adam asked to make it on this diff rather than up front.

## Two guards on the deletion

| Guard | Why |
| --- | --- |
| A **public** guest duplicate is reassigned, not deleted | Deleting it takes a live public page down. A duplicate row is the lesser harm and stays visible to resolve. |
| `Cookbook.recipe_ids` is **remapped**, not left alone | It is a JSON id list. Deleting a row without rewriting the lists referencing it merges a cookbook full of dangling ids. De-duplicates so a cookbook holding both copies does not list the survivor twice. |

Empty slugs never match — otherwise every locally-authored guest recipe would collide with every locally-authored owned one and the merge would eat them.

## Verification

- **9 new tests**, `tests/test_guest_merge_dedup.py`.
- **Confirmed failing first**: the 4 behaviour tests fail against the previous implementation (`merge created a duplicate row`); the 5 regression guards — no over-matching, public rows, other accounts, cookbook rename — pass against **both**, which is the point of them.
- Full suite **357 passed**. `black` / `flake8` / `mypy` clean.
- **No schema change**; `flask db heads` is a single head (`e4a7b2d9c5f1`), so no migration is dragged and this stays a normal ship.

## Acceptance (KAN-186), all four

- [x] Guest recipe duplicating an owned copy does not create a second row on merge
- [x] Guest recipe genuinely new to the account still merges over
- [x] INV-1 … INV-6 unchanged
- [x] No change to `same_owner` / INV-4 ownership refusal — covered by `test_another_users_rows_are_never_touched`

## Ships in two steps

Backend PR here; the cookbook submodule pointer bump follows once this merges.

_Authored by Claude on Adam's behalf_
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

