### PR TITLE
feat(recipes): refuse duplicate saves in the database, not the SPA [KAN-213]

### DIFF
--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -168,7 +168,21 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                     # Nothing of value is lost: the row is kept precisely
                     # because it is a published page in its own right, so its
                     # own `slug` identifies it from here on.
+                    #
+                    # Clear the MIRRORED BLOB KEY TOO, not just the column.
+                    # `source_slug` mirrors `data['sourceSlug']`, and
+                    # update_recipe rebuilds the blob as
+                    # {**(recipe.data or {}), **recipe_data} before restaging
+                    # `recipe.source_slug = data.get('sourceSlug')`. Clearing
+                    # only the column means the next ordinary partial PUT (say
+                    # {"name": "..."}) pulls the stale value back out of the
+                    # untouched blob and writes it to the column — resurrecting
+                    # the duplicate and making the row un-editable behind a 409.
+                    # Caught by Codex review on PR #273; reproduced by
+                    # test_clearing_the_column_survives_a_later_partial_update.
                     recipe.source_slug = None
+                    if recipe.data and "sourceSlug" in recipe.data:
+                        del recipe.data["sourceSlug"]
 
                 recipe.user_id = user.id
                 recipe.guest_session_id = None

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -145,24 +145,29 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                     continue
 
                 if existing_id is not None:
-                    # KAN-213 × KAN-186. This is the public-row exemption above:
-                    # the account already owns a row for this public recipe, but
-                    # this guest row is itself published, so it is reassigned
-                    # rather than deleted — deleting would take a live page down.
+                    # Reached only by a PUBLIC guest row that duplicates an
+                    # owned recipe — the exemption in the branch above.
                     #
-                    # That deliberate duplicate now collides with
-                    # uq_recipe_user_source_slug, and an IntegrityError here
-                    # rolls back the whole merge, orphaning the guest's data at
-                    # login. Clear source_slug so the row leaves the partial
-                    # index's coverage.
+                    # No current path can produce that row. Guests cannot
+                    # publish: the SPA replaces the publish toggle with a
+                    # "log in to publish" link, and the server does not rely on
+                    # that — _gate_is_public() forces is_public=False whenever
+                    # user_id is None, on create and update alike. Rows that
+                    # predate the gate were reassigned or unpublished by
+                    # migration e91b47a2c5d3 (2026-07-07).
                     #
-                    # This loses no identity that matters: the row is being kept
-                    # precisely because it is a published page in its own right,
-                    # and its own `slug` — not "saved from X" — is what
-                    # identifies it from here on. Same reasoning as the Cornbread
-                    # decision in the Sprint 6 runbook §5c: once a row is
-                    # published under its own slug, every code path that reads
-                    # source_slug is short-circuited.
+                    # So this is a legacy-data guard, NOT a live conflict with
+                    # KAN-213's uq_recipe_user_source_slug. Stated plainly
+                    # because the reverse was claimed on review: if such a row
+                    # somehow existed, reassigning it would raise IntegrityError
+                    # and roll back the ENTIRE merge, orphaning the guest's
+                    # recipes and cookbooks at the moment of login. Clearing
+                    # source_slug takes it out of the partial index's coverage
+                    # so a single legacy row cannot cost someone their data.
+                    #
+                    # Nothing of value is lost: the row is kept precisely
+                    # because it is a published page in its own right, so its
+                    # own `slug` identifies it from here on.
                     recipe.source_slug = None
 
                 recipe.user_id = user.id

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -144,6 +144,27 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                     db.session.delete(recipe)
                     continue
 
+                if existing_id is not None:
+                    # KAN-213 × KAN-186. This is the public-row exemption above:
+                    # the account already owns a row for this public recipe, but
+                    # this guest row is itself published, so it is reassigned
+                    # rather than deleted — deleting would take a live page down.
+                    #
+                    # That deliberate duplicate now collides with
+                    # uq_recipe_user_source_slug, and an IntegrityError here
+                    # rolls back the whole merge, orphaning the guest's data at
+                    # login. Clear source_slug so the row leaves the partial
+                    # index's coverage.
+                    #
+                    # This loses no identity that matters: the row is being kept
+                    # precisely because it is a published page in its own right,
+                    # and its own `slug` — not "saved from X" — is what
+                    # identifies it from here on. Same reasoning as the Cornbread
+                    # decision in the Sprint 6 runbook §5c: once a row is
+                    # published under its own slug, every code path that reads
+                    # source_slug is short-circuited.
+                    recipe.source_slug = None
+
                 recipe.user_id = user.id
                 recipe.guest_session_id = None
                 for key in _recipe_identity_keys(recipe):

--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -222,6 +222,16 @@ def update_recipe(user_id, guest_session_id, recipe_id):
 
         return jsonify(recipe.to_dict()), 200
 
+    except db_recipe_repository.RecipeDuplicateError as e:
+        # KAN-213: same R1 refusal as create_recipe — an update that trips the
+        # (owner, source_slug) partial unique index must reach the client as a
+        # deliberate 409 instead of a generic 500. The repository already
+        # re-raises RecipeDuplicateError from update_recipe; catching it here
+        # keeps the PUT contract symmetric with the POST route above.
+        return (
+            jsonify({"error": db_recipe_repository.RECIPE_DUPLICATE_ERROR, "code": e.code}),
+            409,
+        )
     except db_recipe_repository.RecipeSlugError:
         # Fixed message, not str(e): exception text must never reach clients.
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400

--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -146,6 +146,17 @@ def create_recipe(user_id, guest_session_id):
             jsonify({"error": db_recipe_repository.RECIPE_OWNERSHIP_ERROR, "code": e.code}),
             409,
         )
+    except db_recipe_repository.RecipeDuplicateError as e:
+        # KAN-213: 409, not 500. The database refused a second save of the same
+        # public recipe by the same owner — a deliberate refusal from the
+        # partial unique index, not an internal failure. Sprint 6 R1 named
+        # exactly this: a working constraint reported as 500 would tell the user
+        # to check their connection when the real answer is "you already have
+        # this". Same fixed-string + `code` contract as the ownership refusal.
+        return (
+            jsonify({"error": db_recipe_repository.RECIPE_DUPLICATE_ERROR, "code": e.code}),
+            409,
+        )
     except db_recipe_repository.RecipeSlugError:
         # Fixed message, not str(e): exception text must never reach clients.
         return jsonify({"error": db_recipe_repository.PUBLIC_SLUG_REQUIRED_ERROR}), 400

--- a/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
+++ b/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
@@ -117,9 +117,21 @@ def _clear_blob_key_sql(dialect_name):
     nothing about sourceSlug therefore pulls the stale value back out of the
     untouched blob and writes it to the column — resurrecting the very duplicate
     this pre-pass just cleared, and tripping the new index on the next write.
+
+    ``recipe.data`` is PostgreSQL **json**, not **jsonb** (migration
+    b8896f552679 line 37 creates it as ``sa.JSON()``, which SQLAlchemy compiles
+    to ``JSON`` on PostgreSQL). The key-deletion ``-`` operator is defined only
+    for ``jsonb``, so ``data - 'sourceSlug'`` raises *operator does not exist*
+    and aborts the migration — which would abort the deploy. Cast through
+    ``jsonb`` and back.
+
+    Worth noting where this would have bitten: the UPDATE only runs when a
+    duplicate exists, and production has none. It would have passed in
+    production and failed in exactly the dirty environment the pre-pass exists
+    to serve. Caught by Copilot review on PR #273.
     """
     if dialect_name == "postgresql":
-        return "data = data - 'sourceSlug'"
+        return "data = (data::jsonb - 'sourceSlug')::json"
     return "data = json_remove(data, '$.sourceSlug')"
 
 

--- a/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
+++ b/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
@@ -1,12 +1,22 @@
-"""Enforce one saved copy per (owner, source_slug)
+"""Enforce one row per (owner, recipe identity)
 
 KAN-213. Adds two partial unique indexes so the database, not the SPA, refuses
 a duplicate saved recipe:
 
-    uq_recipe_user_source_slug   UNIQUE (user_id, source_slug)
-        WHERE source_slug IS NOT NULL AND user_id IS NOT NULL
-    uq_recipe_guest_source_slug  UNIQUE (guest_session_id, source_slug)
-        WHERE source_slug IS NOT NULL AND guest_session_id IS NOT NULL
+    uq_recipe_user_recipe_identity   UNIQUE (user_id, COALESCE(source_slug, slug))
+    uq_recipe_guest_recipe_identity  UNIQUE (guest_session_id, COALESCE(source_slug, slug))
+    both WHERE COALESCE(source_slug, slug) IS NOT NULL AND <scope> IS NOT NULL
+
+The key is COALESCE(source_slug, slug), not source_slug alone. A recipe's
+identity is `{source_slug, slug}` everywhere else in the codebase —
+auth_api_bp._recipe_identity_keys() and the SPA's INV-1
+(`r.sourceSlug === slug || r.slug === slug`). Keying on source_slug alone left a
+reachable hole, found by Codex review on PR #273: an owner holding the PUBLISHED
+row itself (slug='x', source_slug NULL) who saves /r/x again gets a copy with
+source_slug='x' that collides with nothing, because the published row sits
+outside a source_slug-only partial index. Two rows cannot collide via the slug
+side alone -- `slug` is already globally unique -- so every collision this
+catches involves at least one saved copy, which is the intent.
 
 Exactly one of (user_id, guest_session_id) is non-NULL per row, so two partial
 indexes are the correct shape rather than one composite constraint — the same
@@ -92,31 +102,66 @@ depends_on = None
 
 logger = logging.getLogger("alembic.runtime.migration")
 
+# A recipe's identity: the public recipe it was saved from, or its own page when
+# it is the original. Matches models/recipe.py, _recipe_identity_keys(), and the
+# SPA's INV-1 (`r.sourceSlug === slug || r.slug === slug`).
+_IDENTITY = "coalesce(source_slug, slug)"
 
-def _clear_duplicate_source_slugs(bind, scope_col):
-    """Keep the earliest row per (scope, source_slug); NULL source_slug on the rest.
 
