### PR TITLE
release: promote Backend dev → main for the guest-merge dedup fix [KAN-186]

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,10 +36,14 @@ name: Claude Review (independent model)
 
 on:
   pull_request:
-    # Auto once per PR (opened / un-drafted) + on-demand via the `claude-review`
-    # label. Deliberately NOT `synchronize` — one review per PR keeps cost bounded;
-    # re-request by re-applying the label. To review every push, add `synchronize`.
-    types: [opened, ready_for_review, labeled]
+    # Auto on PR open / un-draft AND on every push (`synchronize`) so commits
+    # pushed after the first review are reviewed too (TAS-3006 / KAN-183) — the PR
+    # lifecycle in CLAUDE.md ("monitor it, answer every comment, loop until
+    # merged") depends on the review loop covering later pushes, not just the first.
+    # Also on-demand via the `claude-review` label. The bot's own `--fix` pushes do
+    # NOT re-trigger (the `if:` guard below skips `github.event.sender.type == 'Bot'`),
+    # and `concurrency: cancel-in-progress` collapses rapid pushes to one review.
+    types: [opened, ready_for_review, labeled, synchronize]
     branches: [main, dev, 'dev/**']
   workflow_dispatch:
     inputs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Review + fix + comment
         if: steps.auth.outputs.present == 'true'
-        uses: anthropics/claude-code-action@e0cf66d1d257526b5d07f141838c338921cb8455 # ratchet:anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # ratchet:anthropics/claude-code-action@v1
         with:
           # OAuth token (subscription) is primary; the action prefers it when set and
           # falls back to the API key when the OAuth secret is empty/unset.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # (v0.3.0 migrate job died on ModuleNotFoundError: flask_cors; see
 # docs/ci/CI-AUDIT-REPORT.md). --frozen means the lockfile is used exactly as
 # committed, never re-resolved at build time.
-FROM ghcr.io/astral-sh/uv:0.11.32-python3.13-trixie-slim AS export
+FROM ghcr.io/astral-sh/uv:0.11.33-python3.13-trixie-slim AS export
 WORKDIR /export
 COPY pyproject.toml uv.lock ./
 RUN uv export --format requirements-txt --no-dev --extra postgres \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # (v0.3.0 migrate job died on ModuleNotFoundError: flask_cors; see
 # docs/ci/CI-AUDIT-REPORT.md). --frozen means the lockfile is used exactly as
 # committed, never re-resolved at build time.
-FROM ghcr.io/astral-sh/uv:0.11.33-python3.13-trixie-slim AS export
+FROM ghcr.io/astral-sh/uv:0.12.1-python3.13-trixie-slim AS export
 WORKDIR /export
 COPY pyproject.toml uv.lock ./
 RUN uv export --format requirements-txt --no-dev --extra postgres \

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -62,8 +62,41 @@ def _dedupe_cookbook_name(name, taken):
         n += 1
 
 
