### PR TITLE
fix(recipes): migration dedup fixed-point, guest-merge collision [KAN-223]

### DIFF
--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -212,15 +212,30 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                             sanitize_log_value(recipe.slug),
                         )
                         # Point guest cookbooks holding this recipe id at the
-                        # owned copy that occupies the same identity. Without
-                        # this, the cookbook gets reassigned to the user with
-                        # a reference to a recipe still owned by the guest
-                        # session — and get_recipe refuses cross-owner access,
-                        # so the SPA sees a dangling id. The existing
-                        # invariant ``set(cb.recipe_ids) <= live_ids`` (see
+                        # owned copy that occupies `recipe.slug` specifically
+                        # — NOT the already-computed `existing_id`. When this
+                        # row's source_slug and slug both matched a different
+                        # owned row each, `existing_id` was resolved by
+                        # iterating `_recipe_identity_keys()`'s *set*, so it
+                        # may hold whichever of the two owned rows was
+                        # matched via the now-cleared source_slug side, not
+                        # the one that owns the identity still colliding here
+                        # (recipe.slug, just tested above). Remapping to the
+                        # stale existing_id would silently substitute the
+                        # wrong recipe into the user's cookbook — worse than
+                        # the dangling-id case this branch also guards,
+                        # because it doesn't 404, it just shows the wrong
+                        # recipe. Caught by Copilot review on PR #277.
+                        #
+                        # Without remapping at all, the cookbook gets
+                        # reassigned to the user with a reference to a recipe
+                        # still owned by the guest session — and get_recipe
+                        # refuses cross-owner access, so the SPA sees a
+                        # dangling id. The existing invariant
+                        # ``set(cb.recipe_ids) <= live_ids`` (see
                         # test_cookbook_membership_is_remapped_to_the_surviving_row)
                         # is exactly what breaks otherwise.
-                        remapped[recipe.id] = existing_id
+                        remapped[recipe.id] = owned_by_key[recipe.slug]
                         continue
 
                 recipe.user_id = user.id

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -17,6 +17,8 @@ from flask import Blueprint, jsonify, redirect, request, session, url_for
 from google_auth_oauthlib.flow import Flow
 from sqlalchemy.exc import IntegrityError
 
+from utils.log_sanitizer import sanitize_log_value
+
 load_dotenv()
 
 logger = logging.getLogger(__name__)
@@ -165,9 +167,12 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                     # source_slug takes it out of the partial index's coverage
                     # so a single legacy row cannot cost someone their data.
                     #
-                    # Nothing of value is lost: the row is kept precisely
+                    # Usually nothing of value is lost: the row is kept
                     # because it is a published page in its own right, so its
-                    # own `slug` identifies it from here on.
+                    # own `slug` identifies it from here on — UNLESS that slug
+                    # is itself what matched `existing_id` (see the KAN-223
+                    # check below), in which case clearing source_slug alone
+                    # doesn't remove the collision.
                     #
                     # Clear the MIRRORED BLOB KEY TOO, not just the column.
                     # `source_slug` mirrors `data['sourceSlug']`, and
@@ -183,6 +188,30 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                     recipe.source_slug = None
                     if recipe.data and "sourceSlug" in recipe.data:
                         del recipe.data["sourceSlug"]
+
+                    # KAN-223: the clear above only removes the collision if
+                    # it came through `source_slug`. `_recipe_identity_keys()`
+                    # matches on `slug` too, and clearing `source_slug`
+                    # doesn't touch that — so if THIS row's own `slug` is what
+                    # matched `existing_id` (not its `source_slug`), the
+                    # post-clear identity (COALESCE(NULL, recipe.slug) ==
+                    # recipe.slug) is exactly the value that collided in the
+                    # first place. Reassigning it would still raise
+                    # IntegrityError and roll back the ENTIRE merge over one
+                    # legacy row, taking every other guest recipe and
+                    # cookbook down with it — check first, and leave this one
+                    # row under its guest session instead.
+                    if recipe.slug and recipe.slug in owned_by_key:
+                        logger.warning(
+                            "KAN-213/KAN-223: guest recipe %s left under its "
+                            "guest session at login — its slug %s still "
+                            "collides with an owned recipe after clearing "
+                            "source_slug (legacy public-row path; should be "
+                            "unreachable via _gate_is_public)",
+                            sanitize_log_value(recipe.id),
+                            sanitize_log_value(recipe.slug),
+                        )
+                        continue
 
                 recipe.user_id = user.id
                 recipe.guest_session_id = None

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -211,6 +211,16 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                             sanitize_log_value(recipe.id),
                             sanitize_log_value(recipe.slug),
                         )