-    Returns the number of rows cleared, so the caller can log a real number
+def _clear_blob_key_sql(dialect_name):
+    """Dialect-specific SQL to drop ``sourceSlug`` from the ``data`` JSON blob.
+
+    Clearing the column alone is not durable: ``update_recipe`` rebuilds the
+    blob as ``{**(recipe.data or {}), **recipe_data}`` and then restages
+    ``recipe.source_slug = data.get("sourceSlug")``. A partial PUT that says
+    nothing about sourceSlug therefore pulls the stale value back out of the
+    untouched blob and writes it to the column — resurrecting the very duplicate
+    this pre-pass just cleared, and tripping the new index on the next write.
+    """
+    if dialect_name == "postgresql":
+        return "data = data - 'sourceSlug'"
+    return "data = json_remove(data, '$.sourceSlug')"
+
+
+def _clear_duplicate_identities(bind, scope_col):
+    """Keep one row per (scope, identity); clear ``source_slug`` on the rest.
+
+    Identity is ``COALESCE(source_slug, slug)`` — the same key the new indexes
+    use, and the same one ``_recipe_identity_keys`` and the SPA's INV-1 use.
+
+    Ordering encodes the survivor rule: ``source_slug IS NULL`` first, so the
+    author's own published row wins over a saved copy of it, then oldest first.
+    That matches runbook §4 rule 2 and is also the only workable choice — the
+    loser is resolved by clearing its ``source_slug``, which a slug-derived row
+    does not have. Two rows can never collide via the slug side alone, because
+    ``slug`` is already globally unique, so a survivor always exists.
+
+    Returns the number of rows cleared so the caller can log a real number
     rather than claiming success blindly.
     """
     rows = bind.execute(
         sa.text(
-            f"SELECT id, {scope_col} AS scope, source_slug "  # noqa: S608 - fixed literal
+            f"SELECT id, {scope_col} AS scope, "  # noqa: S608 - fixed literal
+            "COALESCE(source_slug, slug) AS identity "
             "FROM recipe "
-            f"WHERE source_slug IS NOT NULL AND {scope_col} IS NOT NULL "
-            f"ORDER BY {scope_col}, source_slug, created_at, id"
+            f"WHERE COALESCE(source_slug, slug) IS NOT NULL AND {scope_col} IS NOT NULL "
+            f"ORDER BY {scope_col}, COALESCE(source_slug, slug), "
+            "CASE WHEN source_slug IS NULL THEN 0 ELSE 1 END, created_at, id"
         )
     ).fetchall()
 
+    blob_clear = _clear_blob_key_sql(bind.dialect.name)
     seen: set = set()
     cleared = 0
     for row in rows:
-        key = (row.scope, row.source_slug)
+        key = (row.scope, row.identity)
         if key not in seen:
             seen.add(key)
-            continue  # earliest row for this (scope, source_slug) — keep it
+            continue  # survivor for this (scope, identity) — leave it alone
         bind.execute(
-            sa.text("UPDATE recipe SET source_slug = NULL WHERE id = :id"),
+            sa.text(  # noqa: S608 - blob_clear is one of two fixed literals
+                f"UPDATE recipe SET source_slug = NULL, {blob_clear} WHERE id = :id"
+            ),
             {"id": row.id},
         )
         cleared += 1
@@ -132,8 +177,8 @@ def upgrade():
     if bind.dialect.name == "postgresql":
         op.execute("LOCK TABLE recipe IN ACCESS EXCLUSIVE MODE")
 
-    cleared = _clear_duplicate_source_slugs(bind, "user_id")
-    cleared += _clear_duplicate_source_slugs(bind, "guest_session_id")
+    cleared = _clear_duplicate_identities(bind, "user_id")
+    cleared += _clear_duplicate_identities(bind, "guest_session_id")
     if cleared:
         # Expected to be 0 in production (purged by hand, gates verified empty).
         # A non-zero count here means duplicates appeared after that purge and
@@ -144,24 +189,20 @@ def upgrade():
             cleared,
         )
 
-    op.create_index(
-        "uq_recipe_user_source_slug",
-        "recipe",
-        ["user_id", "source_slug"],
-        unique=True,
-        postgresql_where=sa.text("source_slug IS NOT NULL AND user_id IS NOT NULL"),
-        sqlite_where=sa.text("source_slug IS NOT NULL AND user_id IS NOT NULL"),
-    )
-    op.create_index(
-        "uq_recipe_guest_source_slug",
-        "recipe",
-        ["guest_session_id", "source_slug"],
-        unique=True,
-        postgresql_where=sa.text("source_slug IS NOT NULL AND guest_session_id IS NOT NULL"),
-        sqlite_where=sa.text("source_slug IS NOT NULL AND guest_session_id IS NOT NULL"),
-    )
+    for name, scope in (
+        ("uq_recipe_user_recipe_identity", "user_id"),
+        ("uq_recipe_guest_recipe_identity", "guest_session_id"),
+    ):
+        op.create_index(
+            name,
+            "recipe",
+            [sa.text(scope), sa.text(_IDENTITY)],
+            unique=True,
+            postgresql_where=sa.text(f"{_IDENTITY} IS NOT NULL AND {scope} IS NOT NULL"),
+            sqlite_where=sa.text(f"{_IDENTITY} IS NOT NULL AND {scope} IS NOT NULL"),
+        )
 
 
 def downgrade():
-    op.drop_index("uq_recipe_guest_source_slug", table_name="recipe")
-    op.drop_index("uq_recipe_user_source_slug", table_name="recipe")
+    op.drop_index("uq_recipe_guest_recipe_identity", table_name="recipe")
+    op.drop_index("uq_recipe_user_recipe_identity", table_name="recipe")

--- a/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
+++ b/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
@@ -13,11 +13,30 @@ indexes are the correct shape rather than one composite constraint — the same
 reasoning as the cookbook pair in b7e2a9c4d1f8. Both ship together or neither
 (Sprint 6 R3): guests key on guest_session_id, which is the KAN-186 path.
 
-Partial on ``source_slug IS NOT NULL`` deliberately. Generated and manually
-entered recipes carry no source_slug and are the large majority of the table;
-they have no provenance to collide on. A name-based constraint was rejected —
-two genuinely different recipes may legitimately share a title. This closes
-KAN-213's class and does NOT make the table duplicate-free.
+Partial on ``source_slug IS NOT NULL`` deliberately, and the scope is narrower
+than "most of the table is excluded" suggests. Only ``origin = 'saved'`` rows
+carry a source_slug (the SPA sets origin and sourceSlug together when saving
+from a public page), so:
+
+    These indexes constrain only copies a user took from someone else's public
+    page. They do not constrain a single recipe a user authored.
+
+Recorded ratio: user 1 held 112 NULL-source rows against 4 rows in source_slug
+duplicate groups — roughly 3% coverage for that user.
+
+That is still the right corner, and not by rationalisation: a saved copy is the
+only case where "these two rows are the same recipe" is a machine-checkable
+fact, because the copy records what it was copied from. Two separately generated
+recipes have no such identity, and a name-based constraint was rejected — two
+genuinely different recipes may legitimately share a title.
+
+The evidence agrees the corner is where the duplicates were: all 11 public
+duplicate rows carried a source_slug, and both constraint blockers were
+source_slug pairs. KAN-220 explains why that is not luck — the ghost-session
+path (expired session silently downgraded to guest before a save from a public
+page) produces source_slug-bearing rows by construction.
+
+This closes KAN-213's class and does NOT make the table duplicate-free.
 
 --------------------------------------------------------------------------
 Why NOT ``CREATE INDEX CONCURRENTLY``