+def _recipe_identity_keys(recipe):
+    """Return the slugs that identify which public recipe a row was saved from.
+
+    Mirrors the client-side duplicate check (INV-1) in the cookbook SPA
+    (``src/services/ssr-entry.service.ts``), which matches a candidate against
+    ``r.sourceSlug === slug || r.slug === slug``. Both columns are consulted for
+    the same reason: a row saved from ``/r/<slug>`` carries the public slug in
+    ``source_slug``, while a row that *is* the published copy carries it in
+    ``slug``. Empty values never match — ``None == None`` must not make two
+    unrelated locally-authored recipes look like the same recipe.
+    """
+    return {value for value in (recipe.source_slug, recipe.slug) if value}
+
+
 def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
     """Reassign a guest session's recipes and cookbooks to an authenticated user.
+
+    Recipes are carried over **one row at a time, through a duplicate check**
+    (KAN-186). A recipe saved during a guest session frequently duplicates one
+    the account already owns: the user opens a public recipe, clicks "add to
+    cookbook" before auth resolves, then logs in. Reassigning unconditionally
+    silently created a second row, and publish-time confirmation (INV-3) is the
+    last line of defense rather than the first — by the time it fires the
+    duplicate already exists. Guest rows that match an owned recipe are dropped
+    in favour of the copy the account already has, which is what a duplicate
+    authenticated save does today.
+
+    Two guards on that deletion, both deliberate:
+
+    * A **public** guest row is reassigned rather than deleted. Deleting it
+      would take a live public page down; a duplicate row is the lesser harm
+      and remains visible to the user to resolve.
+    * Cookbook membership is **remapped, not dropped**. ``Cookbook.recipe_ids``
+      is a JSON list of ids, so deleting a row without rewriting the lists that
+      reference it would merge a cookbook full of dangling ids.
 
     Cookbook names are unique per owner (``uq_cookbook_user_name``), so a guest
     cookbook whose name already exists under the target user would collide on
@@ -83,10 +116,38 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
 
     for attempt in range(max_retries):
         try:
-            Recipe.query.filter_by(user_id=None, guest_session_id=guest_session_id).update(
-                {"user_id": user.id, "guest_session_id": None},
-                synchronize_session=False,
-            )
+            owned_by_key = {}
+            for owned in Recipe.query.filter_by(user_id=user.id).all():
+                for key in _recipe_identity_keys(owned):
+                    # First writer wins: if the account somehow already holds two
+                    # rows for the same public recipe, resolve to one of them
+                    # rather than picking arbitrarily on each merge.
+                    owned_by_key.setdefault(key, owned.id)
+
+            guest_recipes = Recipe.query.filter_by(
+                user_id=None, guest_session_id=guest_session_id
+            ).all()
+
+            # Guest recipe id -> the already-owned recipe id it resolves to.
+            remapped = {}
+            for recipe in guest_recipes:
+                existing_id = next(
+                    (
+                        owned_by_key[key]
+                        for key in _recipe_identity_keys(recipe)
+                        if key in owned_by_key
+                    ),
+                    None,
+                )
+                if existing_id is not None and not recipe.is_public:
+                    remapped[recipe.id] = existing_id
+                    db.session.delete(recipe)
+                    continue
+
+                recipe.user_id = user.id
+                recipe.guest_session_id = None
+                for key in _recipe_identity_keys(recipe):
+                    owned_by_key.setdefault(key, recipe.id)
 
             guest_cookbooks = Cookbook.query.filter_by(
                 user_id=None, guest_session_id=guest_session_id
@@ -97,6 +158,8 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                     for row in db.session.query(Cookbook.name).filter_by(user_id=user.id).all()
                 }
                 for cb in guest_cookbooks:
+                    if remapped:
+                        cb.recipe_ids = _remap_recipe_ids(cb.recipe_ids, remapped)
                     cb.name = _dedupe_cookbook_name(cb.name, taken)
                     cb.user_id = user.id
                     cb.guest_session_id = None
@@ -110,6 +173,20 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
             db.session.rollback()
             if attempt == max_retries - 1:
                 raise
+
+
+def _remap_recipe_ids(recipe_ids, remapped):
+    """Point a cookbook's recipe list at surviving rows, preserving order.
+
+    De-duplicates as it goes: a guest cookbook that held both the guest copy and
+    the account's existing copy must not end up listing the survivor twice.
+    """
+    result = []
+    for recipe_id in recipe_ids or []:
+        resolved = remapped.get(recipe_id, recipe_id)
+        if resolved not in result:
+            result.append(resolved)
+    return result
 
 
 def credentials_to_dict(credentials):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "flask-caching==2.4.1",
     "sqlalchemy>=2.0.51", # Use stable 2.0.x with Python 3.13 support
     # Google AI & Authentication
-    "google-genai==2.14.0",
+    "google-genai==2.16.0",
     "google-generativeai==0.8.6",
     "google-ai-generativelanguage==0.6.15",
     "google-auth==2.56.2",
@@ -47,7 +47,7 @@ dependencies = [
     # the production image lost half its runtime deps).
     "google-cloud-storage==3.13.0",
     "google-cloud-pubsub>=2.19.0",
-    "redis==8.0.1",
+    "redis==8.1.0",
     # Data Validation
     "jsonschema==4.26.0",
     "pydantic==2.12.5",
@@ -70,14 +70,14 @@ dependencies = [
     "typing-extensions==4.16.0",
     "tenacity==9.1.4",
     "websockets==16.1.1",
-    "cachetools==7.1.6",
+    "cachetools==7.1.7",
     # Cryptography & Security
     "pyasn1==0.6.4",
     "pyasn1-modules==0.4.2",
     "rsa==4.9.1",
     "flask-cors==6.0.5",
     "pandas>=3.0.5",
-    "ddtrace>=4.12.0",
+    "ddtrace>=4.12.2",
     "gunicorn>=26.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     "rsa==4.9.1",
     "flask-cors==6.0.5",
     "pandas>=3.0.5",
-    "ddtrace>=4.11.1",
+    "ddtrace>=4.12.0",
     "gunicorn>=26.0.0",
 ]
 

--- a/tests/test_guest_merge_dedup.py
+++ b/tests/test_guest_merge_dedup.py
@@ -1,0 +1,218 @@
+"""Guest→login merge runs the duplicate-recipe check (KAN-186 / RCP-61).
+
+A recipe saved during a guest session frequently duplicates one the account
+already owns: the user opens a public recipe, clicks "add to cookbook" before
+auth resolves, then logs in. The merge used to reassign every guest row with a
+single bulk UPDATE, so the account silently gained a second copy; publish-time
+confirmation (INV-3) only caught it after the duplicate row already existed.
+
+Acceptance from KAN-186, one test each:
+- a guest row duplicating an owned recipe does NOT create a second row
+- a guest row genuinely new to the account still merges over
+- ownership-refusal behaviour (INV-4 / same_owner) is untouched
+
+Plus the two guards the fix introduces: public guest rows are reassigned rather
+than deleted, and cookbook membership is remapped instead of left dangling.
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from blueprints.auth_api_bp import _merge_guest_session_into_user  # noqa: E402
+from extensions import db  # noqa: E402
+from models.cookbook import Cookbook  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+GUEST_SESSION = "guest-session-abc"
+
+
+@pytest.fixture
+def app():
+    flask_app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        WTF_CSRF_ENABLED=False,
+    )
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def user(app):
+    row = User(email="adam@example.com", name="Adam")
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def _recipe(name, *, owner=None, guest=None, source_slug=None, slug=None, public=False):
+    row = Recipe(
+        id=str(uuid.uuid4()),
+        user_id=owner.id if owner else None,
+        guest_session_id=guest,
+        name=name,
+        source_slug=source_slug,
+        slug=slug,
+        is_public=public,
+        data={"name": name},
+    )
+    db.session.add(row)
+    return row
+
+
+def _cookbook(name, recipe_ids, *, guest=None, owner=None):
+    row = Cookbook(
+        id=str(uuid.uuid4()),
+        user_id=owner.id if owner else None,
+        guest_session_id=guest,
+        name=name,
+        recipe_ids=recipe_ids,
+    )
+    db.session.add(row)
+    return row
+
+
+def test_duplicate_guest_recipe_does_not_create_a_second_row(app, user):
+    """The KAN-186 repro: same public recipe, saved as guest, then logged in."""
+    owned = _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    db.session.commit()
+    owned_id = owned.id
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    rows = Recipe.query.filter_by(user_id=user.id).all()
+    assert len(rows) == 1, "merge created a duplicate row"
+    assert rows[0].id == owned_id, "merge kept the guest copy instead of the owned one"
+    assert Recipe.query.filter_by(guest_session_id=GUEST_SESSION).count() == 0
+
+
+def test_new_guest_recipe_still_merges_over(app, user):
+    """The other half of the acceptance — no over-matching."""
+    _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    _recipe("Lentil Soup", guest=GUEST_SESSION, source_slug="hearty-lentil-soup")
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    names = sorted(r.name for r in Recipe.query.filter_by(user_id=user.id).all())
+    assert names == ["Lentil Soup", "Pizza Dough"]
+
+
+def test_locally_authored_recipes_are_not_matched_on_null_slugs(app, user):
+    """Two recipes with no slugs at all are not "the same recipe".
+
+    Guards the obvious way to get this wrong: keying on ``source_slug`` without
+    excluding ``None`` makes every locally-authored guest recipe collide with
+    every locally-authored owned one, and the merge silently eats them.
+    """
+    _recipe("My Own Recipe", owner=user)
+    _recipe("A Different Recipe", guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    assert Recipe.query.filter_by(user_id=user.id).count() == 2
+
+
+def test_slug_matches_source_slug_across_the_pair(app, user):
+    """INV-1 matches sourceSlug OR slug; the server check mirrors both."""
+    _recipe("Pizza Dough", owner=user, slug="vegan-fried-pizza-dough", public=True)
+    _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    assert Recipe.query.filter_by(user_id=user.id).count() == 1
+
+
+def test_public_guest_duplicate_is_reassigned_not_deleted(app, user):
+    """Deleting a published row would take a live public page down."""
+    _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    _recipe(
+        "Pizza Dough",
+        guest=GUEST_SESSION,
+        source_slug="vegan-fried-pizza-dough",
+        slug="vegan-fried-pizza-dough-2",
+        public=True,
+    )
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    rows = Recipe.query.filter_by(user_id=user.id).all()
+    assert len(rows) == 2, "a live public page was deleted as a duplicate"
+    assert {r.slug for r in rows} == {None, "vegan-fried-pizza-dough-2"}
+
+
+def test_cookbook_membership_is_remapped_to_the_surviving_row(app, user):
+    """Cookbook.recipe_ids is a JSON id list — it must not keep a dangling id."""
+    owned = _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    guest_dupe = _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    guest_new = _recipe("Lentil Soup", guest=GUEST_SESSION, source_slug="hearty-lentil-soup")
+    db.session.commit()
+    owned_id, guest_dupe_id, guest_new_id = owned.id, guest_dupe.id, guest_new.id
+
+    _cookbook("Weeknight", [guest_dupe_id, guest_new_id], guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    cb = Cookbook.query.filter_by(user_id=user.id).one()
+    assert cb.recipe_ids == [owned_id, guest_new_id]
+    live_ids = {r.id for r in Recipe.query.filter_by(user_id=user.id).all()}
+    assert set(cb.recipe_ids) <= live_ids, "cookbook references a deleted recipe"
+
+
+def test_remap_does_not_list_the_survivor_twice(app, user):
+    """A guest cookbook holding both copies must not end up with a duplicate id."""
+    owned = _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")
+    guest_dupe = _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    db.session.commit()
+    owned_id, guest_dupe_id = owned.id, guest_dupe.id
+
+    _cookbook("Weeknight", [owned_id, guest_dupe_id], guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    cb = Cookbook.query.filter_by(user_id=user.id).one()
+    assert cb.recipe_ids == [owned_id]
+
+
+def test_another_users_rows_are_never_touched(app, user):
+    """INV-4 / same_owner is untouched: the merge only ever reads guest rows."""
+    other = User(email="someone-else@example.com", name="Someone Else")
+    db.session.add(other)
+    db.session.commit()
+
+    _recipe("Pizza Dough", owner=other, source_slug="vegan-fried-pizza-dough")
+    _recipe("Pizza Dough", guest=GUEST_SESSION, source_slug="vegan-fried-pizza-dough")
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    assert Recipe.query.filter_by(user_id=other.id).count() == 1, "another account lost a row"
+    assert Recipe.query.filter_by(user_id=user.id).count() == 1, "guest row did not merge"
+
+
+def test_cookbook_name_collision_still_renames(app, user):
+    """The pre-existing uq_cookbook_user_name behaviour must survive the change."""
+    _cookbook("Weeknight", [], owner=user)
+    _cookbook("Weeknight", [], guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    names = sorted(cb.name for cb in Cookbook.query.filter_by(user_id=user.id).all())
+    assert names == ["Weeknight", "Weeknight (2)"]

--- a/uv.lock
+++ b/uv.lock
@@ -136,11 +136,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.1.6"
+version = "7.1.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/af/861ebc2e318a5c3300e3eb63bc4d30f3d70a46d13b360093728ac0705eed/cachetools-7.1.6.tar.gz", hash = "sha256:c7a79e7f30ba9943c1cefd08cc36f006aaae086e017af9166f1d59d6170c47e1", size = 40572, upload-time = "2026-07-23T22:47:53.737Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz", hash = "sha256:a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50", size = 40680, upload-time = "2026-08-01T21:20:40.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/f2/2086ba18a925a73586c4d4e61d25f4a6058e56fd00d77ce8f1d361ab4c9b/cachetools-7.1.6-py3-none-any.whl", hash = "sha256:2c12e255780330af28b91bb7fb96cce4c766f04e38396b9a24510190a5827096", size = 16954, upload-time = "2026-07-23T22:47:52.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl", hash = "sha256:ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0", size = 16830, upload-time = "2026-08-01T21:20:38.977Z" },
 ]
 
 [[package]]
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "ddtrace"
-version = "4.12.0"
+version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bytecode" },
@@ -304,17 +304,17 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/34/4971944b759647238d68d92e52fa8edfcd0bc715b23ba8608a1f55f9bbe8/ddtrace-4.12.0.tar.gz", hash = "sha256:4dacd7b993d0f3922b72abca37a60911754e21c401f0b9690fdf68522712b588", size = 2508255, upload-time = "2026-07-27T14:24:14.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/28/3eba5a76a4e6e7e6324364e7d6ead58c464fb2b7015b1ffe0facba4c9cf6/ddtrace-4.12.2.tar.gz", hash = "sha256:a3cfa19ebd6b5c0f7c70c16da29d7bf5f50c0ab014ad3dc77e9c06a424ca2cfb", size = 2509893, upload-time = "2026-07-30T20:24:13.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/03/e920e1f6ba30747ae25d50840055843405a19445a071d746ee3c84402224/ddtrace-4.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6684a143e9c8ce119e6f7d3f48a5499b1380c774c2fc7715e840c3fbb8a39655", size = 7256403, upload-time = "2026-07-27T14:22:36.46Z" },
-    { url = "https://files.pythonhosted.org/packages/57/35/43a91cc9db12efbf868807ef728d311f14d1e3cd5394eece559931614c41/ddtrace-4.12.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:f216982377b151683102c636962515cf692d79dda7cf198fd1c387351e524b90", size = 7599919, upload-time = "2026-07-27T14:22:38.97Z" },
-    { url = "https://files.pythonhosted.org/packages/44/22/8ac79469527f3f643d2fe1620803a0853fed1072f54da65dc9555df1f403/ddtrace-4.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bc7260b86182b10f2b7d631a5d5df32b0b7309f3365a1d5177b96851be8bee7f", size = 8597010, upload-time = "2026-07-27T14:22:41.648Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/5c/2a75efee22a42088c1fe1295b879dab89a993e05f2817c408e27ef0f9867/ddtrace-4.12.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:38baab1df19a3111afd89a7491ca6979d437fd6c858402295942a08e468977ee", size = 8829771, upload-time = "2026-07-27T14:22:44.491Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/04/d02563e002b15c74f5842c4c9cbfdf676e6f2a0530c86353e1e4108634e9/ddtrace-4.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:17790dc1ecda0d128eff432cbf308abc0bc361d9ce1f17eb22ddf0d794358a52", size = 9602769, upload-time = "2026-07-27T14:22:47.448Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/f0/0068efa057bb03539e824ca329dac867a173e3197bb81e41321bbfda9729/ddtrace-4.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4c7faecab4b64550ee9592c209b37f1209467540473f1395217b2feb769248c3", size = 9896165, upload-time = "2026-07-27T14:22:50.744Z" },
-    { url = "https://files.pythonhosted.org/packages/27/05/6d8eff744939ed9c12715386e0baef389cf2f0775f58d0fa4a775dd72869/ddtrace-4.12.0-cp313-cp313-win32.whl", hash = "sha256:90e5a586a33781699ed48e36a13764fc2e9beeaf6695f011cd27075f14170bb9", size = 6422306, upload-time = "2026-07-27T14:22:53.643Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/a7/c0bb3426c51b269630b967d34a1187c5124b7248f71eeb80a58fff6b1307/ddtrace-4.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:883957aea82511cf5564c8fa4b6b244bef9688837d004c5926dd307b84e6dfff", size = 7033722, upload-time = "2026-07-27T14:22:56.242Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f3/0d26e2f93c17bf32012ab7efe4c2352446597e6b73fc050f16eed7c855c0/ddtrace-4.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:974ee2a63efc8d30deb57275fa1030584af50c1f5ea83c850724efa64fb07742", size = 7044138, upload-time = "2026-07-27T14:22:58.81Z" },
+    { url = "https://files.pythonhosted.org/packages/63/21/4cfac3ff8738b2c0bcbffc9a4c9479b1d919017f012672b4906115c2ae8d/ddtrace-4.12.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:dd0fb37274914524c2c2a203ca5dcb052faf140d05edeedf97df317a38fc5eba", size = 7261357, upload-time = "2026-07-30T20:22:44.428Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d9/5f027615cbc23470b810a775ac5c9aa45d76bb6c9582bbfed869d82fb3b2/ddtrace-4.12.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:63c7b51d3aedac9b002a9e5032bc9d6e6dbc57b154b5e06e108b96d9c347dd37", size = 7605189, upload-time = "2026-07-30T20:22:46.693Z" },
+    { url = "https://files.pythonhosted.org/packages/65/48/9a5ba8acbbcaca58bc268a9059fe724f1fd3675a6de1b22698f03a528842/ddtrace-4.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef4ec53f9829ab95f85b0d6a27a9e0ab0be7964847f5fa54460903c613fe1d4e", size = 8603338, upload-time = "2026-07-30T20:22:49.119Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d8/1d3bb30422a4ab4202e521355f9c496f5e268346004ce56cdf6124387b8f/ddtrace-4.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:41f7611a4370ceaab7e7d1a85fe866c5ab7944f649d83d8d502c64c82b1ca51d", size = 8836673, upload-time = "2026-07-30T20:22:51.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/45/1bd4ea8dec0dc73ae98f62ffddef1af778528badddd234bff51057603a73/ddtrace-4.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6df5c422813a33e55affe20c05925ef94a9e1494223db08820c3d7bdb1a5f22b", size = 9607518, upload-time = "2026-07-30T20:22:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e9/29f563a3b958e52a150bd969d94db8676651de262e2014499cfcfedfdcb7/ddtrace-4.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:306f9a30e294b77ecd09031e1a131c9b3ff550525f3188403046408e8a401b8d", size = 9901851, upload-time = "2026-07-30T20:22:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/42/eecbce15bb7cca4d9ae74d3474a639fac95df56b8e11c601f86f4546f6f8/ddtrace-4.12.2-cp313-cp313-win32.whl", hash = "sha256:a1febd22143a56337ec60dffef6e3fcb883d26a0d64aba033d9de76d40bcca3b", size = 6428003, upload-time = "2026-07-30T20:23:00.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d2/279060235f51716188800bc2f911053f487eb35e5690d09c66a4d99e722e/ddtrace-4.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:c85c9ab26448c13ca55016e970f52e12e8abbb7125b09b72416770e92fd10306", size = 7036991, upload-time = "2026-07-30T20:23:02.62Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a6/b11f3b5f0851a808fd5d3e8bd9f1995f2ba8421294f2814960aa99223524/ddtrace-4.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:0671ba174626acd94eed6a43c4c66045ec23a4e9c6adeacf0bfd9329d4acaadf", size = 7051149, upload-time = "2026-07-30T20:23:05.203Z" },
 ]
 
 [[package]]
@@ -581,7 +581,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "2.14.0"
+version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -595,9 +595,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/df/4f820054c99f29f2fe3de4a8a7c9534dd795302e4a07483a0cb07c3a29b6/google_genai-2.14.0.tar.gz", hash = "sha256:a9d1f4f362d76280f1be1340fcb3c86e63dbca128f6a4ae09d86ab47ff7148e8", size = 641055, upload-time = "2026-07-22T21:35:44.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e6/ff83088427072cc9d5d21036788cf0ed08cc4906e4a5810e469553a43185/google_genai-2.16.0.tar.gz", hash = "sha256:c4c2524926001b18073db927a5d75bb7c8be7b5fd13ab507d599f51fff2284c5", size = 647939, upload-time = "2026-07-30T14:34:37.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/86/5ac5fb53e44cca4a6607fb917eb331fa237c65a103b9ec2e8e8acc8a42db/google_genai-2.14.0-py3-none-any.whl", hash = "sha256:ae7172cdd35695189b516b33a878e4132e5daa2dbc03a5b44cddfa8a82fad664", size = 1030738, upload-time = "2026-07-22T21:35:42.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c6/f111056110030b1a5fb949687d7f93c2b4e8996f6494ae32efb049482796/google_genai-2.16.0-py3-none-any.whl", hash = "sha256:f9eda6a7a3dd4491a0d2253c4bdd4536462d63838ed3f1b0e4fb9a0eb8f43331", size = 1050096, upload-time = "2026-07-30T14:34:35.578Z" },
 ]
 
 [[package]]
