### PR TITLE
fix(recipes): address PR #275 review feedback [KAN-213]

### DIFF
--- a/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
+++ b/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
@@ -23,7 +23,7 @@ indexes are the correct shape rather than one composite constraint — the same
 reasoning as the cookbook pair in b7e2a9c4d1f8. Both ship together or neither
 (Sprint 6 R3): guests key on guest_session_id, which is the KAN-186 path.
 
-Partial on ``source_slug IS NOT NULL`` deliberately, and the scope is narrower
+Partial on ``COALESCE(source_slug, slug) IS NOT NULL``, and the scope is narrower
 than "most of the table is excluded" suggests. Only ``origin = 'saved'`` rows
 carry a source_slug (the SPA sets origin and sourceSlug together when saving
 from a public page), so:

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -14,10 +14,11 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     # partial indexes are the right shape rather than one composite constraint
     # — the same reasoning as cookbook's uq_cookbook_* pair.
     #
-    # Partial on `source_slug IS NOT NULL` by design, and narrower than that
-    # reads: only `origin='saved'` rows carry a source_slug, so these indexes
-    # constrain COPIES A USER TOOK from someone else's public page and do not
-    # constrain a single recipe a user authored (~3% of user 1's rows).
+    # Partial on `COALESCE(source_slug, slug) IS NOT NULL`, but narrower than
+    # that reads: only `origin='saved'` rows carry a source_slug, and `slug`
+    # is already globally unique, so these indexes constrain COPIES A USER TOOK
+    # from someone else's public page and do not constrain a single recipe a
+    # user authored (~3% of user 1's rows).
     #
     # Still the right corner: a saved copy is the only case where "these two
     # rows are the same recipe" is a machine-checkable fact. Two separately

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -340,7 +340,8 @@ def _duplicate_source_slug_owner(
         return False
     # Mirrors the index key COALESCE(source_slug, slug): a row's identity is the
     # public recipe it points at, or its own page when it is the original.
-    identity = recipe_data.get("sourceSlug") or recipe_data.get("slug")
+    source = recipe_data.get("sourceSlug")
+    identity = source if source is not None else recipe_data.get("slug")
     if identity is None:
         return False  # no identity — outside both partial indexes
 

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -11,10 +11,10 @@ cross-context race by construction: two tabs, or a tab and a phone, both read
 These tests pin the fix at the only layer that can refuse the second write —
 two partial unique indexes:
 
-    uq_recipe_user_source_slug   UNIQUE (user_id, source_slug)
-        WHERE source_slug IS NOT NULL AND user_id IS NOT NULL
-    uq_recipe_guest_source_slug  UNIQUE (guest_session_id, source_slug)
-        WHERE source_slug IS NOT NULL AND guest_session_id IS NOT NULL
+    uq_recipe_user_recipe_identity   UNIQUE (user_id, COALESCE(source_slug, slug))
+        WHERE COALESCE(source_slug, slug) IS NOT NULL AND user_id IS NOT NULL
+    uq_recipe_guest_recipe_identity  UNIQUE (guest_session_id, COALESCE(source_slug, slug))
+        WHERE COALESCE(source_slug, slug) IS NOT NULL AND guest_session_id IS NOT NULL
 
 Both ship together or neither (Sprint 6 R3): ``user_id`` is nullable and guests
 key on ``guest_session_id``, which is the KAN-186 path.


### PR DESCRIPTION
## Summary

Addresses Copilot review feedback on the dev→main promotion PR #275:

- **`or` → `is not None`** (`db_recipe_repository.py`): Python `or` treats `""` as falsy, mismatching SQL `COALESCE("", slug)` which returns `""`. After a duplicate IntegrityError, the probe would check the wrong identity and surface a 500 instead of the promised 409. Practically unreachable (the SPA never sends `sourceSlug: ""`), but the code should match the SQL semantics.
- **Documentation accuracy** (3 files): comments/docstrings said "partial on `source_slug IS NOT NULL`" but the actual predicates are `COALESCE(source_slug, slug) IS NOT NULL`. Updated the model comment, migration docstring, and test module docstring to name the correct index names and WHERE clauses.

Two other review comments (auth_api_bp source_slug clearing, migration fixed-point) were rebutted — see thread replies on #275.

## Test plan

- [x] `uv run pytest tests/test_source_slug_unique.py` — 12 passed, 1 xfailed
- [ ] Full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoJz3wTTx2R9oxWFTN8PBN



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