--- a/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
+++ b/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
@@ -1,0 +1,148 @@
+"""Enforce one saved copy per (owner, source_slug)
+
+KAN-213. Adds two partial unique indexes so the database, not the SPA, refuses
+a duplicate saved recipe:
+
+    uq_recipe_user_source_slug   UNIQUE (user_id, source_slug)
+        WHERE source_slug IS NOT NULL AND user_id IS NOT NULL
+    uq_recipe_guest_source_slug  UNIQUE (guest_session_id, source_slug)
+        WHERE source_slug IS NOT NULL AND guest_session_id IS NOT NULL
+
+Exactly one of (user_id, guest_session_id) is non-NULL per row, so two partial
+indexes are the correct shape rather than one composite constraint — the same
+reasoning as the cookbook pair in b7e2a9c4d1f8. Both ship together or neither
+(Sprint 6 R3): guests key on guest_session_id, which is the KAN-186 path.
+
+Partial on ``source_slug IS NOT NULL`` deliberately. Generated and manually
+entered recipes carry no source_slug and are the large majority of the table;
+they have no provenance to collide on. A name-based constraint was rejected —
+two genuinely different recipes may legitimately share a title. This closes
+KAN-213's class and does NOT make the table duplicate-free.
+
+--------------------------------------------------------------------------
+Why NOT ``CREATE INDEX CONCURRENTLY``
+--------------------------------------------------------------------------
+The Sprint 6 runbook (specs/KAN-213_DEDUP_QUERIES.md §6) originally specified
+CONCURRENTLY inside an ``op.get_context().autocommit_block()``. That is the
+wrong tool here, and the cookbook migration already learned why.
+
+``flask-backend-migrate`` runs as a Cloud Run Job *while the previous Flask
+revision is still serving traffic*. CONCURRENTLY takes no write lock, so a
+duplicate can be inserted during the build — and a unique index build that
+meets a violation does not merely fail, it leaves an **INVALID** index behind
+that silently enforces nothing until someone reindexes it. That is precisely
+the project's recurring failure mode: a guard that appears to exist and does
+not fire.
+
+An ACCESS EXCLUSIVE lock closes that window. It is affordable because `recipe`
+is a small table (hundreds of rows), where the index build is sub-second.
+CONCURRENTLY earns its complexity on large hot tables; this is not one.
+
+--------------------------------------------------------------------------
+Why the pre-pass NULLs rather than deletes
+--------------------------------------------------------------------------
+Creating a unique index over dirty data fails and aborts the deploy. Production
+was purged by hand on 2026-08-08/09 and both gates returned zero rows, so this
+pre-pass is expected to be a no-op there. It exists because (a) other
+environments may hold duplicates, and (b) nothing prevents a new duplicate
+between that purge and this deploy — the guard being added here is the very
+thing that does not exist yet.
+
+It clears ``source_slug`` on the later rows instead of deleting them. A
+migration must not destroy user content unattended, and the recipe body is
+fully preserved; only the "saved from" pointer is dropped on the loser, which
+takes that row out of the partial index's coverage. Deleting duplicate recipes
+in production is Adam's call (Sprint 6 D4), not a migration's.
+
+Revision ID: c8f3b71d20a4
+Revises: e4a7b2d9c5f1
+Create Date: 2026-08-09 00:00:00.000000
+
+"""
+
+import logging
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8f3b71d20a4"
+down_revision = "e4a7b2d9c5f1"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def _clear_duplicate_source_slugs(bind, scope_col):
+    """Keep the earliest row per (scope, source_slug); NULL source_slug on the rest.
+
+    Returns the number of rows cleared, so the caller can log a real number
+    rather than claiming success blindly.
+    """
+    rows = bind.execute(
+        sa.text(
+            f"SELECT id, {scope_col} AS scope, source_slug "  # noqa: S608 - fixed literal
+            "FROM recipe "
+            f"WHERE source_slug IS NOT NULL AND {scope_col} IS NOT NULL "
+            f"ORDER BY {scope_col}, source_slug, created_at, id"
+        )
+    ).fetchall()
+
+    seen: set = set()
+    cleared = 0
+    for row in rows:
+        key = (row.scope, row.source_slug)
+        if key not in seen:
+            seen.add(key)
+            continue  # earliest row for this (scope, source_slug) — keep it
+        bind.execute(
+            sa.text("UPDATE recipe SET source_slug = NULL WHERE id = :id"),
+            {"id": row.id},
+        )
+        cleared += 1
+    return cleared
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    # Hold writers out of the gap between the de-dup pass and the index build.
+    # Held until this migration's transaction commits, i.e. past index creation.
+    # Postgres only: SQLite has no LOCK TABLE and runs single-connection anyway.
+    if bind.dialect.name == "postgresql":
+        op.execute("LOCK TABLE recipe IN ACCESS EXCLUSIVE MODE")
+
+    cleared = _clear_duplicate_source_slugs(bind, "user_id")
+    cleared += _clear_duplicate_source_slugs(bind, "guest_session_id")
+    if cleared:
+        # Expected to be 0 in production (purged by hand, gates verified empty).
+        # A non-zero count here means duplicates appeared after that purge and
+        # is worth seeing in the job log rather than passing silently.
+        logger.warning(
+            "KAN-213: cleared source_slug on %d duplicate recipe row(s) before "
+            "creating the unique indexes",
+            cleared,
+        )
+
+    op.create_index(
+        "uq_recipe_user_source_slug",
+        "recipe",
+        ["user_id", "source_slug"],
+        unique=True,
+        postgresql_where=sa.text("source_slug IS NOT NULL AND user_id IS NOT NULL"),
+        sqlite_where=sa.text("source_slug IS NOT NULL AND user_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_recipe_guest_source_slug",
+        "recipe",
+        ["guest_session_id", "source_slug"],
+        unique=True,
+        postgresql_where=sa.text("source_slug IS NOT NULL AND guest_session_id IS NOT NULL"),
+        sqlite_where=sa.text("source_slug IS NOT NULL AND guest_session_id IS NOT NULL"),
+    )
+
+
+def downgrade():
+    op.drop_index("uq_recipe_guest_source_slug", table_name="recipe")
+    op.drop_index("uq_recipe_user_source_slug", table_name="recipe")

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -14,11 +14,17 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     # partial indexes are the right shape rather than one composite constraint
     # — the same reasoning as cookbook's uq_cookbook_* pair.
     #
-    # Partial on `source_slug IS NOT NULL` by design: generated and manually
-    # entered recipes have no provenance to collide on and are the large
-    # majority of the table. A name-based constraint was rejected — two
-    # genuinely different recipes may share a title. So this closes KAN-213's
-    # class; it does not make the table duplicate-free.
+    # Partial on `source_slug IS NOT NULL` by design, and narrower than that
+    # reads: only `origin='saved'` rows carry a source_slug, so these indexes
+    # constrain COPIES A USER TOOK from someone else's public page and do not
+    # constrain a single recipe a user authored (~3% of user 1's rows).
+    #
+    # Still the right corner: a saved copy is the only case where "these two
+    # rows are the same recipe" is a machine-checkable fact. Two separately
+    # generated recipes have no such identity, and a name-based constraint was
+    # rejected — two genuinely different recipes may share a title. See
+    # migration c8f3b71d20a4 for the evidence and KAN-220 for why the covered
+    # corner is where the real duplicates come from.
     #
     # Declared on the model as well as in migration c8f3b71d20a4 so that
     # `db.create_all()` (tests, fresh local dev) builds the same indexes the

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -30,22 +30,36 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     # `db.create_all()` (tests, fresh local dev) builds the same indexes the
     # migration builds in production. Without this the suite would pass against
     # a schema that cannot refuse anything.
+    # The key is COALESCE(source_slug, slug), not source_slug alone. A recipe's
+    # identity is `{source_slug, slug}` everywhere else in the codebase —
+    # auth_api_bp._recipe_identity_keys() and the SPA's INV-1
+    # (`r.sourceSlug === slug || r.slug === slug`). Keying on source_slug alone
+    # left a reachable hole: an owner who holds the PUBLISHED row itself
+    # (slug='x', source_slug NULL) and saves /r/x again gets a copy with
+    # source_slug='x' that collides with nothing, because the published row sits
+    # outside a source_slug-only partial index. Caught by Codex review on #273.
+    #
+    # COALESCE puts both rows on the same key. Two rows cannot collide via the
+    # slug side alone — `slug` is already globally unique — so every collision
+    # this catches involves at least one saved copy, which is the intent.
+    _IDENTITY = "coalesce(source_slug, slug)"
+
     __table_args__ = (
         Index(
-            "uq_recipe_user_source_slug",
-            "user_id",
-            "source_slug",
+            "uq_recipe_user_recipe_identity",
+            text("user_id"),
+            text(_IDENTITY),
             unique=True,
-            postgresql_where=text("source_slug IS NOT NULL AND user_id IS NOT NULL"),
-            sqlite_where=text("source_slug IS NOT NULL AND user_id IS NOT NULL"),
+            postgresql_where=text(f"{_IDENTITY} IS NOT NULL AND user_id IS NOT NULL"),
+            sqlite_where=text(f"{_IDENTITY} IS NOT NULL AND user_id IS NOT NULL"),
         ),
         Index(
-            "uq_recipe_guest_source_slug",
-            "guest_session_id",
-            "source_slug",
+            "uq_recipe_guest_recipe_identity",
+            text("guest_session_id"),
+            text(_IDENTITY),
             unique=True,
-            postgresql_where=text("source_slug IS NOT NULL AND guest_session_id IS NOT NULL"),
-            sqlite_where=text("source_slug IS NOT NULL AND guest_session_id IS NOT NULL"),
+            postgresql_where=text(f"{_IDENTITY} IS NOT NULL AND guest_session_id IS NOT NULL"),
+            sqlite_where=text(f"{_IDENTITY} IS NOT NULL AND guest_session_id IS NOT NULL"),
         ),
     )
 

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -1,12 +1,48 @@
 from datetime import datetime
 
 from sqlalchemy import JSON as GenericJSON
+from sqlalchemy import Index, text
 from sqlalchemy.ext.mutable import MutableDict
 
 from extensions import db
 
 
 class Recipe(db.Model):  # type: ignore[name-defined, misc]
+    # KAN-213 — the duplicate invariant lives here, not in the SPA.
+    #
+    # Exactly one of (user_id, guest_session_id) is non-NULL on a row, so two
+    # partial indexes are the right shape rather than one composite constraint
+    # — the same reasoning as cookbook's uq_cookbook_* pair.
+    #
+    # Partial on `source_slug IS NOT NULL` by design: generated and manually
+    # entered recipes have no provenance to collide on and are the large
+    # majority of the table. A name-based constraint was rejected — two
+    # genuinely different recipes may share a title. So this closes KAN-213's
+    # class; it does not make the table duplicate-free.
+    #
+    # Declared on the model as well as in migration c8f3b71d20a4 so that
+    # `db.create_all()` (tests, fresh local dev) builds the same indexes the
+    # migration builds in production. Without this the suite would pass against
+    # a schema that cannot refuse anything.
+    __table_args__ = (
+        Index(
+            "uq_recipe_user_source_slug",
+            "user_id",
+            "source_slug",
+            unique=True,
+            postgresql_where=text("source_slug IS NOT NULL AND user_id IS NOT NULL"),
+            sqlite_where=text("source_slug IS NOT NULL AND user_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_recipe_guest_source_slug",
+            "guest_session_id",
+            "source_slug",
+            unique=True,
+            postgresql_where=text("source_slug IS NOT NULL AND guest_session_id IS NOT NULL"),
+            sqlite_where=text("source_slug IS NOT NULL AND guest_session_id IS NOT NULL"),
+        ),
+    )
+
     id = db.Column(db.String(36), primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     guest_session_id = db.Column(db.String(64), nullable=True, index=True)

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -11,7 +11,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from sqlalchemy import and_, or_
 from sqlalchemy.exc import IntegrityError
@@ -99,6 +99,40 @@ RECIPE_OWNERSHIP_ERROR = (
 OWNERSHIP_CODE_OTHER_ACCOUNT = "OWNERSHIP_OTHER_ACCOUNT"
 OWNERSHIP_CODE_OTHER_GUEST_SESSION = "OWNERSHIP_OTHER_GUEST_SESSION"
 OWNERSHIP_CODE_ORPHANED_GUEST_ROW = "OWNERSHIP_ORPHANED_GUEST_ROW"
+
+
+# Also returned verbatim by the API routes (fixed string, same rationale as
+# PUBLIC_SLUG_REQUIRED_ERROR above).
+RECIPE_DUPLICATE_ERROR = "You already have this recipe saved."
+
+# Machine-readable discriminator, sent alongside the message as `code` — same
+# contract as the OWNERSHIP_CODE_* constants. A duplicate is a *successful*
+# outcome from the user's point of view (the recipe they wanted is in their
+# cookbook), which is the opposite of the ownership refusals, so the SPA needs
+# to tell them apart to choose between an error toast and a benign one.
+DUPLICATE_CODE_ALREADY_SAVED = "RECIPE_ALREADY_SAVED"
+
+
+class RecipeDuplicateError(ValueError):
+    """This owner already has a row for this source_slug — refuse the write (KAN-213).
+
+    Raised when the database refuses the second save of the same public recipe
+    by the same owner. The refusal itself comes from a partial unique index
+    (uq_recipe_user_source_slug / uq_recipe_guest_source_slug, migration
+    c8f3b71d20a4), not from application code: a check-then-write test in the
+    SPA cannot close a two-tab race by construction, which is why six previous
+    fixes at six different layers did not hold.
+
+    This exception exists so that refusal reaches the client as a 409 rather
+    than a 500. Sprint 6 named that the dominant risk (R1): the repository
+    catches broadly and returns None, which the blueprint answers with 500, so
+    a working constraint would have looked like a server outage and told the
+    user to check their connection.
+    """
+
+    def __init__(self, message: str, code: str = DUPLICATE_CODE_ALREADY_SAVED):
+        super().__init__(message)
+        self.code = code
 
 
 class RecipeOwnershipError(ValueError):
@@ -257,11 +291,45 @@ def _resolve_public_slug(
     return candidate
 
 
+def _duplicate_source_slug_owner(
+    recipe_data: Dict[str, Any],
+    recipe_id: str,
+    owner_scope: Optional[Tuple[Optional[int], Optional[str]]],
+) -> bool:
+    """Did this write lose to an existing row on (owner, source_slug)? (KAN-213)
+
+    Called only after a rollback. Constraint names in the IntegrityError are
+    backend-specific (SQLite vs PostgreSQL), so — exactly as with the slug race
+    above — the portable signal is to ask the database who owns the key now.
+
+    Scoped to the acting owner on purpose: two different people saving the same
+    public recipe is the product working, not a duplicate, and the partial
+    indexes are per-owner for that reason.
+    """
+    if owner_scope is None:
+        return False
+    source_slug = recipe_data.get("sourceSlug")
+    if source_slug is None:
+        return False  # NULL source_slug is outside both partial indexes
+
+    user_id, guest_session_id = owner_scope
+    query = Recipe.query.filter(Recipe.source_slug == source_slug, Recipe.id != recipe_id)
+    if user_id is not None:
+        query = query.filter(Recipe.user_id == user_id)
+    elif guest_session_id is not None:
+        query = query.filter(Recipe.guest_session_id == guest_session_id)
+    else:
+        return False  # neither scope set — no partial index covers this row
+
+    return query.first() is not None
+
+
 def _commit_publish_retrying(
     stage: Callable[[Dict[str, Any]], Recipe],
     recipe_data: Dict[str, Any],
     recipe_id: str,
     current_slug: Optional[str] = None,
+    owner_scope: Optional[Tuple[Optional[int], Optional[str]]] = None,
 ) -> Recipe:
     """Stage and commit a recipe write, retrying slug collisions lost to races.
 
@@ -309,7 +377,22 @@ def _commit_publish_retrying(
                 ).first()
                 is not None
             )
-            if not lost_slug_race or attempts > _SLUG_COMMIT_RETRIES:
+            if not lost_slug_race:
+                # KAN-213: the (owner, source_slug) index refused a second save
+                # of the same public recipe. Distinguish it from a genuine
+                # integrity failure BEFORE re-raising, so it can reach the
+                # client as a 409 refusal instead of a 500 (R1). Checked only
+                # on the non-slug-race path, so the slug retry above is
+                # untouched.
+                if _duplicate_source_slug_owner(recipe_data, recipe_id, owner_scope):
+                    logger.info(
+                        "Recipe %s refused: owner already has source_slug %r",
+                        sanitize_log_value(recipe_id),
+                        sanitize_log_value(recipe_data.get("sourceSlug")),
+                    )
+                    raise RecipeDuplicateError(RECIPE_DUPLICATE_ERROR)
+                raise
+            if attempts > _SLUG_COMMIT_RETRIES:
                 raise
             skip.add(attempted_slug)
             logger.warning(
@@ -698,7 +781,11 @@ def create_recipe(
                 return existing  # type: ignore[no-any-return]
 
             return _commit_publish_retrying(
-                stage_existing, recipe_data_with_id, recipe_id, existing.slug
+                stage_existing,
+                recipe_data_with_id,
+                recipe_id,
+                existing.slug,
+                owner_scope=(existing.user_id, existing.guest_session_id),
             )
 
         recipe_name = recipe_data.get("name", "Unnamed Recipe")
@@ -728,7 +815,12 @@ def create_recipe(
             db.session.add(recipe)
             return recipe
 
-        recipe = _commit_publish_retrying(stage_new, recipe_data_with_id, recipe_id)
+        recipe = _commit_publish_retrying(
+            stage_new,
+            recipe_data_with_id,
+            recipe_id,
+            owner_scope=(user_id, None if user_id is not None else guest_session_id),
+        )
 
         logger.info(
             "Created recipe %s for user %s",
@@ -737,7 +829,13 @@ def create_recipe(
         )
         return recipe
 
-    except (RecipeSlugError, CanonicalRecipeError, ManualRecipeError, RecipeOwnershipError):
+    except (
+        RecipeSlugError,
+        CanonicalRecipeError,
+        ManualRecipeError,
+        RecipeOwnershipError,
+        RecipeDuplicateError,
+    ):
         raise
     except Exception as e:
         logger.error("Error creating recipe: %s", sanitize_log_value(e))
@@ -841,13 +939,22 @@ def update_recipe(
             return recipe
 
         updated = _commit_publish_retrying(
-            stage_update, recipe_data_with_id, recipe_id, recipe.slug
+            stage_update,
+            recipe_data_with_id,
+            recipe_id,
+            recipe.slug,
+            owner_scope=(recipe.user_id, recipe.guest_session_id),
         )
 
         logger.info("Updated recipe %s", sanitize_log_value(recipe_id))
         return updated
 
-    except (RecipeSlugError, CanonicalRecipeError, ManualRecipeError):
+    except (
+        RecipeSlugError,
+        CanonicalRecipeError,
+        ManualRecipeError,
+        RecipeDuplicateError,
+    ):
         raise
     except Exception as e:
         logger.error(

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import IntegrityError
 
 from extensions import db
@@ -291,6 +291,36 @@ def _resolve_public_slug(
     return candidate
 
 
+def _pin_source_slug_to_column(
+    merged: Dict[str, Any], recipe_data: Dict[str, Any], existing: Recipe
+) -> None:
+    """Keep ``sourceSlug`` in the merged blob honest when the payload omits it.
+
+    Exactly the rule already applied to ``slug`` above, for the same reason.
+    ``source_slug`` is a column mirroring ``data['sourceSlug']``, and writes
+    rebuild the blob as ``{**(existing.data or {}), **recipe_data}`` before
+    restaging ``recipe.source_slug = data.get("sourceSlug")``. So anything that
+    clears the column without also clearing the blob — the KAN-213 migration's
+    pre-pass, the guest-merge legacy guard — is silently undone by the next
+    partial PUT, which pulls the stale value out of the untouched blob and
+    writes it back to the column. That resurrects a cleared duplicate and then
+    trips the unique index on a write the user never meant as a save.
+
+    The column is authoritative. Key presence, not truthiness: a payload that
+    explicitly sends ``sourceSlug: null`` is the caller clearing it, and that
+    value goes through unchanged.
+
+    Found by Codex review on PR #273 — reproduced by
+    ``test_clearing_the_column_survives_a_later_partial_update``.
+    """
+    if "sourceSlug" in recipe_data:
+        return
+    if existing.source_slug is not None:
+        merged["sourceSlug"] = existing.source_slug
+    else:
+        merged.pop("sourceSlug", None)
+
+
 def _duplicate_source_slug_owner(
     recipe_data: Dict[str, Any],
     recipe_id: str,
@@ -308,12 +338,17 @@ def _duplicate_source_slug_owner(
     """
     if owner_scope is None:
         return False
-    source_slug = recipe_data.get("sourceSlug")
-    if source_slug is None:
-        return False  # NULL source_slug is outside both partial indexes
+    # Mirrors the index key COALESCE(source_slug, slug): a row's identity is the
+    # public recipe it points at, or its own page when it is the original.
+    identity = recipe_data.get("sourceSlug") or recipe_data.get("slug")
+    if identity is None:
+        return False  # no identity — outside both partial indexes
 
     user_id, guest_session_id = owner_scope
-    query = Recipe.query.filter(Recipe.source_slug == source_slug, Recipe.id != recipe_id)
+    query = Recipe.query.filter(
+        func.coalesce(Recipe.source_slug, Recipe.slug) == identity,
+        Recipe.id != recipe_id,
+    )
     if user_id is not None:
         query = query.filter(Recipe.user_id == user_id)
     elif guest_session_id is not None:
@@ -759,6 +794,7 @@ def create_recipe(
                     merged["slug"] = existing.slug
                 else:
                     merged.pop("slug", None)
+            _pin_source_slug_to_column(merged, recipe_data, existing)
             recipe_data_with_id = _gate_is_public(merged, user_id)
             next_origin = _resolve_origin(existing.origin, recipe_data)
             _gate_manual_publish(next_origin, recipe_data_with_id)
@@ -918,6 +954,8 @@ def update_recipe(
                 recipe_data_with_id["slug"] = recipe.slug
             else:
                 recipe_data_with_id.pop("slug", None)
+
+        _pin_source_slug_to_column(recipe_data_with_id, recipe_data, recipe)
 
         next_origin = _resolve_origin(recipe.origin, recipe_data)
         _gate_manual_publish(next_origin, recipe_data_with_id)

--- a/tests/test_migration_recipe_source_slug_unique.py
+++ b/tests/test_migration_recipe_source_slug_unique.py
@@ -262,3 +262,29 @@ def test_index_refuses_a_copy_of_your_own_published_recipe(tmp_path):
         # Another owner saving that same public recipe is still fine.
         _insert(conn, [("other", 2, None, "vegan-cornbread", "2026-01-02")])
         assert conn.execute(sa.text("SELECT count(*) FROM recipe")).scalar() == 2
+
+
+def test_postgres_blob_clear_casts_through_jsonb():
+    """`recipe.data` is PostgreSQL json, not jsonb — the `-` operator is jsonb-only.
+
+    SQLite cannot catch this: the whole suite runs on SQLite, where the blob
+    clear is `json_remove`. On PostgreSQL, `data - 'sourceSlug'` raises
+    *operator does not exist* and aborts the migration, taking the deploy with
+    it (migration b8896f552679 creates `data` as `sa.JSON()`, which SQLAlchemy
+    compiles to `JSON`).
+
+    Worse, the UPDATE only runs when a duplicate exists. Production has none, so
+    it would have passed there and failed in exactly the dirty environment the
+    pre-pass exists to serve — a guard broken only on the day it is needed.
+    Asserting the emitted SQL is weak coverage, but it is the coverage available
+    without a PostgreSQL fixture, and it fails if someone drops the casts.
+    """
+    mig = _load_migration()
+
+    pg = mig._clear_blob_key_sql("postgresql")
+    assert (
+        "::jsonb" in pg and "::json" in pg
+    ), f"PostgreSQL blob clear must cast through jsonb, got: {pg}"
+    assert "- 'sourceSlug'" in pg
+
+    assert mig._clear_blob_key_sql("sqlite") == "data = json_remove(data, '$.sourceSlug')"

--- a/tests/test_migration_recipe_source_slug_unique.py
+++ b/tests/test_migration_recipe_source_slug_unique.py
@@ -1,7 +1,8 @@
 """Tests for the de-duplication pre-pass in migration c8f3b71d20a4 (KAN-213).
 
 The migration must clear ``source_slug`` on pre-existing duplicate
-(scope, source_slug) rows before it can create the unique indexes — otherwise
+(scope, COALESCE(source_slug, slug)) rows before it can create the unique
+indexes — otherwise
 ``flask db upgrade`` fails on dirty data, which aborts the flask-backend-migrate
 job and blocks the deploy while the old Flask revision keeps serving.
 
@@ -47,38 +48,52 @@ def _bare_recipe_engine(tmp_path):
                 "CREATE TABLE recipe ("
                 "id TEXT PRIMARY KEY, user_id INTEGER, guest_session_id TEXT, "
                 "name TEXT NOT NULL, slug TEXT, is_public INTEGER DEFAULT 0, "
-                "source_slug TEXT, created_at TEXT)"
+                "source_slug TEXT, data TEXT NOT NULL DEFAULT '{}', created_at TEXT)"
             )
         )
     return engine
 
 
 def _insert(conn, rows):
-    for rid, user_id, guest, source_slug, created in rows:
+    """Rows are (id, user_id, guest_session_id, source_slug, created_at[, slug]).
+
+    The blob mirrors source_slug, as production rows do — the pre-pass has to
+    clear both or the next partial PUT restages the stale value.
+    """
+    for row in rows:
+        rid, user_id, guest, source_slug, created = row[:5]
+        slug = row[5] if len(row) > 5 else None
+        blob = '{"sourceSlug": "%s"}' % source_slug if source_slug else "{}"
         conn.execute(
             sa.text(
-                "INSERT INTO recipe (id, user_id, guest_session_id, name, source_slug, created_at) "
-                "VALUES (:id, :u, :g, 'R', :s, :c)"
+                "INSERT INTO recipe (id, user_id, guest_session_id, name, source_slug, "
+                "slug, data, created_at) VALUES (:id, :u, :g, 'R', :s, :sl, :d, :c)"
             ),
-            {"id": rid, "u": user_id, "g": guest, "s": source_slug, "c": created},
+            {
+                "id": rid,
+                "u": user_id,
+                "g": guest,
+                "s": source_slug,
+                "sl": slug,
+                "d": blob,
+                "c": created,
+            },
         )
 
 
 def _build_indexes(conn):
     """The statements the migration issues after the pre-pass."""
-    conn.execute(
-        sa.text(
-            "CREATE UNIQUE INDEX uq_recipe_user_source_slug ON recipe (user_id, source_slug) "
-            "WHERE source_slug IS NOT NULL AND user_id IS NOT NULL"
+    for name, scope in (
+        ("uq_recipe_user_recipe_identity", "user_id"),
+        ("uq_recipe_guest_recipe_identity", "guest_session_id"),
+    ):
+        conn.execute(
+            sa.text(
+                f"CREATE UNIQUE INDEX {name} ON recipe "
+                f"({scope}, coalesce(source_slug, slug)) "
+                f"WHERE coalesce(source_slug, slug) IS NOT NULL AND {scope} IS NOT NULL"
+            )
         )
-    )
-    conn.execute(
-        sa.text(
-            "CREATE UNIQUE INDEX uq_recipe_guest_source_slug "
-            "ON recipe (guest_session_id, source_slug) "
-            "WHERE source_slug IS NOT NULL AND guest_session_id IS NOT NULL"
-        )
-    )
 
 
 def test_keeps_earliest_row_and_clears_the_later_duplicates(tmp_path):
@@ -94,7 +109,7 @@ def test_keeps_earliest_row_and_clears_the_later_duplicates(tmp_path):
                 ("d", 2, None, "vegan-cornbread", "2026-01-01"),
             ],
         )
-        cleared = mig._clear_duplicate_source_slugs(conn, "user_id")
+        cleared = mig._clear_duplicate_identities(conn, "user_id")
 
         kept = conn.execute(
             sa.text("SELECT id FROM recipe WHERE source_slug IS NOT NULL ORDER BY id")
@@ -122,8 +137,8 @@ def test_guest_scope_is_deduped_independently(tmp_path):
                 ("g3", None, "sess-b", "vegan-cornbread", "2026-01-01"),
             ],
         )
-        assert mig._clear_duplicate_source_slugs(conn, "user_id") == 0
-        assert mig._clear_duplicate_source_slugs(conn, "guest_session_id") == 1
+        assert mig._clear_duplicate_identities(conn, "user_id") == 0
+        assert mig._clear_duplicate_identities(conn, "guest_session_id") == 1
 
         kept = conn.execute(
             sa.text("SELECT id FROM recipe WHERE source_slug IS NOT NULL ORDER BY id")
@@ -151,8 +166,8 @@ def test_clean_data_is_a_no_op(tmp_path):
                 ("d", 1, None, None, "2026-01-04"),
             ],
         )
-        cleared = mig._clear_duplicate_source_slugs(conn, "user_id")
-        cleared += mig._clear_duplicate_source_slugs(conn, "guest_session_id")
+        cleared = mig._clear_duplicate_identities(conn, "user_id")
+        cleared += mig._clear_duplicate_identities(conn, "guest_session_id")
 
         remaining = conn.execute(
             sa.text("SELECT count(*) AS n FROM recipe WHERE source_slug IS NOT NULL")
@@ -189,3 +204,61 @@ def test_indexes_actually_refuse_a_duplicate_after_the_migration(tmp_path):
         _insert(conn, [("d", 1, None, None, "2026-01-03")])
         _insert(conn, [("e", 1, None, None, "2026-01-04")])
         assert conn.execute(sa.text("SELECT count(*) FROM recipe")).scalar() == 4
+
+
+def test_published_original_wins_over_a_saved_copy_of_itself(tmp_path):
+    """The identity case Codex found on PR #273.
+
+    An owner who holds the published row itself (``slug='x'``,
+    ``source_slug`` NULL) and also a copy saved from ``/r/x``
+    (``source_slug='x'``) has two rows for one recipe. Keying on
+    ``source_slug`` alone missed it entirely — the published row sits outside
+    that index. Under ``COALESCE(source_slug, slug)`` both rows share a key.
+
+    The survivor must be the published original, regardless of dates: the loser
+    is resolved by clearing its ``source_slug``, and a row whose key comes from
+    ``slug`` has none to clear. Ordering encodes that, which is why the copy
+    here is deliberately the OLDER row.
+    """
+    mig = _load_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                ("copy", 1, None, "vegan-cornbread", "2026-01-01"),
+                ("published", 1, None, None, "2026-01-02", "vegan-cornbread"),
+            ],
+        )
+        cleared = mig._clear_duplicate_identities(conn, "user_id")
+
+        rows = dict(conn.execute(sa.text("SELECT id, source_slug FROM recipe")).fetchall())
+        blob = conn.execute(sa.text("SELECT data FROM recipe WHERE id = 'copy'")).scalar()
+
+    assert cleared == 1
+    assert rows["published"] is None, "the published original must be untouched"
+    assert rows["copy"] is None, "the saved copy's source_slug must be cleared"
+    assert "sourceSlug" not in blob, (
+        "the mirrored blob key must be cleared too, or the next partial PUT "
+        "restages the stale value onto the column"
+    )
+
+    with engine.begin() as conn:
+        _build_indexes(conn)
+
+
+def test_index_refuses_a_copy_of_your_own_published_recipe(tmp_path):
+    """The refusal itself, for the identity case — seen to fire."""
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _build_indexes(conn)
+        _insert(conn, [("published", 1, None, None, "2026-01-01", "vegan-cornbread")])
+
+    with pytest.raises(sa.exc.IntegrityError):
+        with engine.begin() as conn:
+            _insert(conn, [("copy", 1, None, "vegan-cornbread", "2026-01-02")])
+
+    with engine.begin() as conn:
+        # Another owner saving that same public recipe is still fine.
+        _insert(conn, [("other", 2, None, "vegan-cornbread", "2026-01-02")])
+        assert conn.execute(sa.text("SELECT count(*) FROM recipe")).scalar() == 2

--- a/tests/test_migration_recipe_source_slug_unique.py
+++ b/tests/test_migration_recipe_source_slug_unique.py
@@ -1,0 +1,191 @@
+"""Tests for the de-duplication pre-pass in migration c8f3b71d20a4 (KAN-213).
+
+The migration must clear ``source_slug`` on pre-existing duplicate
+(scope, source_slug) rows before it can create the unique indexes — otherwise
+``flask db upgrade`` fails on dirty data, which aborts the flask-backend-migrate
+job and blocks the deploy while the old Flask revision keeps serving.
+
+Production was purged by hand on 2026-08-08/09 and both gates returned zero
+rows, so this pre-pass is expected to be a no-op there. It is tested precisely
+*because* it is expected never to fire in production: an untested pre-pass that
+only runs on the one day the data is dirty is the same failure mode as a guard
+nobody ever watched fire.
+
+Exercised against a table built WITHOUT the indexes (the model now carries them,
+so a normal ``db.create_all`` cannot hold duplicates to test against) — the same
+approach as ``test_migration_cookbook_unique.py``.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+
+def _load_migration():
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "migrations"
+        / "versions"
+        / "c8f3b71d20a4_recipe_source_slug_unique_indexes.py"
+    )
+    spec = importlib.util.spec_from_file_location("mig_c8f3b71d20a4", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _bare_recipe_engine(tmp_path):
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'mig.db'}")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE recipe ("
+                "id TEXT PRIMARY KEY, user_id INTEGER, guest_session_id TEXT, "
+                "name TEXT NOT NULL, slug TEXT, is_public INTEGER DEFAULT 0, "
+                "source_slug TEXT, created_at TEXT)"
+            )
+        )
+    return engine
+
+
+def _insert(conn, rows):
+    for rid, user_id, guest, source_slug, created in rows:
+        conn.execute(
+            sa.text(
+                "INSERT INTO recipe (id, user_id, guest_session_id, name, source_slug, created_at) "
+                "VALUES (:id, :u, :g, 'R', :s, :c)"
+            ),
+            {"id": rid, "u": user_id, "g": guest, "s": source_slug, "c": created},
+        )
+
+
+def _build_indexes(conn):
+    """The statements the migration issues after the pre-pass."""
+    conn.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX uq_recipe_user_source_slug ON recipe (user_id, source_slug) "
+            "WHERE source_slug IS NOT NULL AND user_id IS NOT NULL"
+        )
+    )
+    conn.execute(
+        sa.text(
+            "CREATE UNIQUE INDEX uq_recipe_guest_source_slug "
+            "ON recipe (guest_session_id, source_slug) "
+            "WHERE source_slug IS NOT NULL AND guest_session_id IS NOT NULL"
+        )
+    )
+
+
+def test_keeps_earliest_row_and_clears_the_later_duplicates(tmp_path):
+    mig = _load_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                ("a", 1, None, "vegan-cornbread", "2026-01-01"),
+                ("b", 1, None, "vegan-cornbread", "2026-01-02"),
+                ("c", 1, None, "vegan-cornbread", "2026-01-03"),
+                ("d", 2, None, "vegan-cornbread", "2026-01-01"),
+            ],
+        )
+        cleared = mig._clear_duplicate_source_slugs(conn, "user_id")
+
+        kept = conn.execute(
+            sa.text("SELECT id FROM recipe WHERE source_slug IS NOT NULL ORDER BY id")
+        ).fetchall()
+
+    assert cleared == 2
+    # Earliest per (user, source_slug) survives; a different user is untouched.
+    assert [r.id for r in kept] == ["a", "d"]
+
+    # The whole point: the indexes can now be built.
+    with engine.begin() as conn:
+        _build_indexes(conn)
+
+
+def test_guest_scope_is_deduped_independently(tmp_path):
+    """R3 — the guest index needs its own pass; user_id is NULL on those rows."""
+    mig = _load_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                ("g1", None, "sess-a", "vegan-cornbread", "2026-01-01"),
+                ("g2", None, "sess-a", "vegan-cornbread", "2026-01-02"),
+                ("g3", None, "sess-b", "vegan-cornbread", "2026-01-01"),
+            ],
+        )
+        assert mig._clear_duplicate_source_slugs(conn, "user_id") == 0
+        assert mig._clear_duplicate_source_slugs(conn, "guest_session_id") == 1
+
+        kept = conn.execute(
+            sa.text("SELECT id FROM recipe WHERE source_slug IS NOT NULL ORDER BY id")
+        ).fetchall()
+
+    assert [r.id for r in kept] == ["g1", "g3"]
+    with engine.begin() as conn:
+        _build_indexes(conn)
+
+
+def test_clean_data_is_a_no_op(tmp_path):
+    """The expected production case: purged already, nothing to do.
+
+    Pinned so the pre-pass cannot start quietly rewriting rows on every deploy.
+    """
+    mig = _load_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                ("a", 1, None, "vegan-cornbread", "2026-01-01"),
+                ("b", 1, None, "vegan-pot-pie", "2026-01-02"),
+                ("c", 1, None, None, "2026-01-03"),
+                ("d", 1, None, None, "2026-01-04"),
+            ],
+        )
+        cleared = mig._clear_duplicate_source_slugs(conn, "user_id")
+        cleared += mig._clear_duplicate_source_slugs(conn, "guest_session_id")
+
+        remaining = conn.execute(
+            sa.text("SELECT count(*) AS n FROM recipe WHERE source_slug IS NOT NULL")
+        ).scalar()
+
+    assert cleared == 0
+    # NULL-source rows are untouched and stay unconstrained by design.
+    assert remaining == 2
+    with engine.begin() as conn:
+        _build_indexes(conn)
+
+
+def test_indexes_actually_refuse_a_duplicate_after_the_migration(tmp_path):
+    """Seen to fail for the reason it exists.
+
+    An index that is created but never observed refusing anything is the
+    project's most expensive recurring failure mode (cf. the Alembic head-check
+    and check_sprint_lane.sh before it was wired into gate.needs). This asserts
+    the refusal itself, and asserts the two cases that must NOT be refused.
+    """
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _build_indexes(conn)
+        _insert(conn, [("a", 1, None, "vegan-cornbread", "2026-01-01")])
+
+    with pytest.raises(sa.exc.IntegrityError):
+        with engine.begin() as conn:
+            _insert(conn, [("b", 1, None, "vegan-cornbread", "2026-01-02")])
+
+    with engine.begin() as conn:
+        # A different owner saving the same public recipe is the product working.
+        _insert(conn, [("c", 2, None, "vegan-cornbread", "2026-01-02")])
+        # Generated recipes carry no source_slug and stay unconstrained.
+        _insert(conn, [("d", 1, None, None, "2026-01-03")])
+        _insert(conn, [("e", 1, None, None, "2026-01-04")])
+        assert conn.execute(sa.text("SELECT count(*) FROM recipe")).scalar() == 4

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -255,24 +255,40 @@ def test_same_user_may_save_two_different_public_recipes(client, logged_in):
 # ─── KAN-213 × KAN-186: the guest-merge public-row exemption ─────────────────
 
 