@@ -1305,11 +1305,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "8.0.1"
+version = "8.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]
@@ -1523,10 +1523,10 @@ requires-dist = [
     { name = "anyio", specifier = "==4.14.2" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.5.1" },
     { name = "blinker", specifier = "==1.9.0" },
-    { name = "cachetools", specifier = "==7.1.6" },
+    { name = "cachetools", specifier = "==7.1.7" },
     { name = "certifi", specifier = "==2026.7.22" },
     { name = "charset-normalizer", specifier = "==3.4.9" },
-    { name = "ddtrace", specifier = ">=4.12.0" },
+    { name = "ddtrace", specifier = ">=4.12.2" },
     { name = "distro", specifier = "==1.9.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "flask", specifier = "==3.1.3" },
@@ -1540,7 +1540,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", specifier = "==1.4.0" },
     { name = "google-cloud-pubsub", specifier = ">=2.19.0" },
     { name = "google-cloud-storage", specifier = "==3.13.0" },
-    { name = "google-genai", specifier = "==2.14.0" },
+    { name = "google-genai", specifier = "==2.16.0" },
     { name = "google-generativeai", specifier = "==0.8.6" },
     { name = "googleapis-common-protos", specifier = "==1.75.0" },
     { name = "gunicorn", specifier = ">=26.0.0" },
@@ -1561,7 +1561,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-multipart", specifier = "==0.0.32" },
-    { name = "redis", specifier = "==8.0.1" },
+    { name = "redis", specifier = "==8.1.0" },
     { name = "requests", specifier = "==2.34.2" },
     { name = "requests-oauthlib", specifier = "==2.0.0" },
     { name = "rsa", specifier = "==4.9.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "ddtrace"
-version = "4.11.1"
+version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bytecode" },
@@ -304,17 +304,17 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5b/c9f72f6c690c30724fd683ace8921aeec5183cf0a1979769782598c14ac3/ddtrace-4.11.1.tar.gz", hash = "sha256:fa28db048830489e080b64bdcdd56ef31001d4dc6bd9f5ff3f9dca744236ce69", size = 2422782, upload-time = "2026-07-17T09:04:38.371Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/34/4971944b759647238d68d92e52fa8edfcd0bc715b23ba8608a1f55f9bbe8/ddtrace-4.12.0.tar.gz", hash = "sha256:4dacd7b993d0f3922b72abca37a60911754e21c401f0b9690fdf68522712b588", size = 2508255, upload-time = "2026-07-27T14:24:14.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/27/e40cc3ca6e1f3226edcd25907a8e79d034a4fe4631c423587d3fea76f2ff/ddtrace-4.11.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:9ee9f9966dc26a2108112565cd3d61f4f65e21a30de19dc7eb9c98127a977193", size = 7102117, upload-time = "2026-07-17T09:03:05.534Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/64/4d8b2a5856a2146af50725fef2be8d63498286a6eba0463195df853e4024/ddtrace-4.11.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:1c844c9b3f5334aeaad00c0d436485183163ea3fa95e9dd93c40e3bb99d00d5f", size = 7435484, upload-time = "2026-07-17T09:03:07.89Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d4/a2e490551eb9bd051b324c96f6ac9317f49f68208486458ebda4b8807eca/ddtrace-4.11.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1b72a1bb9095ef8e2934842d706c63fe3789d980baebe99b182c719a8c2d0b99", size = 8506386, upload-time = "2026-07-17T09:03:10.531Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/4e/0abd8512663745fe3c490ae0a35782d8bba3e5c9d3a627aff9b23bd8a3d4/ddtrace-4.11.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c6fecbb10dfebb6435ed596c60ec2223859f193cf514d37cd124d1a39510cc8f", size = 8728280, upload-time = "2026-07-17T09:03:13.3Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/64/afbcb739dc4d394d178ae958f4162abb3d10adb99c536289ea78015294d2/ddtrace-4.11.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2ab0080c0cb479b6a3945c328ccfe504964533dc0d2f07ea1888402d0f1fc3ad", size = 9513166, upload-time = "2026-07-17T09:03:16.396Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/eb/cc64b3b55374689a6fb43a5e0d705f869d7aac5e907a529ea18d3888d23d/ddtrace-4.11.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2baa6667e4eee4c45a5eff426828bc063c0dd5b145cdf44fcaf9a4d8c92f17d3", size = 9794600, upload-time = "2026-07-17T09:03:19.265Z" },
-    { url = "https://files.pythonhosted.org/packages/89/4c/ef50f6456548c6e718e8eeb5cd6e84ebc4c7b1ce4c5d2307c28ee7cdf80a/ddtrace-4.11.1-cp313-cp313-win32.whl", hash = "sha256:ca2b6f093be2d6f88c6ff91c1213d4a894ee3a12bfc3db35e94022e29f5b062e", size = 5739852, upload-time = "2026-07-17T09:03:22.402Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/53/c3586e68ebf6185826db20045a04f620bd87b0b9fb9375c6540ef6035a07/ddtrace-4.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:19d34a567dfb546cd40071a9946d65ff0b25b0c0599e03556a6edc69622223d9", size = 6321359, upload-time = "2026-07-17T09:03:25.242Z" },
-    { url = "https://files.pythonhosted.org/packages/97/fc/2075907f5fa59eedd2fb54eb0b291b9411e42d06456c8690c02d1dd1bfe7/ddtrace-4.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:e47b4b1adff4b69f16580b6d13604f6af67186d9a0ac675502494079dd305dae", size = 5965707, upload-time = "2026-07-17T09:03:27.73Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/03/e920e1f6ba30747ae25d50840055843405a19445a071d746ee3c84402224/ddtrace-4.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6684a143e9c8ce119e6f7d3f48a5499b1380c774c2fc7715e840c3fbb8a39655", size = 7256403, upload-time = "2026-07-27T14:22:36.46Z" },
+    { url = "https://files.pythonhosted.org/packages/57/35/43a91cc9db12efbf868807ef728d311f14d1e3cd5394eece559931614c41/ddtrace-4.12.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:f216982377b151683102c636962515cf692d79dda7cf198fd1c387351e524b90", size = 7599919, upload-time = "2026-07-27T14:22:38.97Z" },
+    { url = "https://files.pythonhosted.org/packages/44/22/8ac79469527f3f643d2fe1620803a0853fed1072f54da65dc9555df1f403/ddtrace-4.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bc7260b86182b10f2b7d631a5d5df32b0b7309f3365a1d5177b96851be8bee7f", size = 8597010, upload-time = "2026-07-27T14:22:41.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5c/2a75efee22a42088c1fe1295b879dab89a993e05f2817c408e27ef0f9867/ddtrace-4.12.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:38baab1df19a3111afd89a7491ca6979d437fd6c858402295942a08e468977ee", size = 8829771, upload-time = "2026-07-27T14:22:44.491Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/04/d02563e002b15c74f5842c4c9cbfdf676e6f2a0530c86353e1e4108634e9/ddtrace-4.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:17790dc1ecda0d128eff432cbf308abc0bc361d9ce1f17eb22ddf0d794358a52", size = 9602769, upload-time = "2026-07-27T14:22:47.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f0/0068efa057bb03539e824ca329dac867a173e3197bb81e41321bbfda9729/ddtrace-4.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4c7faecab4b64550ee9592c209b37f1209467540473f1395217b2feb769248c3", size = 9896165, upload-time = "2026-07-27T14:22:50.744Z" },
+    { url = "https://files.pythonhosted.org/packages/27/05/6d8eff744939ed9c12715386e0baef389cf2f0775f58d0fa4a775dd72869/ddtrace-4.12.0-cp313-cp313-win32.whl", hash = "sha256:90e5a586a33781699ed48e36a13764fc2e9beeaf6695f011cd27075f14170bb9", size = 6422306, upload-time = "2026-07-27T14:22:53.643Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a7/c0bb3426c51b269630b967d34a1187c5124b7248f71eeb80a58fff6b1307/ddtrace-4.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:883957aea82511cf5564c8fa4b6b244bef9688837d004c5926dd307b84e6dfff", size = 7033722, upload-time = "2026-07-27T14:22:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f3/0d26e2f93c17bf32012ab7efe4c2352446597e6b73fc050f16eed7c855c0/ddtrace-4.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:974ee2a63efc8d30deb57275fa1030584af50c1f5ea83c850724efa64fb07742", size = 7044138, upload-time = "2026-07-27T14:22:58.81Z" },
 ]
 
 [[package]]
@@ -1526,7 +1526,7 @@ requires-dist = [
     { name = "cachetools", specifier = "==7.1.6" },
     { name = "certifi", specifier = "==2026.7.22" },
     { name = "charset-normalizer", specifier = "==3.4.9" },
-    { name = "ddtrace", specifier = ">=4.11.1" },
+    { name = "ddtrace", specifier = ">=4.12.0" },
     { name = "distro", specifier = "==1.9.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "flask", specifier = "==3.1.3" },


### PR DESCRIPTION
Promotes Backend `dev` → `main` so the cookbook pointer can pin `main`'s own SHA for the next release. **No build fires on this merge** — Backend has no push-to-`main` trigger; only the cookbook tag push reaches Cloud Build. This is a lane move (`RUNBOOK.md` step 2).

## Why now

**KAN-186 (guest→login merge duplicate-recipe check) is on Backend `dev` and not on `main`, so it is not in production.** It is S1 of Sprint 5 — the highest-priority open row in either project, and the only committed item breaking a user today. The cookbook pointer bump (#3344) landed on cookbook `dev` pinning `fd2d1c1`, but that SHA is reachable only from Backend `dev`. Until this promotion merges and the pointer is re-pinned to `main`, the fix ships nowhere.

## What rides along

| Commit | What |
|---|---|
| `fd2d1c1` | **fix(auth): run the duplicate-recipe check on guest→login merge [KAN-186]** (#267) |
| `bb7e167` | ci: review every push to open PRs via `synchronize` (#266) — KAN-183, S6 of Sprint 5 |
| `0114c84` | build(deps): bump the python-production group with 4 updates (#269) |
| `e30f7ac` | build(docker): bump astral-sh/uv 0.11.33 → 0.12.1 (#268) |
| `5806a58` | ci: bump anthropics/claude-code-action (#265) |
| `e5e07a0` | build(deps): bump ddtrace 4.11.1 → 4.12.0 (#264) |
| `50ce1bc` | build(docker): bump astral-sh/uv 0.11.32 → 0.11.33 (#263) |

Plus the `3fac56b` back-sync merge from the KAN-155 promotion, which is ancestry only.

## Pre-flight

```
$ uv run flask db heads
e4a7b2d9c5f1 (head)          # exactly one — flask db upgrade will run
```

A single Alembic head is the blocking precondition: two heads and the `flask-backend-migrate` Cloud Run Job fails, aborting the build (the old Flask revision keeps serving, which is the desired failure, but the release is dead until the heads are merged).

## After this merges — the two steps that are easy to skip

1. **Back-sync `main` → `dev`** (`./scripts/release/train-backsync.sh --apply --merge`). The promotion leaves a merge commit on `main` that `dev` lacks; skipping it is the most repeated miss in this project's history.
2. **Re-check for staleness before pinning.** A promotion goes stale the moment anything else lands on Backend `dev` — on v0.4.8, #258 promoted and #259 merged to `dev` hours later, the step list said "done", and `main` did not have the code. Verify by content, not by the checklist:
   ```bash
   git -C Backend merge-base --is-ancestor <merge-sha> origin/main && echo OK || echo STALE
   ```

Note Backend #270 (actions-all bump) is open and deliberately **not** included — it landed after this promotion was cut, and pulling it in is what makes a promotion stale.

## Jira

[KAN-186](https://tasteslikegood.atlassian.net/browse/KAN-186) ↔ RCP-61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp

[KAN-186]: https://tasteslikegood.atlassian.net/browse/KAN-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAN-186]: https://tasteslikegood.atlassian.net/browse/KAN-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