+                        # Point guest cookbooks holding this recipe id at the
+                        # owned copy that occupies the same identity. Without
+                        # this, the cookbook gets reassigned to the user with
+                        # a reference to a recipe still owned by the guest
+                        # session — and get_recipe refuses cross-owner access,
+                        # so the SPA sees a dangling id. The existing
+                        # invariant ``set(cb.recipe_ids) <= live_ids`` (see
+                        # test_cookbook_membership_is_remapped_to_the_surviving_row)
+                        # is exactly what breaks otherwise.
+                        remapped[recipe.id] = existing_id
                         continue
 
                 recipe.user_id = user.id

--- a/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
+++ b/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
@@ -150,6 +150,11 @@ def _clear_duplicate_identities(bind, scope_col):
 
     Returns the number of rows cleared so the caller can log a real number
     rather than claiming success blindly.
+
+    One pass, not a fixed point: clearing a loser's ``source_slug`` moves its
+    identity to its own ``slug`` (COALESCE's fallback side), which this
+    snapshot never re-evaluates. Callers MUST loop this to a fixed point
+    (KAN-223) — see ``upgrade()`` below.
     """
     rows = bind.execute(
         sa.text(
@@ -189,8 +194,20 @@ def upgrade():
     if bind.dialect.name == "postgresql":
         op.execute("LOCK TABLE recipe IN ACCESS EXCLUSIVE MODE")
 
-    cleared = _clear_duplicate_identities(bind, "user_id")
-    cleared += _clear_duplicate_identities(bind, "guest_session_id")
+    # Loop each scope to a fixed point (KAN-223). A single pass can clear a
+    # loser onto an identity (its own `slug`) that then collides with a row
+    # the snapshot never re-examined. Guaranteed to terminate: a cleared row
+    # (source_slug NULL) can never lose again — `slug` is globally unique, so
+    # at most one NULL-source row exists per (scope, identity) group, and it
+    # always sorts first — so the count of NOT-NULL-source rows strictly
+    # decreases every round that clears anything.
+    cleared = 0
+    for scope_col in ("user_id", "guest_session_id"):
+        while True:
+            round_cleared = _clear_duplicate_identities(bind, scope_col)
+            cleared += round_cleared
+            if not round_cleared:
+                break
     if cleared:
         # Expected to be 0 in production (purged by hand, gates verified empty).
         # A non-zero count here means duplicates appeared after that purge and

--- a/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
+++ b/migrations/versions/c8f3b71d20a4_recipe_source_slug_unique_indexes.py
@@ -154,7 +154,7 @@ def _clear_duplicate_identities(bind, scope_col):
     One pass, not a fixed point: clearing a loser's ``source_slug`` moves its
     identity to its own ``slug`` (COALESCE's fallback side), which this
     snapshot never re-evaluates. Callers MUST loop this to a fixed point
-    (KAN-223) — see ``upgrade()`` below.
+    (KAN-223) — see ``_clear_scope_to_fixed_point()`` below.
     """
     rows = bind.execute(
         sa.text(
@@ -185,6 +185,30 @@ def _clear_duplicate_identities(bind, scope_col):
     return cleared
 
 
+def _clear_scope_to_fixed_point(bind, scope_col):
+    """Loop ``_clear_duplicate_identities`` for one scope until it clears nothing.
+
+    A single pass can clear a loser onto an identity (its own `slug`) that then
+    collides with a row the snapshot never re-examined (KAN-223). Guaranteed to
+    terminate: a cleared row (source_slug NULL) can never lose again — `slug` is
+    globally unique, so at most one NULL-source row exists per (scope, identity)
+    group, and it always sorts first — so the count of NOT-NULL-source rows
+    strictly decreases every round that clears anything.
+
+    Shared by ``upgrade()`` and the regression test that pins this behavior
+    (``test_migration_recipe_source_slug_unique.py``) so a test hand-rolling
+    its own loop can't drift from what production actually runs. Caught by
+    Copilot review on PR #277.
+    """
+    cleared = 0
+    while True:
+        round_cleared = _clear_duplicate_identities(bind, scope_col)
+        cleared += round_cleared
+        if not round_cleared:
+            break
+    return cleared
+
+
 def upgrade():
     bind = op.get_bind()
 
@@ -194,20 +218,10 @@ def upgrade():
     if bind.dialect.name == "postgresql":
         op.execute("LOCK TABLE recipe IN ACCESS EXCLUSIVE MODE")
 
-    # Loop each scope to a fixed point (KAN-223). A single pass can clear a
-    # loser onto an identity (its own `slug`) that then collides with a row
-    # the snapshot never re-examined. Guaranteed to terminate: a cleared row
-    # (source_slug NULL) can never lose again — `slug` is globally unique, so
-    # at most one NULL-source row exists per (scope, identity) group, and it
-    # always sorts first — so the count of NOT-NULL-source rows strictly
-    # decreases every round that clears anything.
-    cleared = 0
-    for scope_col in ("user_id", "guest_session_id"):
-        while True:
-            round_cleared = _clear_duplicate_identities(bind, scope_col)
-            cleared += round_cleared
-            if not round_cleared:
-                break
+    cleared = sum(
+        _clear_scope_to_fixed_point(bind, scope_col)
+        for scope_col in ("user_id", "guest_session_id")
+    )
     if cleared:
         # Expected to be 0 in production (purged by hand, gates verified empty).
         # A non-zero count here means duplicates appeared after that purge and

--- a/tests/test_guest_merge_dedup.py
+++ b/tests/test_guest_merge_dedup.py
@@ -155,6 +155,41 @@ def test_public_guest_duplicate_is_reassigned_not_deleted(app, user):
     assert {r.slug for r in rows} == {None, "vegan-fried-pizza-dough-2"}
 
 
+def test_guest_own_slug_collision_is_left_unreassigned_not_rolled_back(app, user):
+    """KAN-223: the legacy public-row clear only handles a source_slug-side match.
+
+    Owned row X is a saved copy pointing at public page "cornbread"
+    (``source_slug="cornbread"``). The guest's public row IS that page
+    (``slug="cornbread"``) — so ``_recipe_identity_keys()`` matches
+    ``existing_id`` via the guest row's own ``slug``, not its ``source_slug``.
+    Clearing ``source_slug`` (which is already None here) does nothing: the
+    post-clear identity is still ``COALESCE(None, "cornbread") == "cornbread"``,
+    the exact value that collided.
+
+    Before the fix this raised IntegrityError on commit — every retry hit the
+    same collision — and the exception propagated out of
+    ``_merge_guest_session_into_user``, which would have taken every other
+    guest recipe and cookbook in the same login merge down with it. The fix
+    detects the still-colliding identity before reassigning and leaves this
+    one row under its guest session instead.
+    """
+    _recipe("Cornbread copy", owner=user, source_slug="cornbread")
+    guest_original = _recipe("Cornbread", guest=GUEST_SESSION, slug="cornbread", public=True)
+    db.session.commit()
+    guest_original_id = guest_original.id
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)  # must not raise
+
+    owned_rows = Recipe.query.filter_by(user_id=user.id).all()
+    assert len(owned_rows) == 1, "the still-colliding row must not have been reassigned"
+
+    left_behind = Recipe.query.filter_by(id=guest_original_id).one()
+    assert left_behind.user_id is None
+    assert (
+        left_behind.guest_session_id == GUEST_SESSION
+    ), "left under the guest session, not lost, not partially merged"
+
+
 def test_cookbook_membership_is_remapped_to_the_surviving_row(app, user):
     """Cookbook.recipe_ids is a JSON id list — it must not keep a dangling id."""
     owned = _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")

--- a/tests/test_guest_merge_dedup.py
+++ b/tests/test_guest_merge_dedup.py
@@ -204,6 +204,51 @@ def test_guest_own_slug_collision_is_left_unreassigned_not_rolled_back(app, user
     assert set(cb.recipe_ids) <= live_ids, "cookbook references a recipe the user does not own"
 
 
+def test_guest_own_slug_collision_remaps_to_the_row_that_still_collides(app, user):
+    """KAN-223 continued (Copilot on PR #277): existing_id can be ambiguous.
+
+    The legacy public row here matches an owned recipe via TWO different
+    identity keys at once: its ``source_slug`` matches "pizza-dough" (owned by
+    ``other_original``) and its own ``slug`` matches "cornbread" (owned by
+    ``cornbread_original``). ``existing_id`` is resolved by iterating
+    ``_recipe_identity_keys()``'s *set*, so it may hold either match — but
+    once ``source_slug`` is cleared, the identity that still collides is only
+    "cornbread". Remapping to a stale ``existing_id`` that happened to resolve
+    via the "pizza-dough" side would point the cookbook at the wrong recipe
+    entirely: silent data substitution, not just a dangling id.
+    """
+    other_original = _recipe("Pizza Dough", owner=user, source_slug="pizza-dough")
+    cornbread_original = _recipe("Cornbread copy", owner=user, source_slug="cornbread")
+    guest_original = _recipe(
+        "Cornbread",
+        guest=GUEST_SESSION,
+        source_slug="pizza-dough",
+        slug="cornbread",
+        public=True,
+    )
+    db.session.commit()
+    other_original_id = other_original.id
+    cornbread_original_id = cornbread_original.id
+    guest_original_id = guest_original.id
+
+    _cookbook("Weeknight", [guest_original_id], guest=GUEST_SESSION)
+    db.session.commit()
+
+    _merge_guest_session_into_user(user, GUEST_SESSION)  # must not raise
+
+    cb = Cookbook.query.filter_by(user_id=user.id).one()
+    assert cb.recipe_ids == [cornbread_original_id], (
+        "must remap to the row occupying 'cornbread' — the identity that "
+        "still collides after source_slug is cleared — not the row matched "
+        "via the already-cleared 'pizza-dough' side"
+    )
+    assert other_original_id not in cb.recipe_ids
+
+    left_behind = Recipe.query.filter_by(id=guest_original_id).one()
+    assert left_behind.user_id is None
+    assert left_behind.guest_session_id == GUEST_SESSION
+
+
 def test_cookbook_membership_is_remapped_to_the_surviving_row(app, user):
     """Cookbook.recipe_ids is a JSON id list — it must not keep a dangling id."""
     owned = _recipe("Pizza Dough", owner=user, source_slug="vegan-fried-pizza-dough")

--- a/tests/test_guest_merge_dedup.py
+++ b/tests/test_guest_merge_dedup.py
@@ -173,10 +173,16 @@ def test_guest_own_slug_collision_is_left_unreassigned_not_rolled_back(app, user
     detects the still-colliding identity before reassigning and leaves this
     one row under its guest session instead.
     """
-    _recipe("Cornbread copy", owner=user, source_slug="cornbread")
+    owned = _recipe("Cornbread copy", owner=user, source_slug="cornbread")
     guest_original = _recipe("Cornbread", guest=GUEST_SESSION, slug="cornbread", public=True)
     db.session.commit()
-    guest_original_id = guest_original.id
+    owned_id, guest_original_id = owned.id, guest_original.id
+
+    # A guest cookbook holding the skipped recipe must not be reassigned to the
+    # user with a dangling id — get_recipe refuses cross-owner access, so a
+    # user cookbook pointing at a guest-owned recipe id 404s in the SPA.
+    _cookbook("Weeknight", [guest_original_id], guest=GUEST_SESSION)
+    db.session.commit()
 
     _merge_guest_session_into_user(user, GUEST_SESSION)  # must not raise
 
@@ -188,6 +194,14 @@ def test_guest_own_slug_collision_is_left_unreassigned_not_rolled_back(app, user
     assert (
         left_behind.guest_session_id == GUEST_SESSION
     ), "left under the guest session, not lost, not partially merged"
+
+    cb = Cookbook.query.filter_by(user_id=user.id).one()
+    assert cb.recipe_ids == [owned_id], (
+        "cookbook must be remapped to the owned copy, not left pointing at "
+        "the guest-owned recipe (dangling reference)"
+    )
+    live_ids = {r.id for r in Recipe.query.filter_by(user_id=user.id).all()}
+    assert set(cb.recipe_ids) <= live_ids, "cookbook references a recipe the user does not own"
 
 
 def test_cookbook_membership_is_remapped_to_the_surviving_row(app, user):

--- a/tests/test_migration_recipe_source_slug_unique.py
+++ b/tests/test_migration_recipe_source_slug_unique.py
@@ -295,10 +295,12 @@ def test_single_pass_misses_a_chained_collision_that_looping_resolves(tmp_path):
         "this is the bug: building the indexes here would still fail"
     )
 
-    # The fix: loop the same call, per scope, until it clears nothing.
+    # The fix: loop the same call, per scope, until it clears nothing. Calls
+    # the exact helper upgrade() calls (Copilot review on PR #277) — a
+    # hand-rolled loop here wouldn't notice if upgrade() regressed to a
+    # single pass.
     with engine.begin() as conn:
-        while mig._clear_duplicate_identities(conn, "user_id"):
-            pass
+        mig._clear_scope_to_fixed_point(conn, "user_id")
         rows = dict(conn.execute(sa.text("SELECT id, source_slug FROM recipe")).fetchall())
 
     assert rows["a"] == "orig", "A is untouched — it won its group outright"

--- a/tests/test_migration_recipe_source_slug_unique.py
+++ b/tests/test_migration_recipe_source_slug_unique.py
@@ -247,6 +247,69 @@ def test_published_original_wins_over_a_saved_copy_of_itself(tmp_path):
         _build_indexes(conn)
 
 
+def test_single_pass_misses_a_chained_collision_that_looping_resolves(tmp_path):
+    """KAN-223: clearing a loser can expose a new collision the snapshot never re-checks.
+
+    Same user scope, three rows:
+      A: source_slug='orig'              (a saved copy pointing at /r/orig)
+      B: source_slug='orig', slug='copy' (a saved copy of /r/orig, later
+                                           published at its own /r/copy)
+      C: source_slug='copy'              (a saved copy pointing at /r/copy — i.e. of B)
+
+    One call groups strictly by the pre-call snapshot: {A, B} collide on
+    identity 'orig' (B loses, cleared), {C} is alone on 'copy' — the snapshot
+    was taken before B's clear, so it never saw that B's post-clear identity
+    (COALESCE(NULL, 'copy') = 'copy') now collides with C. Building the
+    indexes on that residual state still fails.
+
+    A second call (fresh SELECT) sees B's now-NULL source_slug and correctly
+    re-groups {B, C} on 'copy' — and B rightly wins: it is the actual page at
+    /r/copy (case=0, NULL-source first), C is a copy of it (case=1). Looping
+    per scope until a call clears nothing (``upgrade()``'s fix) reaches this
+    fixed point in general, not just for this one extra round.
+    """
+    mig = _load_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                ("a", 1, None, "orig", "2026-01-01"),
+                ("b", 1, None, "orig", "2026-01-02", "copy"),
+                ("c", 1, None, "copy", "2026-01-03"),
+            ],
+        )
+        first_pass = mig._clear_duplicate_identities(conn, "user_id")
+        residual = conn.execute(
+            sa.text(
+                "SELECT count(*) FROM ("
+                "  SELECT coalesce(source_slug, slug) AS identity, count(*) AS n"
+                "  FROM recipe WHERE user_id = 1 GROUP BY identity"
+                ") t WHERE t.n > 1"
+            )
+        ).scalar()
+
+    assert first_pass == 1, "one pass only resolves the collision the pre-call snapshot saw"
+    assert residual == 1, (
+        "a single pass leaves B's newly-exposed collision with C unresolved — "
+        "this is the bug: building the indexes here would still fail"
+    )
+
+    # The fix: loop the same call, per scope, until it clears nothing.
+    with engine.begin() as conn:
+        while mig._clear_duplicate_identities(conn, "user_id"):
+            pass
+        rows = dict(conn.execute(sa.text("SELECT id, source_slug FROM recipe")).fetchall())
+
+    assert rows["a"] == "orig", "A is untouched — it won its group outright"
+    assert rows["b"] is None, "B lost 'orig' to A, then won 'copy' outright (it's the real page)"
+    assert rows["c"] is None, "C lost 'copy' to B once B's post-clear identity was re-evaluated"
+
+    # The whole point: the indexes can now be built without a residual collision.
+    with engine.begin() as conn:
+        _build_indexes(conn)
+
+
 def test_index_refuses_a_copy_of_your_own_published_recipe(tmp_path):
     """The refusal itself, for the identity case — seen to fire."""
     engine = _bare_recipe_engine(tmp_path)


### PR DESCRIPTION
## Summary

Fixes the two remaining unfixed findings from PR #273's second Copilot review pass, confirmed still live on `origin/dev` (see PR #275 review + [Sprint 6 retro discussion](https://github.com/adamtasteslikegood/tasteslikegoodtheangularsvegancookbook/discussions/3376) for full history). PR #276 fixed a third finding (`or`/`COALESCE`); these two were never fixed, replied to, or actually covered by the KAN-221 deferral — checked KAN-221 directly, its scope is only the schema redesign.

- **Migration `_clear_duplicate_identities` is now a fixed point, not a single pass.** Clearing a loser's `source_slug` can move its identity to its own `slug` (COALESCE's fallback side), which a single snapshot never re-evaluates — could leave a chained collision that fails index creation. Now loops each scope until a call clears nothing.
- **Guest-merge clearing gap bounded.** The legacy public-guest-row clear only removed `source_slug` from the collision; if the match came through the row's own `slug`, reassignment still raised `IntegrityError` and rolled back the *entire* login merge over one row. Now checks the post-clear identity before reassigning and skips just that row (left under its guest session, logged) instead.

Both currently unreachable against live data/paths (prod dedup count expected 0; guests can't publish per `_gate_is_public`) — fixed anyway since the failure mode if either invariant breaks is severe relative to the fix cost.

Jira: [KAN-223](https://tasteslikegood.atlassian.net/browse/KAN-223)

## Test plan

- [x] New regression test for the migration fixed-point bug (`test_single_pass_misses_a_chained_collision_that_looping_resolves`) — verified it fails without the fix (residual collision after one pass), passes with it
- [x] New regression test for the guest-merge gap (`test_guest_own_slug_collision_is_left_unreassigned_not_rolled_back`) — verified it fails without the fix (`IntegrityError` propagates, exactly as predicted), passes with it
- [x] Full suite: `uv run pytest` — 378 passed, 1 xfailed (expected, KAN-221)
- [x] `uv run black --check .`, `uv run flake8`, `uv run mypy .` — all clean
- [x] `uv run flask db heads` — single head

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KAN-223]: https://tasteslikegood.atlassian.net/browse/KAN-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