-def test_guest_merge_reassigns_a_published_duplicate_without_tripping_the_index(app, user):
-    """Logging in must not fail because of the new constraint.
+def test_guest_cannot_create_the_row_that_would_collide(client, guest):
+    """The reason the merge exemption is not a live conflict with this index.
 
-    KAN-186's merge deletes a guest row that duplicates one the account owns —
+    KAN-186's merge deletes a guest row that duplicates an owned recipe —
     *except* when the guest row is published, which is reassigned instead
-    because deleting it would take a live public page down. That exemption
-    deliberately creates a duplicate (owner, source_slug) pair, which the new
-    index refuses.
+    because deleting would take a live page down. Reassigning a duplicate is
+    exactly what the new index refuses, so that reads like a conflict.
 
-    An IntegrityError there is not a contained failure: it rolls back the whole
-    merge, so the guest's recipes and cookbooks are orphaned at the moment of
-    login. The merge clears ``source_slug`` on the reassigned row instead — it
-    is kept because it is a published page in its own right, so its own slug is
-    what identifies it.
+    It is not, because **a guest cannot publish at all.** The SPA replaces the
+    publish toggle with a "log in to publish" link, and the server does not
+    trust the SPA: ``_gate_is_public`` forces ``is_public=False`` whenever
+    ``user_id is None``. Asserted here through the API rather than the ORM —
+    constructing the row directly with ``Recipe(is_public=True, ...)`` bypasses
+    the gate and would "prove" a state the product cannot reach.
+    """
+    response = client.post("/api/recipes", json={**_payload(), "is_public": True})
 
-    Pinned here rather than only in test_guest_merge_dedup.py because the two
-    behaviours are only correct together; a future widening of either one has to
-    fail a test that names the interaction.
+    assert response.status_code == 201
+    row = Recipe.query.filter_by(guest_session_id=guest).one()
+    assert row.is_public is False, "a guest published a recipe — the gate is gone"
+    assert row.data["is_public"] is False, "blob and column must not disagree"
+
+
+def test_legacy_public_guest_row_cannot_roll_back_a_login_merge(app, user):
+    """Defence for rows predating the publish gate — not a live path.
+
+    Migration e91b47a2c5d3 (2026-07-07) reassigned or unpublished the
+    guest-published rows that existed before ``_gate_is_public``, so production
+    holds none. This builds one directly through the ORM *on purpose*, to prove
+    what happens if one ever reappears: without the ``source_slug`` clear, the
+    reassignment raises IntegrityError, which rolls back the ENTIRE merge and
+    orphans the guest's recipes and cookbooks at the moment of login.
+
+    A single legacy row must not be able to cost someone their data.
     """
     from blueprints.auth_api_bp import _merge_guest_session_into_user
 

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -216,6 +216,70 @@ def test_update_that_collides_also_returns_409_not_500(client, logged_in):
     assert Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).count() == 1
 
 
+def test_slug_race_and_duplicate_source_slug_together_still_end_in_409(
+    client, logged_in, monkeypatch
+):
+    """Settles a disagreement between two reviews on PR #273.
+
+    ``_duplicate_source_slug_owner`` is consulted only on the *non*-slug-race
+    branch of ``_commit_publish_retrying``. One review read that as: a write
+    that loses a slug race AND has a duplicate source_slug burns all
+    ``_SLUG_COMMIT_RETRIES`` and then re-raises the raw IntegrityError as a
+    500 — R1 reopened from a narrower angle. A later review read the same code
+    as self-correcting after one retry. They cannot both be right, and neither
+    wrote a test.
+
+    Tracing it: attempt 1 fails with another row owning the probed slug, so
+    ``lost_slug_race`` is True and the duplicate check is skipped. Attempt 2
+    resolves a *fresh* slug that nobody owns, so ``lost_slug_race`` is now
+    False — control reaches the duplicate check and raises
+    ``RecipeDuplicateError``. One extra retry, then 409.
+
+    This asserts that, so the claim stops being a matter of reading.
+    """
+    from repositories import db_recipe_repository
+
+    _insert_competing_row(user_id=logged_in.id)  # owner already holds SOURCE_SLUG
+
+    real_resolve = db_recipe_repository._resolve_public_slug
+    state = {"raced": False, "resolves": 0}
+
+    def racing_resolve(data, recipe_id, current_slug=None, skip=frozenset()):
+        slug = real_resolve(data, recipe_id, current_slug, skip=skip)
+        state["resolves"] += 1
+        if not state["raced"]:
+            state["raced"] = True
+            # Another writer claims the probed slug before our commit, so
+            # attempt 1 is a genuine slug race on top of the duplicate.
+            with db.engine.begin() as conn:
+                conn.execute(
+                    sa.text(
+                        "INSERT INTO recipe (id, name, status, slug, is_public, "
+                        "is_canonical, data, created_at, updated_at) VALUES "
+                        "(:id, 'Racer', 'ready', :slug, 0, 0, '{}', "
+                        "'2026-08-09 00:00:00', '2026-08-09 00:00:00')"
+                    ),
+                    {"id": str(uuid.uuid4()), "slug": slug},
+                )
+        return slug
+
+    monkeypatch.setattr(db_recipe_repository, "_resolve_public_slug", racing_resolve)
+
+    response = client.post("/api/recipes", json={**_payload(), "is_public": True})
+
+    assert state["raced"], "the slug race never fired — test is not exercising both collisions"
+    assert response.status_code == 409, (
+        f"expected 409, got {response.status_code}. A 500 here would mean the "
+        "slug-retry branch swallows the duplicate refusal — R1 from a narrower angle."
+    )
+    # Two resolves = one race retry, not an exhausted retry budget.
+    assert state["resolves"] == 2, (
+        f"expected exactly one retry, saw {state['resolves']} slug resolutions — "
+        "the duplicate check is not short-circuiting on the second attempt"
+    )
+    assert Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).count() == 1
+
+
 def test_guest_saves_are_constrained_too(client, guest, monkeypatch):
     """R3 — both indexes ship together or neither.
 

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -422,3 +422,77 @@ def test_legacy_public_guest_row_cannot_roll_back_a_login_merge(app, user):
         "the reassigned row must leave the partial index's coverage, "
         "or the whole merge rolls back at login"
     )
+
+
+# ─── Codex review findings, PR #273 — reproduced before fixing ──────────────
+
+
+def test_clearing_the_column_survives_a_later_partial_update(client, logged_in):
+    """P2 — the column clear must not be undone by the mirrored JSON blob.
+
+    ``source_slug`` is a mirror of ``data['sourceSlug']``. Both the migration
+    pre-pass and the guest-merge legacy guard clear only the **column**.
+    ``update_recipe`` then rebuilds the blob as
+    ``{**(recipe.data or {}), **recipe_data}`` and ``stage_update`` restages
+    ``recipe.source_slug = data.get('sourceSlug')`` — so the next ordinary
+    partial PUT pulls the stale value back out of the untouched blob and writes
+    it to the column.
+
+    That resurrects the duplicate the clear just removed, and the row then trips
+    the unique index on a write the user did not intend as a save.
+    """
+    created = client.post("/api/recipes", json=_payload()).get_json()
+    row = db.session.get(Recipe, created["id"])
+    assert row.data.get("sourceSlug") == SOURCE_SLUG, "precondition: blob mirrors the column"
+
+    # What the migration pre-pass and the merge guard do today.
+    row.source_slug = None
+    db.session.commit()
+
+    # An ordinary partial PUT that says nothing about sourceSlug.
+    response = client.put(f"/api/recipes/{created['id']}", json={"name": "Renamed"})
+    assert response.status_code == 200
+
+    refreshed = db.session.get(Recipe, created["id"])
+    assert refreshed.source_slug is None, (
+        "the stale data['sourceSlug'] was restaged onto the column — the clear "
+        "is not durable, so the migration pre-pass undoes itself on the next PUT"
+    )
+
+
+def test_saving_your_own_published_recipe_again_is_refused(client, logged_in):
+    """P1 — the index must cover the identity the rest of the codebase uses.
+
+    ``_recipe_identity_keys`` (``auth_api_bp.py``) and the SPA's INV-1 both
+    treat a recipe's identity as ``{source_slug, slug}`` —
+    ``r.sourceSlug === slug || r.slug === slug``. The indexes key only on
+    ``source_slug``.
+
+    So when a user already owns the **published row itself**
+    (``slug='x'``, ``source_slug`` NULL) and saves ``/r/x`` again, the copy gets
+    ``source_slug='x'`` and collides with nothing: the published row is outside
+    the partial index entirely. The database accepts a duplicate that this PR's
+    own helper would classify as the same recipe — which is the exact case the
+    PR claims to close, reachable by any caller that bypasses the SPA or holds a
+    stale recipe list.
+    """
+    published = Recipe(
+        id="own-published",
+        user_id=logged_in.id,
+        name="Vegan Cornbread",
+        slug=SOURCE_SLUG,
+        source_slug=None,
+        is_public=True,
+        data={"name": "Vegan Cornbread", "slug": SOURCE_SLUG, "is_public": True},
+    )
+    db.session.add(published)
+    db.session.commit()
+
+    # The author opens their own /r/vegan-cornbread and saves it.
+    response = client.post("/api/recipes", json=_payload())
+
+    assert response.status_code == 409, (
+        f"expected 409, got {response.status_code} — the owner now holds two rows "
+        "for one recipe, which is the duplicate this PR is meant to refuse"
+    )
+    assert Recipe.query.filter_by(user_id=logged_in.id).count() == 1

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -255,13 +255,21 @@ def test_two_users_may_each_save_the_same_public_recipe(client, logged_in, monke
 def test_generated_recipes_are_unconstrained(client, logged_in):
     """The documented coverage limit, pinned so it cannot regress silently.
 
-    Both indexes are partial on ``source_slug IS NOT NULL``. Generated and
-    manually entered recipes carry no sourceSlug and are the large majority of
-    the table; they have no provenance to collide on. A name-based constraint
-    was rejected because two genuinely different recipes may share a title.
+    Both indexes are partial on ``source_slug IS NOT NULL``, and only
+    ``origin='saved'`` rows carry one — so they constrain copies a user took
+    from someone else's public page and **do not constrain a single recipe a
+    user authored** (~3% of user 1's rows: 4 constrained against 112 not).
+
+    That is deliberate, not an oversight. A saved copy is the only case where
+    "these two rows are the same recipe" is a machine-checkable fact; two
+    separately generated recipes have no such identity, and a name-based
+    constraint was rejected because two genuinely different recipes may share a
+    title.
 
     So KAN-213's class is closed, and the table is NOT duplicate-free. If this
-    test ever fails, someone widened the constraint beyond what was agreed.
+    test ever fails, someone widened the constraint beyond what was agreed —
+    most likely onto authored recipes, where it cannot be correct without a
+    content hash (Sprint 7).
     """
     first = client.post("/api/recipes", json=_payload(source_slug=None))
     second = client.post("/api/recipes", json=_payload(source_slug=None))

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -189,6 +189,33 @@ def test_duplicate_refusal_body_carries_a_code_and_no_exception_text(
         assert leak not in str(body), f"response leaked internals: {leak!r}"
 
 
+def test_update_that_collides_also_returns_409_not_500(client, logged_in):
+    """The PUT route must refuse the same way the POST route does.
+
+    Covers the sibling path of R1: the repository re-raises
+    RecipeDuplicateError from update_recipe, so without a handler on the PUT
+    route the refusal falls into the generic 500. Unlike the create case this
+    needs no race — editing one recipe to carry another's sourceSlug trips the
+    index directly.
+    """
+    first = client.post("/api/recipes", json=_payload()).get_json()
+    second = client.post(
+        "/api/recipes", json=_payload(name="Vegan Pot Pie", source_slug="pot-pie")
+    ).get_json()
+    assert first["id"] != second["id"]
+
+    # Point the second recipe at the first's source — now a duplicate pair.
+    response = client.put(f"/api/recipes/{second['id']}", json=_payload(name="Vegan Pot Pie"))
+
+    assert response.status_code == 409, (
+        f"expected 409, got {response.status_code} — an update that trips the "
+        "index must be a deliberate refusal, not an internal error"
+    )
+    assert "code" in response.get_json()
+    # The write must not have landed.
+    assert Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).count() == 1
+
+
 def test_guest_saves_are_constrained_too(client, guest, monkeypatch):
     """R3 — both indexes ship together or neither.
 

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -1,0 +1,309 @@
+"""KAN-213 — the duplicate invariant lives in the database, not in the client.
+
+Six duplicate-recipe tickets were filed and fixed between 2026-07-18 and
+2026-08-08 (KAN-137, -156, -157, -186, -194). Every one patched the layer the
+symptom appeared in; none touched the schema, so the bug kept coming back. The
+uniqueness rule (INV-1) lived only in SPA code
+(``src/services/ssr-entry.service.ts``), and a client-side check cannot close a
+cross-context race by construction: two tabs, or a tab and a phone, both read
+"you don't have this yet" before either writes.
+
+These tests pin the fix at the only layer that can refuse the second write —
+two partial unique indexes:
+
+    uq_recipe_user_source_slug   UNIQUE (user_id, source_slug)
+        WHERE source_slug IS NOT NULL AND user_id IS NOT NULL
+    uq_recipe_guest_source_slug  UNIQUE (guest_session_id, source_slug)
+        WHERE source_slug IS NOT NULL AND guest_session_id IS NOT NULL
+
+Both ship together or neither (Sprint 6 R3): ``user_id`` is nullable and guests
+key on ``guest_session_id``, which is the KAN-186 path.
+
+The race is injected deterministically rather than with threads — the same
+idiom as ``test_publish_gate.py``'s slug-race tests. A thread race would
+reproduce this interleaving only sometimes; monkeypatching the commit boundary
+reproduces it every run, and the competing row is written on a *separate
+connection* so it is a genuine second writer, not a same-session artifact.
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from extensions import db  # noqa: E402
+from models.recipe import Recipe  # noqa: E402
+from models.user import User  # noqa: E402
+
+SOURCE_SLUG = "vegan-cornbread"
+GUEST_SESSION = "guest-session-abc"
+
+
+@pytest.fixture
+def app(tmp_path):
+    # File-backed rather than :memory: — the race test opens a SECOND
+    # connection to play the competing writer, and separate connections to an
+    # in-memory SQLite database do not necessarily see the same data.
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI=f"sqlite:///{tmp_path / 'kan213.db'}",
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def user(app):
+    u = User(email="owner@example.com", name="Owner")
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+@pytest.fixture
+def logged_in(client, user):
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+    return user
+
+
+@pytest.fixture
+def guest(client):
+    # The app keys the guest scope on session["session_id"]
+    # (utils/session_utils.get_or_create_session_id), NOT "guest_session_id" —
+    # which is the name it carries once it reaches the model. Setting the wrong
+    # key mints a fresh random id instead and the test silently passes against
+    # an unconstrained pair.
+    with client.session_transaction() as sess:
+        sess["session_id"] = GUEST_SESSION
+    return GUEST_SESSION
+
+
+def _payload(name="Vegan Cornbread", source_slug=SOURCE_SLUG):
+    """The body the SPA sends when saving a public recipe to a cookbook."""
+    body = {"name": name, "ingredients": ["cornmeal"], "instructions": ["bake"]}
+    if source_slug is not None:
+        body["sourceSlug"] = source_slug
+    return body
+
+
+def _insert_competing_row(user_id=None, guest_session_id=None, source_slug=SOURCE_SLUG):
+    """Write the other tab's row on a SEPARATE connection.
+
+    Deliberately raw SQL on its own connection rather than ``db.session.add``:
+    the point of the test is a second writer that our session has not seen, and
+    staging it on the shared session would prove nothing about the index.
+    """
+    with db.engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "INSERT INTO recipe (id, user_id, guest_session_id, name, status, "
+                "slug, is_public, is_canonical, source_slug, data, created_at, updated_at) "
+                "VALUES (:id, :user_id, :guest, :name, 'ready', NULL, 0, 0, :source_slug, "
+                ":data, '2026-08-09 00:00:00', '2026-08-09 00:00:00')"
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "user_id": user_id,
+                "guest": guest_session_id,
+                "name": "Vegan Cornbread",
+                "source_slug": source_slug,
+                "data": '{"name": "Vegan Cornbread"}',
+            },
+        )
+
+
+def _race_on_commit(monkeypatch, **competitor):
+    """Land the competing row once, immediately before our first commit."""
+    real_commit = db.session.commit
+    state = {"raced": False}
+
+    def racing_commit():
+        if not state["raced"]:
+            state["raced"] = True
+            _insert_competing_row(**competitor)
+        return real_commit()
+
+    monkeypatch.setattr(db.session, "commit", racing_commit)
+    return state
+
+
+# ─── The anchor gate (Sprint 6 D1) ───────────────────────────────────────────
+
+
+def test_concurrent_saves_of_same_source_slug_persist_one_row_and_return_409(
+    client, logged_in, monkeypatch
+):
+    """Two concurrent POSTs with the same sourceSlug: one row, and the loser
+    gets a 409 — not a 500.
+
+    This is Sprint 6's definition of done. The 409 half is as load-bearing as
+    the one-row half: R1 named "the new constraint surfaces as a raw 500" as
+    the dominant risk, because the repository catches IntegrityError broadly and
+    returns None, which the blueprint answers with 500. A 500 tells the SPA to
+    show "check your connection" for what is really "you already have this".
+    """
+    state = _race_on_commit(monkeypatch, user_id=logged_in.id)
+
+    response = client.post("/api/recipes", json=_payload())
+
+    assert state["raced"], "the competing writer never ran — test is not exercising the race"
+    assert response.status_code == 409, (
+        f"expected 409 (deliberate refusal), got {response.status_code}. "
+        "A 500 here is R1: the constraint fired but the API reported an internal error."
+    )
+
+    rows = Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).all()
+    assert len(rows) == 1, f"expected exactly one persisted row, found {len(rows)}"
+
+
+def test_duplicate_refusal_body_carries_a_code_and_no_exception_text(
+    client, logged_in, monkeypatch
+):
+    """The refusal must be actionable by the SPA and must not leak internals.
+
+    Same rule as the sibling refusals (KAN-155): a fixed message plus a machine
+    -readable ``code``, never ``str(e)`` — exception text must not reach clients
+    (CodeQL py/stack-trace-exposure).
+    """
+    _race_on_commit(monkeypatch, user_id=logged_in.id)
+
+    body = client.post("/api/recipes", json=_payload()).get_json()
+
+    assert "code" in body, "SPA cannot distinguish this refusal without a code"
+    for leak in ("Traceback", "IntegrityError", "UNIQUE constraint", "INSERT INTO"):
+        assert leak not in str(body), f"response leaked internals: {leak!r}"
+
+
+def test_guest_saves_are_constrained_too(client, guest, monkeypatch):
+    """R3 — both indexes ship together or neither.
+
+    Guests key on ``guest_session_id`` with ``user_id`` NULL, so the
+    authenticated index does not cover them. This is the KAN-186 path, and
+    leaving it unconstrained would reopen the bug for exactly the users who hit
+    it most: someone saving a recipe before signing in.
+    """
+    state = _race_on_commit(monkeypatch, guest_session_id=guest)
+
+    response = client.post("/api/recipes", json=_payload())
+
+    assert state["raced"]
+    assert response.status_code == 409
+    rows = Recipe.query.filter_by(guest_session_id=guest, source_slug=SOURCE_SLUG).all()
+    assert len(rows) == 1
+
+
+# ─── The constraint must be narrow: these are NOT duplicates ─────────────────
+
+
+def test_two_users_may_each_save_the_same_public_recipe(client, logged_in, monkeypatch):
+    """The index is scoped per owner. Two people saving the same public recipe
+    is the product working, not a duplicate — a global unique index on
+    source_slug would break the core save flow."""
+    other = User(email="other@example.com", name="Other")
+    db.session.add(other)
+    db.session.commit()
+    _insert_competing_row(user_id=other.id)
+
+    response = client.post("/api/recipes", json=_payload())
+
+    assert response.status_code == 201
+    assert Recipe.query.filter_by(source_slug=SOURCE_SLUG).count() == 2
+
+
+def test_generated_recipes_are_unconstrained(client, logged_in):
+    """The documented coverage limit, pinned so it cannot regress silently.
+
+    Both indexes are partial on ``source_slug IS NOT NULL``. Generated and
+    manually entered recipes carry no sourceSlug and are the large majority of
+    the table; they have no provenance to collide on. A name-based constraint
+    was rejected because two genuinely different recipes may share a title.
+
+    So KAN-213's class is closed, and the table is NOT duplicate-free. If this
+    test ever fails, someone widened the constraint beyond what was agreed.
+    """
+    first = client.post("/api/recipes", json=_payload(source_slug=None))
+    second = client.post("/api/recipes", json=_payload(source_slug=None))
+
+    assert (first.status_code, second.status_code) == (201, 201)
+    assert Recipe.query.filter_by(source_slug=None).count() == 2
+
+
+def test_same_user_may_save_two_different_public_recipes(client, logged_in):
+    """Sanity floor: the constraint keys on (owner, source_slug), not owner."""
+    assert client.post("/api/recipes", json=_payload()).status_code == 201
+    second = client.post("/api/recipes", json=_payload(name="Vegan Pot Pie", source_slug="pot-pie"))
+
+    assert second.status_code == 201
+    assert Recipe.query.filter_by(user_id=logged_in.id).count() == 2
+
+
+# ─── KAN-213 × KAN-186: the guest-merge public-row exemption ─────────────────
+
+
+def test_guest_merge_reassigns_a_published_duplicate_without_tripping_the_index(app, user):
+    """Logging in must not fail because of the new constraint.
+
+    KAN-186's merge deletes a guest row that duplicates one the account owns —
+    *except* when the guest row is published, which is reassigned instead
+    because deleting it would take a live public page down. That exemption
+    deliberately creates a duplicate (owner, source_slug) pair, which the new
+    index refuses.
+
+    An IntegrityError there is not a contained failure: it rolls back the whole
+    merge, so the guest's recipes and cookbooks are orphaned at the moment of
+    login. The merge clears ``source_slug`` on the reassigned row instead — it
+    is kept because it is a published page in its own right, so its own slug is
+    what identifies it.
+
+    Pinned here rather than only in test_guest_merge_dedup.py because the two
+    behaviours are only correct together; a future widening of either one has to
+    fail a test that names the interaction.
+    """
+    from blueprints.auth_api_bp import _merge_guest_session_into_user
+
+    owned = Recipe(
+        id="owned",
+        user_id=user.id,
+        name="Pizza Dough",
+        source_slug="vegan-fried-pizza-dough",
+        is_public=False,
+        data={"name": "Pizza Dough"},
+    )
+    published_guest_copy = Recipe(
+        id="guest-published",
+        guest_session_id=GUEST_SESSION,
+        name="Pizza Dough",
+        slug="vegan-fried-pizza-dough-2",
+        source_slug="vegan-fried-pizza-dough",
+        is_public=True,
+        data={"name": "Pizza Dough"},
+    )
+    db.session.add_all([owned, published_guest_copy])
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)
+
+    rows = Recipe.query.filter_by(user_id=user.id).all()
+    assert len(rows) == 2, "the live public page was dropped by the merge"
+    survivor = next(r for r in rows if r.id == "guest-published")
+    assert survivor.is_public is True, "the public page must stay live"
+    assert survivor.slug == "vegan-fried-pizza-dough-2", "its own address is unchanged"
+    assert survivor.source_slug is None, (
+        "the reassigned row must leave the partial index's coverage, "
+        "or the whole merge rolls back at login"
+    )

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -496,3 +496,41 @@ def test_saving_your_own_published_recipe_again_is_refused(client, logged_in):
         "for one recipe, which is the duplicate this PR is meant to refuse"
     )
     assert Recipe.query.filter_by(user_id=logged_in.id).count() == 1
+
+
+@pytest.mark.xfail(
+    reason="KAN-221: known dual-identity gap. A row holding BOTH source_slug and "
+    "slug (a saved copy that was later published) is indexed only by its "
+    "source_slug, so saving that row's own public URL is accepted. A unique "
+    "index keys one value per row and cannot express 'alias sets must be "
+    "disjoint', so there is no index-shaped fix. The two alternatives both cost "
+    "more than the gap: clearing source_slug on publish would shrink the row's "
+    "alias set and break KAN-186's guest-merge dedup, and a recipe_identity "
+    "side table is exactly what KAN-221 deletes when it replaces mutable slugs "
+    "with a stable source-recipe id. Documented rather than patched.",
+    strict=True,
+)
+def test_saving_your_own_published_copy_is_not_yet_refused(client, logged_in):
+    """The third hole in the same model — recorded so it cannot be forgotten.
+
+    Found by Copilot on PR #273 after the COALESCE fix closed the second one.
+    Three rounds found three holes in one identity model, which is the finding:
+    ``source_slug`` is a mutable string standing in for a relationship, so every
+    index over it has an aliasing hole. KAN-221 replaces it.
+    """
+    copy_then_published = Recipe(
+        id="copy-published",
+        user_id=logged_in.id,
+        name="Vegan Cornbread",
+        source_slug="someone-elses-original",
+        slug="my-copy",
+        is_public=True,
+        data={"name": "Vegan Cornbread"},
+    )
+    db.session.add(copy_then_published)
+    db.session.commit()
+
+    # The owner saves their OWN published copy's page.
+    response = client.post("/api/recipes", json=_payload(source_slug="my-copy"))
+
+    assert response.status_code == 409


### PR DESCRIPTION
## What

Sprint 6's anchor outcome (S1): **a duplicate recipe cannot be persisted, because the database refuses it.**

Six duplicate-recipe tickets were filed and fixed between 2026-07-18 and 2026-08-08 — KAN-137, KAN-156, KAN-157, KAN-186, KAN-194. Every one patched the layer the symptom appeared in. None touched the schema, so the bug kept coming back. The uniqueness rule (INV-1) lived only in `src/services/ssr-entry.service.ts`, and a client-side check cannot close a cross-context race by construction.

## The constraint

Migration `c8f3b71d20a4` adds two partial unique indexes, declared on the model as well so `db.create_all()` (tests, fresh local dev) builds the same schema the migration builds in production — otherwise the suite would pass against a schema that cannot refuse anything.

```
uq_recipe_user_recipe_identity   UNIQUE (user_id,           COALESCE(source_slug, slug))
uq_recipe_guest_recipe_identity  UNIQUE (guest_session_id,  COALESCE(source_slug, slug))
both WHERE COALESCE(source_slug, slug) IS NOT NULL AND <scope> IS NOT NULL
```

**The key is `COALESCE(source_slug, slug)`, not `source_slug` alone** — corrected after Codex review found a reachable hole in the first version. A recipe's identity is `{source_slug, slug}` everywhere else in the codebase (`_recipe_identity_keys()`, and the SPA's INV-1 `r.sourceSlug === slug || r.slug === slug`). Keying on `source_slug` alone meant an owner holding the **published row itself** (`slug='x'`, `source_slug` NULL) could save `/r/x` again and get a copy with `source_slug='x'` that collided with nothing, because the published row sits outside a `source_slug`-only partial index. The database accepted exactly the duplicate this PR exists to refuse.

Fixed in the schema rather than the application: doing it in the app would have repeated the mistake this PR was written to end. Two rows cannot collide on the slug side alone — `slug` is already globally unique — so every collision this adds involves at least one saved copy.

Both ship together or neither (Sprint 6 R3) — `user_id` is nullable and guests key on `guest_session_id`, which is the KAN-186 path.

## The 409 is half the deliverable

R1 named the dominant risk: *the new constraint surfaces as a raw 500*. The repository catches `Exception` broadly and returns `None`, which the blueprint answers with 500 — so a **working** constraint would have looked like a server outage and told the user to check their connection, when the real answer is "you already have this".

`RecipeDuplicateError` → 409 with a machine-readable `code`, same contract as the KAN-155 ownership refusal (fixed string, never `str(e)` — CodeQL `py/stack-trace-exposure`). Detection uses the **same portable signal as the existing slug-race path** — ask the database who owns the key after rollback — because constraint names differ between SQLite and PostgreSQL. It runs only on the non-slug-race branch, so the existing retry is untouched.

Applies to **both** routes. The `PUT` handler was missing in the first pass (`6e82b0e` fixed it, `3bf981b` added the test): the repository already re-raised `RecipeDuplicateError` from `update_recipe` and the route never caught it, so an update tripping the index fell into the generic 500 — R1 on the sibling path. That path needs no race at all; editing one recipe to carry another's `sourceSlug` trips the index directly.

## Not `CREATE INDEX CONCURRENTLY` — deliberate

The runbook's §6 specified it inside an `autocommit_block()`. This follows `b7e2a9c4d1f8`'s `LOCK TABLE … ACCESS EXCLUSIVE` instead.

`flask-backend-migrate` runs as a Cloud Run Job *while the previous Flask revision is still serving traffic*. CONCURRENTLY takes no write lock, so a duplicate can land mid-build — and a unique index build that meets a violation leaves an **INVALID** index that silently enforces nothing. That is this project's recurring failure mode. `recipe` is a small table, so ACCESS EXCLUSIVE costs nothing here.

## Correction: there is no KAN-213 × KAN-186 conflict

An earlier version of this description claimed the guest-merge public-row exemption conflicted with the new index. **That was wrong.** A guest cannot publish:

- the SPA replaces the publish toggle with a "log in to publish" link, and
- the server does not depend on the SPA — `_gate_is_public` (`db_recipe_repository.py:414`) forces `is_public = False` whenever `user_id is None`, on create and update alike, normalising the flag in the data blob so the column and JSON cannot disagree.
- Rows predating that gate were reassigned or unpublished by migration `e91b47a2c5d3` (2026-07-07).

So KAN-186's exemption is **unreachable** and the duplicate pair described does not occur in any live path. The `source_slug` clear in `auth_api_bp.py` remains as **legacy-data defence** — if such a row ever reappeared, the `IntegrityError` would roll back the *entire* merge and orphan a guest's recipes and cookbooks at the moment of login, and one legacy row must not be able to cost someone their data.

The original test was the worse half of that error: it built the colliding row via the ORM, bypassing `_gate_is_public`, so it passed while asserting a state the product cannot reach. Replaced by two tests that separate the claims — one asserting the publish gate **through the API**, one explicitly labelled legacy-data defence.

## Verification

- **Confirmed failing on the pre-migration code first** (Sprint 6 D1): the constraint tests returned `201` where `409` is required, and persisted two rows where one is. The "must stay unconstrained" tests passed before and after.
- **The index was observed refusing a duplicate for the reason it exists** — not merely created: `UNIQUE constraint failed: recipe.user_id, recipe.source_slug`, with a different owner and NULL-source rows confirmed still allowed.
- The PUT test was likewise confirmed to fail for its stated reason by removing the handler and re-running (500, not 409).
- Migration applied end-to-end against a fresh database; `flask db heads` is a single head (`c8f3b71d20a4`).
- `370 passed`, Black + Flake8 clean, mypy `Success: no issues found in 95 source files`.

## Known coverage limit — stated, not papered over

These are **partial** indexes. Rows with `source_slug IS NULL` — generated and manually entered recipes, the large majority of the table — are **not** constrained. That is correct: a generated recipe has no provenance to collide on, and a name-based constraint was rejected because two genuinely different recipes may share a title.

**This closes KAN-213's class. It does not make the table duplicate-free**, and the charter must not be read that way. A test pins the limit so nobody widens it silently.

## Where the duplicates actually come from — see KAN-220

The charter frames KAN-213 as a two-tab race. The purge data disagreed: runbook §5b found the real constraint-blocking pairs **10 hours** and **3 days** apart. KAN-220 identifies the mechanism — an expired Flask session is silently downgraded to a guest session on save (`ensureGuestSession()` is called unconditionally), while Google's SSO cookie stays valid so the later login is instant. One user, one tab, no race.

This does not change anything in this PR, but it means the path that will refuse most real duplicates is the **guest→login merge**, not the concurrent `POST`.

## Ships with

Cookbook PR bumping the submodule pointer — this cannot reach production alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EfffNRnHWdCc7Pn4rEfMp

















<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

