### PR TITLE
feat(recipes): saved-copy publish guard + schema split [RCP-74] [KAN-221]

### DIFF
--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -240,14 +240,36 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
 
                 recipe.user_id = user.id
                 recipe.guest_session_id = None
-                # KAN-221: carry author/saver columns through login-merge.
-                # user_id_saved_to follows user_id (saver is the acting user).
-                # user_id_author follows user_id only for originals (guest IS
-                # the author); for saved copies it stays immutable.
-                if recipe.user_id_saved_to is not None:
+                # KAN-221: carry author/saver columns through login-merge, per
+                # the locked merge rules. Branch on PERSISTED provenance — the
+                # previous condition (`user_id_saved_to is not None`) was never
+                # true for guest rows, because the create path sets saved_to to
+                # user_id, which is None for every guest (Copilot B2 on #279).
+                #
+                #   guest-SAVED copy (provenance non-null): the guest is the
+                #     saver, not the author — author = the source row's owner,
+                #     saved_to = the user logging in. Author stays immutable if
+                #     creation already resolved it; an unresolvable source
+                #     (deleted, never existed) leaves it NULL, matching the
+                #     orphan rule in migration d680a4b61194.
+                #   guest-GENERATED original: the guest IS the author —
+                #     author = saved_to = the user logging in.
+                if recipe.source_slug is not None or recipe.source_recipe_id is not None:
                     recipe.user_id_saved_to = user.id
-                if recipe.source_slug is None and recipe.user_id_author is None:
-                    recipe.user_id_author = user.id
+                    if recipe.user_id_author is None:
+                        source = None
+                        if recipe.source_recipe_id is not None:
+                            source = db.session.get(Recipe, recipe.source_recipe_id)
+                        if source is None and recipe.source_slug is not None:
+                            source = Recipe.query.filter(
+                                Recipe.slug == recipe.source_slug,
+                                Recipe.id != recipe.id,
+                            ).first()
+                        recipe.user_id_author = source.user_id if source is not None else None
+                else:
+                    if recipe.user_id_author is None:
+                        recipe.user_id_author = user.id
+                    recipe.user_id_saved_to = user.id
                 for key in _recipe_identity_keys(recipe):
                     owned_by_key.setdefault(key, recipe.id)
 

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -240,6 +240,14 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
 
                 recipe.user_id = user.id
                 recipe.guest_session_id = None
+                # KAN-221: carry author/saver columns through login-merge.
+                # user_id_saved_to follows user_id (saver is the acting user).
+                # user_id_author follows user_id only for originals (guest IS
+                # the author); for saved copies it stays immutable.
+                if recipe.user_id_saved_to is not None:
+                    recipe.user_id_saved_to = user.id
+                if recipe.source_slug is None and recipe.user_id_author is None:
+                    recipe.user_id_author = user.id
                 for key in _recipe_identity_keys(recipe):
                     owned_by_key.setdefault(key, recipe.id)
 

--- a/blueprints/auth_api_bp.py
+++ b/blueprints/auth_api_bp.py
@@ -75,7 +75,7 @@ def _recipe_identity_keys(recipe):
     ``slug``. Empty values never match — ``None == None`` must not make two
     unrelated locally-authored recipes look like the same recipe.
     """
-    return {value for value in (recipe.source_slug, recipe.slug) if value}
+    return {value for value in (recipe.source_recipe_id, recipe.source_slug, recipe.slug) if value}
 
 
 def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
@@ -263,13 +263,13 @@ def _merge_guest_session_into_user(user, guest_session_id, max_retries=3):
                         if source is None and recipe.source_slug is not None:
                             source = Recipe.query.filter(
                                 Recipe.slug == recipe.source_slug,
+                                Recipe.is_public.is_(True),
                                 Recipe.id != recipe.id,
                             ).first()
                         recipe.user_id_author = source.user_id if source is not None else None
                 else:
                     if recipe.user_id_author is None:
                         recipe.user_id_author = user.id
-                    recipe.user_id_saved_to = user.id
                 for key in _recipe_identity_keys(recipe):
                     owned_by_key.setdefault(key, recipe.id)
 

--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -76,6 +76,7 @@ def list_recipes(user_id, guest_session_id):
                             "is_public": recipe.is_public,
                             "is_canonical": recipe.is_canonical,
                             "source_slug": recipe.source_slug,
+                            "source_recipe_id": recipe.source_recipe_id,
                             "origin": recipe.origin,
                             "created_at": (
                                 recipe.created_at.isoformat() if recipe.created_at else None

--- a/blueprints/recipes_api_bp.py
+++ b/blueprints/recipes_api_bp.py
@@ -164,6 +164,8 @@ def create_recipe(user_id, guest_session_id):
         return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
     except db_recipe_repository.ManualRecipeError:
         return jsonify({"error": db_recipe_repository.MANUAL_RECIPE_UNPUBLISHABLE_ERROR}), 400
+    except db_recipe_repository.SavedCopyPublishError:
+        return jsonify({"error": db_recipe_repository.SAVED_COPY_PUBLISH_ERROR}), 403
     except Exception as e:
         logger.error(f"Error creating recipe: {e}")
         return jsonify({"error": "Failed to create recipe"}), 500
@@ -239,6 +241,8 @@ def update_recipe(user_id, guest_session_id, recipe_id):
         return jsonify({"error": db_recipe_repository.CANONICAL_RECIPE_LOCKED_ERROR}), 400
     except db_recipe_repository.ManualRecipeError:
         return jsonify({"error": db_recipe_repository.MANUAL_RECIPE_UNPUBLISHABLE_ERROR}), 400
+    except db_recipe_repository.SavedCopyPublishError:
+        return jsonify({"error": db_recipe_repository.SAVED_COPY_PUBLISH_ERROR}), 403
     except Exception as e:
         logger.error(
             "Error updating recipe %s: %s",

--- a/migrations/versions/a3c9e1f4b7d2_add_source_recipe_id_and_rekey_identity.py
+++ b/migrations/versions/a3c9e1f4b7d2_add_source_recipe_id_and_rekey_identity.py
@@ -1,0 +1,157 @@
+"""add source_recipe_id and re-key the KAN-213 identity indexes onto it
+
+KAN-221 (locked 2026-08-10/11): the provenance key moves from the mutable slug
+string to the stable source row id.
+
+    source_recipe_id  String(36) FK -> recipe.id, ON DELETE SET NULL.
+                      Immutable once set; resolved server-side, never
+                      client-writable. source_slug is KEPT — it still builds
+                      the /r/<slug> link — only the KEY moves.
+
+The KAN-213 partial unique indexes are re-keyed from
+
+    (scope, COALESCE(source_slug, slug))            [c8f3b71d20a4]
+
+to
+
+    (scope, COALESCE(source_recipe_id, source_slug, id))
+
+For saved copies this IS the locked (user_id_saved_to, source_recipe_id)
+constraint: user_id == user_id_saved_to on every saved copy by construction
+(create sets both to the saver; login-merge sets both to the new user), and the
+scope columns stay user_id / guest_session_id so guest copies and non-copy rows
+keep their coverage. Reading the new COALESCE:
+
+  - a resolved copy keys on its source's immutable id, so it collides with the
+    source row itself (which keys on its own id — the `id` arm) and with every
+    other resolved copy of it under the same owner, regardless of slug renames;
+  - an unresolved copy (source gone before this backfill, raw legacy rows)
+    falls back to the slug pointer, preserving c8f3b71d20a4's dedup between
+    such copies;
+  - every other row keys on its own primary key, which is vacuously unique —
+    the constraint still only ever refuses pairs involving a saved copy, so
+    authored recipes remain unconstrained exactly as agreed on KAN-213.
+
+Why NO de-dup pre-pass this time: every group the new key forms is a subset of
+a group the old key formed (a resolved copy's source id replaces the slug both
+sides shared; the id arm only joins rows the slug arm already joined via the
+globally-unique slug). Data that satisfies the c8f3b71d20a4 indexes therefore
+cannot violate these, and alembic guarantees c8f3b71d20a4 ran first.
+
+Same operational rules as c8f3b71d20a4: NO ``CREATE INDEX CONCURRENTLY``
+(an invalid index that silently enforces nothing is this project's most
+expensive recurring failure mode); an ACCESS EXCLUSIVE lock instead, held for
+the whole transaction, affordable because `recipe` is a small table. The old
+indexes are dropped before the batch column-add so SQLite's batch table
+recreation never has to copy the expression indexes.
+
+Revision ID: a3c9e1f4b7d2
+Revises: d680a4b61194
+Create Date: 2026-08-11 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3c9e1f4b7d2"
+down_revision = "d680a4b61194"
+branch_labels = None
+depends_on = None
+
+# Matches models/recipe.py._IDENTITY — the model declares the same indexes so
+# db.create_all() (tests, fresh dev) matches what this migration builds.
+_IDENTITY = "coalesce(source_recipe_id, source_slug, id)"
+_IDENTITY_V1 = "coalesce(source_slug, slug)"
+
+_INDEXES = (
+    ("uq_recipe_user_recipe_identity", "user_id"),
+    ("uq_recipe_guest_recipe_identity", "guest_session_id"),
+)
+
+
+def _backfill_source_recipe_id(conn):
+    """Resolve each copy's source_slug to the source row's id.
+
+    The same resolution d680a4b61194 used for the author backfill (slug match
+    on a public row), so the two provenance columns can never disagree about
+    which row a copy came from. Unresolvable pointers stay NULL: the row keeps
+    its source_slug, stays a saved copy for the publish guard, and falls back
+    to the slug arm of the identity key. On a bare connection so tests can
+    execute the real thing (the c8f3b71d20a4 pattern).
+    """
+    conn.execute(
+        sa.text(
+            "UPDATE recipe SET "
+            "  source_recipe_id = ("
+            "    SELECT r2.id FROM recipe r2 "
+            "    WHERE r2.slug = recipe.source_slug "
+            "    AND r2.is_public "
+            "    LIMIT 1"
+            "  ) "
+            "WHERE source_slug IS NOT NULL"
+        )
+    )
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    # Hold writers out for the whole drop -> add -> backfill -> re-key
+    # sequence; released when this migration's transaction commits.
+    # Postgres only: SQLite has no LOCK TABLE and runs single-connection.
+    if bind.dialect.name == "postgresql":
+        op.execute("LOCK TABLE recipe IN ACCESS EXCLUSIVE MODE")
+
+    # IF EXISTS (portable across PostgreSQL and SQLite), not op.drop_index: on
+    # SQLite, d680a4b61194's batch_alter_table recreated the recipe table and
+    # silently dropped these expression indexes (alembic batch mode cannot
+    # reflect them), so a local dev chain reaches this point without them. On
+    # PostgreSQL batch mode is a plain ALTER and they exist. Either way this
+    # migration ends by (re)creating the re-keyed pair below, which also heals
+    # the SQLite drift.
+    for name, _scope in _INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {name}")
+
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("source_recipe_id", sa.String(length=36), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_recipe_source_recipe_id",
+            "recipe",
+            ["source_recipe_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    _backfill_source_recipe_id(bind)
+
+    for name, scope in _INDEXES:
+        op.create_index(
+            name,
+            "recipe",
+            [sa.text(scope), sa.text(_IDENTITY)],
+            unique=True,
+            postgresql_where=sa.text(f"{scope} IS NOT NULL"),
+            sqlite_where=sa.text(f"{scope} IS NOT NULL"),
+        )
+
+
+def downgrade():
+    for name, _scope in _INDEXES:
+        op.drop_index(name, table_name="recipe")
+
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_recipe_source_recipe_id", type_="foreignkey")
+        batch_op.drop_column("source_recipe_id")
+
+    # Restore the c8f3b71d20a4 shape.
+    for name, scope in _INDEXES:
+        op.create_index(
+            name,
+            "recipe",
+            [sa.text(scope), sa.text(_IDENTITY_V1)],
+            unique=True,
+            postgresql_where=sa.text(f"{_IDENTITY_V1} IS NOT NULL AND {scope} IS NOT NULL"),
+            sqlite_where=sa.text(f"{_IDENTITY_V1} IS NOT NULL AND {scope} IS NOT NULL"),
+        )

--- a/migrations/versions/d680a4b61194_add_user_id_author_and_user_id_saved_to_.py
+++ b/migrations/versions/d680a4b61194_add_user_id_author_and_user_id_saved_to_.py
@@ -1,0 +1,86 @@
+"""add user_id_author and user_id_saved_to to recipe
+
+Revision ID: d680a4b61194
+Revises: c8f3b71d20a4
+Create Date: 2026-08-10 07:16:43.476435
+
+KAN-221: Split user_id into explicit author and saver identities.
+
+- user_id_author  = the user who created/generated the recipe (immutable)
+- user_id_saved_to = the user who saved a copy from a public page (NULL for originals)
+
+Backfill logic:
+  - Originals (source_slug IS NULL): user_id_author = user_id, user_id_saved_to = NULL
+  - Saved copies (source_slug IS NOT NULL): look up source recipe's user_id
+    as author; current user_id becomes user_id_saved_to
+  - Orphaned copies (source deleted): user_id_author = NULL, user_id_saved_to = user_id
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "d680a4b61194"
+down_revision = "c8f3b71d20a4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("user_id_author", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("user_id_saved_to", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key("fk_recipe_user_id_author", "user", ["user_id_author"], ["id"])
+        batch_op.create_foreign_key(
+            "fk_recipe_user_id_saved_to", "user", ["user_id_saved_to"], ["id"]
+        )
+
+    # --- Backfill ---
+    conn = op.get_bind()
+
+    # 1. Originals (source_slug IS NULL): author = owner, saved_to = NULL
+    conn.execute(sa.text("UPDATE recipe SET user_id_author = user_id " "WHERE source_slug IS NULL"))
+
+    # 2. Saved copies: author = source recipe's user_id, saved_to = this row's user_id
+    conn.execute(
+        sa.text(
+            "UPDATE recipe SET "
+            "  user_id_author = ("
+            "    SELECT r2.user_id FROM recipe r2 "
+            "    WHERE r2.slug = recipe.source_slug "
+            "    AND r2.is_public "
+            "    LIMIT 1"
+            "  ), "
+            "  user_id_saved_to = user_id "
+            "WHERE source_slug IS NOT NULL"
+        )
+    )
+
+    # 3. Orphaned saved copies (source recipe deleted/unpublished):
+    #    author stays NULL, but ensure saved_to is set
+    conn.execute(
+        sa.text(
+            "UPDATE recipe SET user_id_saved_to = user_id "
+            "WHERE source_slug IS NOT NULL "
+            "AND user_id_author IS NULL "
+            "AND user_id_saved_to IS NULL"
+        )
+    )
+
+    # Optional index for author lookups
+    op.create_index(
+        "idx_recipe_user_id_author",
+        "recipe",
+        ["user_id_author"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index("idx_recipe_user_id_author", table_name="recipe")
+
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_recipe_user_id_saved_to", type_="foreignkey")
+        batch_op.drop_constraint("fk_recipe_user_id_author", type_="foreignkey")
+        batch_op.drop_column("user_id_saved_to")
+        batch_op.drop_column("user_id_author")

--- a/migrations/versions/d680a4b61194_add_user_id_author_and_user_id_saved_to_.py
+++ b/migrations/versions/d680a4b61194_add_user_id_author_and_user_id_saved_to_.py
@@ -26,18 +26,9 @@ branch_labels = None
 depends_on = None
 
 
-def upgrade():
-    with op.batch_alter_table("recipe", schema=None) as batch_op:
-        batch_op.add_column(sa.Column("user_id_author", sa.Integer(), nullable=True))
-        batch_op.add_column(sa.Column("user_id_saved_to", sa.Integer(), nullable=True))
-        batch_op.create_foreign_key("fk_recipe_user_id_author", "user", ["user_id_author"], ["id"])
-        batch_op.create_foreign_key(
-            "fk_recipe_user_id_saved_to", "user", ["user_id_saved_to"], ["id"]
-        )
-
-    # --- Backfill ---
-    conn = op.get_bind()
-
+def _backfill_author_saver(conn):
+    """The backfill, on a bare connection so tests can execute the real thing
+    (the pattern set by c8f3b71d20a4's helpers + its migration test)."""
     # 1. Originals (source_slug IS NULL): author = owner, saved_to = NULL
     conn.execute(sa.text("UPDATE recipe SET user_id_author = user_id " "WHERE source_slug IS NULL"))
 
@@ -66,6 +57,18 @@ def upgrade():
             "AND user_id_saved_to IS NULL"
         )
     )
+
+
+def upgrade():
+    with op.batch_alter_table("recipe", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("user_id_author", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("user_id_saved_to", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key("fk_recipe_user_id_author", "user", ["user_id_author"], ["id"])
+        batch_op.create_foreign_key(
+            "fk_recipe_user_id_saved_to", "user", ["user_id_saved_to"], ["id"]
+        )
+
+    _backfill_author_saver(op.get_bind())
 
     # Optional index for author lookups
     op.create_index(

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -27,23 +27,37 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     # migration c8f3b71d20a4 for the evidence and KAN-220 for why the covered
     # corner is where the real duplicates come from.
     #
-    # Declared on the model as well as in migration c8f3b71d20a4 so that
+    # Declared on the model as well as in migration a3c9e1f4b7d2 so that
     # `db.create_all()` (tests, fresh local dev) builds the same indexes the
     # migration builds in production. Without this the suite would pass against
     # a schema that cannot refuse anything.
-    # The key is COALESCE(source_slug, slug), not source_slug alone. A recipe's
-    # identity is `{source_slug, slug}` everywhere else in the codebase —
-    # auth_api_bp._recipe_identity_keys() and the SPA's INV-1
-    # (`r.sourceSlug === slug || r.slug === slug`). Keying on source_slug alone
-    # left a reachable hole: an owner who holds the PUBLISHED row itself
-    # (slug='x', source_slug NULL) and saves /r/x again gets a copy with
-    # source_slug='x' that collides with nothing, because the published row sits
-    # outside a source_slug-only partial index. Caught by Codex review on #273.
     #
-    # COALESCE puts both rows on the same key. Two rows cannot collide via the
-    # slug side alone — `slug` is already globally unique — so every collision
-    # this catches involves at least one saved copy, which is the intent.
-    _IDENTITY = "coalesce(source_slug, slug)"
+    # KAN-221 re-key: the provenance key moved from the mutable slug string to
+    # the stable source row id. Reading the COALESCE:
+    #
+    #   source_recipe_id  a saved copy whose source resolved at save time (or
+    #                     via the a3c9e1f4b7d2 backfill) keys on the source's
+    #                     immutable id, so it collides with the source row
+    #                     itself and with every other resolved copy of it under
+    #                     the same owner — regardless of slug renames.
+    #   source_slug       a copy whose source never resolved (raw/legacy rows,
+    #                     source gone before backfill) falls back to the slug
+    #                     pointer, preserving KAN-213's dedup between such
+    #                     copies.
+    #   id                every other row keys on its own primary key. This is
+    #                     what makes the source row collide with a resolved
+    #                     copy of it (copy.source_recipe_id == source.id) —
+    #                     the Codex #273 identity case — without the slug
+    #                     aliasing KAN-221 retires. Between originals it is
+    #                     vacuously unique, so the constraint still only ever
+    #                     refuses pairs involving a saved copy.
+    #
+    # Scope: for saved copies user_id == user_id_saved_to by construction
+    # (create sets both to the saver; login-merge sets both to the new user),
+    # so scoping on user_id IS the locked (user_id_saved_to, source_recipe_id)
+    # constraint on the rows it covers, while non-copy rows keep their
+    # identity semantics under the same pair of indexes.
+    _IDENTITY = "coalesce(source_recipe_id, source_slug, id)"
 
     __table_args__ = (
         Index(
@@ -51,16 +65,16 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
             text("user_id"),
             text(_IDENTITY),
             unique=True,
-            postgresql_where=text(f"{_IDENTITY} IS NOT NULL AND user_id IS NOT NULL"),
-            sqlite_where=text(f"{_IDENTITY} IS NOT NULL AND user_id IS NOT NULL"),
+            postgresql_where=text("user_id IS NOT NULL"),
+            sqlite_where=text("user_id IS NOT NULL"),
         ),
         Index(
             "uq_recipe_guest_recipe_identity",
             text("guest_session_id"),
             text(_IDENTITY),
             unique=True,
-            postgresql_where=text(f"{_IDENTITY} IS NOT NULL AND guest_session_id IS NOT NULL"),
-            sqlite_where=text(f"{_IDENTITY} IS NOT NULL AND guest_session_id IS NOT NULL"),
+            postgresql_where=text("guest_session_id IS NOT NULL"),
+            sqlite_where=text("guest_session_id IS NOT NULL"),
         ),
     )
 
@@ -78,7 +92,20 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     is_canonical = db.Column(db.Boolean, default=False, nullable=False, server_default="0")
     # Slug of the public recipe this row was saved from (the blob's sourceSlug,
     # mirrored to a column so publish-state checks don't need to parse JSON).
+    # Kept after KAN-221: it still builds the /r/<slug> link — only the
+    # identity KEY moved to source_recipe_id below.
     source_slug = db.Column(db.String(255), nullable=True)
+    # KAN-221: id of the source recipe this row was saved from — the stable,
+    # immutable provenance key. Resolved server-side at save time (never
+    # client-writable) and backfilled from source_slug by migration
+    # a3c9e1f4b7d2. ON DELETE SET NULL: deleting the source clears the pointer,
+    # while source_slug stays, so the copy remains a saved copy (and remains
+    # unpublishable) after the source is gone.
+    source_recipe_id = db.Column(
+        db.String(36),
+        db.ForeignKey("recipe.id", name="fk_recipe_source_recipe_id", ondelete="SET NULL"),
+        nullable=True,
+    )
     # How the recipe entered the system: 'manual' | 'generated' | 'saved'
     # (NULL = legacy/unknown). Manually entered recipes cannot be published
     # (KAN-140) — free-text content with no AI mediation must not reach the
@@ -111,6 +138,7 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
             "is_public": self.is_public,
             "is_canonical": self.is_canonical,
             "source_slug": self.source_slug,
+            "source_recipe_id": self.source_recipe_id,
             "origin": self.origin,
             "user_id_author": self.user_id_author,
             "user_id_saved_to": self.user_id_saved_to,

--- a/models/recipe.py
+++ b/models/recipe.py
@@ -84,6 +84,13 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
     # (KAN-140) — free-text content with no AI mediation must not reach the
     # public /r/<slug> surface. Settable while NULL, immutable once set.
     origin = db.Column(db.String(20), nullable=True)
+    # KAN-221: split user_id into explicit author and saver identities.
+    # user_id_author = the user who created/generated the recipe (immutable).
+    # user_id_saved_to = the user who saved a copy from a public page (NULL
+    # for originals). Existing user_id retains its meaning ("the account that
+    # holds this row") — these columns add precision without removing anything.
+    user_id_author = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    user_id_saved_to = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
     # MutableDict ensures in-place JSON updates are tracked (important for SQLite dev).
     data = db.Column(MutableDict.as_mutable(GenericJSON), nullable=False)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
@@ -91,7 +98,7 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
         db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
     )
 
-    user = db.relationship("User", backref=db.backref("recipes", lazy=True))
+    user = db.relationship("User", foreign_keys=[user_id], backref=db.backref("recipes", lazy=True))
 
     def to_dict(self):
         return {
@@ -105,6 +112,8 @@ class Recipe(db.Model):  # type: ignore[name-defined, misc]
             "is_canonical": self.is_canonical,
             "source_slug": self.source_slug,
             "origin": self.origin,
+            "user_id_author": self.user_id_author,
+            "user_id_saved_to": self.user_id_saved_to,
             "data": self.data,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -61,6 +61,9 @@ MANUAL_RECIPE_UNPUBLISHABLE_ERROR = (
     "can have a public page."
 )
 
+# RCP-74: saved copies inherit their public page from the source recipe.
+SAVED_COPY_PUBLISH_ERROR = "Cannot publish a saved copy."
+
 # 'manual' gates publishing; the others exist so curation can query by
 # provenance. NULL = legacy/unknown, treated as publishable.
 _ALLOWED_ORIGINS = frozenset({"manual", "generated", "saved"})
@@ -68,6 +71,10 @@ _ALLOWED_ORIGINS = frozenset({"manual", "generated", "saved"})
 
 class ManualRecipeError(ValueError):
     """Manually entered recipes cannot be published (KAN-140)."""
+
+
+class SavedCopyPublishError(ValueError):
+    """Saved copies cannot be published — the source page owns publication (RCP-74)."""
 
 
 # Also returned verbatim by the API routes (fixed string, same rationale as
@@ -454,6 +461,10 @@ def _gate_is_public(recipe_data: Dict[str, Any], user_id: Optional[int]) -> Dict
     owner to moderate or ban behind a guest-published /r/<slug> page. The flag
     is normalized in the data blob itself so the JSON payload and the
     is_public column can never disagree.
+
+    RCP-74: saved copies (source_slug is not None) cannot be published — the
+    source page owns publication. Raises SavedCopyPublishError (403 at the API)
+    so the SPA's revert-and-toast path fires.
     """
     wants_public = recipe_data.get("is_public") is True
     if wants_public and user_id is None:
@@ -461,7 +472,12 @@ def _gate_is_public(recipe_data: Dict[str, Any], user_id: Optional[int]) -> Dict
             "Guest attempted to publish recipe %s — forcing is_public=False",
             sanitize_log_value(recipe_data.get("id", "<no id>")),
         )
-    return {**recipe_data, "is_public": wants_public if user_id is not None else False}
+        return {**recipe_data, "is_public": False}
+    # RCP-74: only authenticated users reach here with wants_public=True.
+    # A saved copy must not be re-published — the source page owns publication.
+    if wants_public and recipe_data.get("sourceSlug") is not None:
+        raise SavedCopyPublishError(SAVED_COPY_PUBLISH_ERROR)
+    return {**recipe_data, "is_public": wants_public}
 
 
 def get_user_recipes(
@@ -837,6 +853,18 @@ def create_recipe(
             recipe_data_with_id.pop("origin", None)
 
         def stage_new(data: Dict[str, Any]) -> Recipe:
+            # KAN-221: set author/saver columns on create.
+            source_slug = data.get("sourceSlug")
+            if source_slug is not None:
+                # Saved copy: look up the source recipe's owner as author.
+                source = Recipe.query.filter_by(slug=source_slug).first()
+                author_id = source.user_id if source else None
+                saved_to_id = user_id
+            else:
+                # Original recipe: author = owner, no saver.
+                author_id = user_id
+                saved_to_id = None
+
             recipe = Recipe(
                 id=recipe_id,
                 user_id=user_id,
@@ -844,8 +872,10 @@ def create_recipe(
                 name=recipe_name,
                 slug=data.get("slug"),
                 is_public=data.get("is_public", False),
-                source_slug=data.get("sourceSlug"),
+                source_slug=source_slug,
                 origin=origin_value,
+                user_id_author=author_id,
+                user_id_saved_to=saved_to_id,
                 data=data,
                 status=status,
             )
@@ -870,6 +900,7 @@ def create_recipe(
         RecipeSlugError,
         CanonicalRecipeError,
         ManualRecipeError,
+        SavedCopyPublishError,
         RecipeOwnershipError,
         RecipeDuplicateError,
     ):
@@ -992,6 +1023,7 @@ def update_recipe(
         RecipeSlugError,
         CanonicalRecipeError,
         ManualRecipeError,
+        SavedCopyPublishError,
         RecipeDuplicateError,
     ):
         raise

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -313,19 +313,53 @@ def _pin_source_slug_to_column(
     writes it back to the column. That resurrects a cleared duplicate and then
     trips the unique index on a write the user never meant as a save.
 
-    The column is authoritative. Key presence, not truthiness: a payload that
-    explicitly sends ``sourceSlug: null`` is the caller clearing it, and that
-    value goes through unchanged.
-
-    Found by Codex review on PR #273 — reproduced by
-    ``test_clearing_the_column_survives_a_later_partial_update``.
+    The column is authoritative — in BOTH directions. When the payload omits
+    the key, the column value is restored into the blob (the Codex #273 case,
+    reproduced by ``test_clearing_the_column_survives_a_later_partial_update``).
+    And when the payload explicitly sends ``sourceSlug: null`` against a row
+    whose column is non-NULL, the null is overridden with the column value:
+    persisted provenance is NOT client-clearable. Before this rule, one
+    ``PUT {"is_public": true, "sourceSlug": null}`` wiped the provenance and
+    published the copy in a single call (Copilot B1 on PR #279) — the write
+    that erases the evidence must not be the same write the guard trusts.
+    A payload carrying a non-null value still goes through unchanged; only
+    server-side paths (login-merge legacy guard, migration pre-passes) clear
+    the column.
     """
     if "sourceSlug" in recipe_data:
+        if recipe_data["sourceSlug"] is None and existing.source_slug is not None:
+            merged["sourceSlug"] = existing.source_slug
         return
     if existing.source_slug is not None:
         merged["sourceSlug"] = existing.source_slug
     else:
         merged.pop("sourceSlug", None)
+
+
+def _resolve_source_recipe_id(
+    current: Optional[str], source_slug: Optional[str], recipe_id: str
+) -> Optional[str]:
+    """Column value for source_recipe_id: resolved while NULL, immutable once set.
+
+    KAN-221: the stable provenance key. Set from the source row whose slug the
+    copy points at, exactly once — a later payload cannot re-point a copy at a
+    different source (the same immutability rule as ``origin``), and no client
+    value ever reaches this column. An unresolvable pointer (source deleted, or
+    a slug that never existed) stays NULL; the row still carries source_slug,
+    so it stays a saved copy for the publish guard and falls back to the slug
+    key in the identity indexes.
+    """
+    if current is not None:
+        return current
+    if source_slug is None:
+        return None
+    # no_autoflush: this runs inside the stage functions with the row already
+    # dirty — a flush here would hit the unique indexes mid-stage, outside
+    # _commit_publish_retrying's IntegrityError handling. The lookup needs no
+    # pending state; it resolves against committed rows only.
+    with db.session.no_autoflush:
+        source = Recipe.query.filter(Recipe.slug == source_slug, Recipe.id != recipe_id).first()
+    return source.id if source is not None else None
 
 
 def _duplicate_source_slug_owner(
@@ -345,16 +379,21 @@ def _duplicate_source_slug_owner(
     """
     if owner_scope is None:
         return False
-    # Mirrors the index key COALESCE(source_slug, slug): a row's identity is the
-    # public recipe it points at, or its own page when it is the original.
+    # Mirrors the index key COALESCE(source_recipe_id, source_slug, id)
+    # (KAN-221). Only a write that carries a source pointer can lose to the
+    # index: rows without one key on their own unique id, which cannot collide.
     source = recipe_data.get("sourceSlug")
-    identity = source if source is not None else recipe_data.get("slug")
-    if identity is None:
-        return False  # no identity — outside both partial indexes
+    if source is None:
+        return False
+    # The staged row's identity is the resolved source id, or the slug pointer
+    # when the source does not resolve — the same resolution the stage
+    # functions apply before commit.
+    source_row = Recipe.query.filter(Recipe.slug == source, Recipe.id != recipe_id).first()
+    identity = source_row.id if source_row is not None else source
 
     user_id, guest_session_id = owner_scope
     query = Recipe.query.filter(
-        func.coalesce(Recipe.source_slug, Recipe.slug) == identity,
+        func.coalesce(Recipe.source_recipe_id, Recipe.source_slug, Recipe.id) == identity,
         Recipe.id != recipe_id,
     )
     if user_id is not None:
@@ -454,7 +493,11 @@ def _apply_recipe_scope(query, user_id: Optional[int], guest_session_id: Optiona
     return query.filter_by(user_id=None, guest_session_id=None)
 
 
-def _gate_is_public(recipe_data: Dict[str, Any], user_id: Optional[int]) -> Dict[str, Any]:
+def _gate_is_public(
+    recipe_data: Dict[str, Any],
+    user_id: Optional[int],
+    existing: Optional[Recipe] = None,
+) -> Dict[str, Any]:
     """Only authenticated users may publish: guests get is_public forced False.
 
     A guest_session_id is a throwaway browser token — there is no accountable
@@ -462,9 +505,16 @@ def _gate_is_public(recipe_data: Dict[str, Any], user_id: Optional[int]) -> Dict
     is normalized in the data blob itself so the JSON payload and the
     is_public column can never disagree.
 
-    RCP-74: saved copies (source_slug is not None) cannot be published — the
-    source page owns publication. Raises SavedCopyPublishError (403 at the API)
-    so the SPA's revert-and-toast path fires.
+    RCP-74 / KAN-221: saved copies cannot be published — the source page owns
+    publication, permanently, with no author exception. For an existing row
+    the refusal keys on the PERSISTED provenance columns (``source_slug``,
+    ``source_recipe_id``), never on what the payload claims: a payload is the
+    caller's story, and ``PUT {"is_public": true, "sourceSlug": null}`` was a
+    working bypass while the guard trusted it (Copilot B1 on PR #279). For a
+    row being created, the staged blob IS what will be persisted, so the check
+    on it is a check on the columns being written. Raises
+    SavedCopyPublishError (403 at the API) so the SPA's revert-and-toast path
+    fires.
     """
     wants_public = recipe_data.get("is_public") is True
     if wants_public and user_id is None:
@@ -474,9 +524,16 @@ def _gate_is_public(recipe_data: Dict[str, Any], user_id: Optional[int]) -> Dict
         )
         return {**recipe_data, "is_public": False}
     # RCP-74: only authenticated users reach here with wants_public=True.
-    # A saved copy must not be re-published — the source page owns publication.
-    if wants_public and recipe_data.get("sourceSlug") is not None:
-        raise SavedCopyPublishError(SAVED_COPY_PUBLISH_ERROR)
+    if wants_public:
+        is_saved_copy = recipe_data.get("sourceSlug") is not None
+        if existing is not None:
+            is_saved_copy = (
+                is_saved_copy
+                or existing.source_slug is not None
+                or existing.source_recipe_id is not None
+            )
+        if is_saved_copy:
+            raise SavedCopyPublishError(SAVED_COPY_PUBLISH_ERROR)
     return {**recipe_data, "is_public": wants_public}
 
 
@@ -812,7 +869,7 @@ def create_recipe(
                 else:
                     merged.pop("slug", None)
             _pin_source_slug_to_column(merged, recipe_data, existing)
-            recipe_data_with_id = _gate_is_public(merged, user_id)
+            recipe_data_with_id = _gate_is_public(merged, user_id, existing)
             next_origin = _resolve_origin(existing.origin, recipe_data)
             _gate_manual_publish(next_origin, recipe_data_with_id)
             if next_origin is not None:
@@ -827,6 +884,9 @@ def create_recipe(
                 existing.slug = data.get("slug")
                 existing.is_public = data.get("is_public", False)
                 existing.source_slug = data.get("sourceSlug")
+                existing.source_recipe_id = _resolve_source_recipe_id(
+                    existing.source_recipe_id, data.get("sourceSlug"), recipe_id
+                )
                 existing.origin = next_origin
                 existing.data = data
                 existing.status = next_status
@@ -853,16 +913,20 @@ def create_recipe(
             recipe_data_with_id.pop("origin", None)
 
         def stage_new(data: Dict[str, Any]) -> Recipe:
-            # KAN-221: set author/saver columns on create.
+            # KAN-221: set author/saver columns and the stable provenance key
+            # on create.
             source_slug = data.get("sourceSlug")
             if source_slug is not None:
-                # Saved copy: look up the source recipe's owner as author.
+                # Saved copy: look up the source recipe — its owner is the
+                # author, its id is the immutable provenance key.
                 source = Recipe.query.filter_by(slug=source_slug).first()
                 author_id = source.user_id if source else None
+                source_recipe_id = source.id if source else None
                 saved_to_id = user_id
             else:
-                # Original recipe: author = owner, no saver.
+                # Original recipe: author = owner, no saver, no source.
                 author_id = user_id
+                source_recipe_id = None
                 saved_to_id = None
 
             recipe = Recipe(
@@ -873,6 +937,7 @@ def create_recipe(
                 slug=data.get("slug"),
                 is_public=data.get("is_public", False),
                 source_slug=source_slug,
+                source_recipe_id=source_recipe_id,
                 origin=origin_value,
                 user_id_author=author_id,
                 user_id_saved_to=saved_to_id,
@@ -966,7 +1031,11 @@ def update_recipe(
             # stale blob value.
             merged["is_public"] = recipe.is_public
 
-        recipe_data_with_id = _gate_is_public(merged, user_id)
+        # Pin BEFORE the gate, so the gate never reads a stale blob value the
+        # column has disowned (or a payload null the column overrides).
+        _pin_source_slug_to_column(merged, recipe_data, recipe)
+
+        recipe_data_with_id = _gate_is_public(merged, user_id, recipe)
 
         if "name" not in recipe_data_with_id and recipe.name:
             # Publish-only partial updates keep the persisted name (see
@@ -987,8 +1056,6 @@ def update_recipe(
             else:
                 recipe_data_with_id.pop("slug", None)
 
-        _pin_source_slug_to_column(recipe_data_with_id, recipe_data, recipe)
-
         next_origin = _resolve_origin(recipe.origin, recipe_data)
         _gate_manual_publish(next_origin, recipe_data_with_id)
         if next_origin is not None:
@@ -1001,6 +1068,9 @@ def update_recipe(
             recipe.slug = data.get("slug")
             recipe.is_public = data["is_public"]
             recipe.source_slug = data.get("sourceSlug")
+            recipe.source_recipe_id = _resolve_source_recipe_id(
+                recipe.source_recipe_id, data.get("sourceSlug"), recipe_id
+            )
             recipe.origin = next_origin
             recipe.data = data
             if status is not None:

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -316,18 +316,18 @@ def _pin_source_slug_to_column(
     The column is authoritative — in BOTH directions. When the payload omits
     the key, the column value is restored into the blob (the Codex #273 case,
     reproduced by ``test_clearing_the_column_survives_a_later_partial_update``).
-    And when the payload explicitly sends ``sourceSlug: null`` against a row
-    whose column is non-NULL, the null is overridden with the column value:
-    persisted provenance is NOT client-clearable. Before this rule, one
+    And when the payload sends ANY value (null or non-null) against a row
+    whose column is already non-NULL, the persisted value wins: provenance
+    is NOT client-mutable once set. Before this rule, one
     ``PUT {"is_public": true, "sourceSlug": null}`` wiped the provenance and
-    published the copy in a single call (Copilot B1 on PR #279) — the write
-    that erases the evidence must not be the same write the guard trusts.
-    A payload carrying a non-null value still goes through unchanged; only
-    server-side paths (login-merge legacy guard, migration pre-passes) clear
-    the column.
+    published the copy in a single call (Copilot B1 on PR #279); and a
+    ``PUT {"sourceSlug": "other-slug"}`` repointed the copy, creating a
+    disagreement between ``source_slug`` and the immutable
+    ``source_recipe_id`` (Copilot/claude review round 2). Only server-side
+    paths (login-merge legacy guard, migration pre-passes) clear the column.
     """
     if "sourceSlug" in recipe_data:
-        if recipe_data["sourceSlug"] is None and existing.source_slug is not None:
+        if existing.source_slug is not None:
             merged["sourceSlug"] = existing.source_slug
         return
     if existing.source_slug is not None:
@@ -358,7 +358,11 @@ def _resolve_source_recipe_id(
     # _commit_publish_retrying's IntegrityError handling. The lookup needs no
     # pending state; it resolves against committed rows only.
     with db.session.no_autoflush:
-        source = Recipe.query.filter(Recipe.slug == source_slug, Recipe.id != recipe_id).first()
+        source = Recipe.query.filter(
+            Recipe.slug == source_slug,
+            Recipe.is_public.is_(True),
+            Recipe.id != recipe_id,
+        ).first()
     return source.id if source is not None else None
 
 
@@ -388,7 +392,9 @@ def _duplicate_source_slug_owner(
     # The staged row's identity is the resolved source id, or the slug pointer
     # when the source does not resolve — the same resolution the stage
     # functions apply before commit.
-    source_row = Recipe.query.filter(Recipe.slug == source, Recipe.id != recipe_id).first()
+    source_row = Recipe.query.filter(
+        Recipe.slug == source, Recipe.is_public.is_(True), Recipe.id != recipe_id
+    ).first()
     identity = source_row.id if source_row is not None else source
 
     user_id, guest_session_id = owner_scope
@@ -918,8 +924,11 @@ def create_recipe(
             source_slug = data.get("sourceSlug")
             if source_slug is not None:
                 # Saved copy: look up the source recipe — its owner is the
-                # author, its id is the immutable provenance key.
-                source = Recipe.query.filter_by(slug=source_slug).first()
+                # author, its id is the immutable provenance key. Only public
+                # sources resolve (matches migration backfill predicate).
+                source = Recipe.query.filter(
+                    Recipe.slug == source_slug, Recipe.is_public.is_(True)
+                ).first()
                 author_id = source.user_id if source else None
                 source_recipe_id = source.id if source else None
                 saved_to_id = user_id

--- a/tests/test_migration_kan221_provenance.py
+++ b/tests/test_migration_kan221_provenance.py
@@ -1,0 +1,280 @@
+"""Tests executing the KAN-221 migration backfills (Copilot B3 on PR #279).
+
+Two migrations carry KAN-221's schema split, and both ship data backfills that
+run exactly once, unattended, inside the flask-backend-migrate Cloud Run Job:
+
+    d680a4b61194  adds user_id_author / user_id_saved_to and backfills them
+    a3c9e1f4b7d2  adds source_recipe_id, backfills it from source_slug, and
+                  re-keys the KAN-213 identity indexes onto it
+
+An untested backfill is the project's named failure mode: code that runs only
+on the one day it matters, with nobody watching. These tests execute the REAL
+backfill helpers the migrations call — not a re-implementation, and not
+``db.create_all()`` — against a bare table, the pattern set by
+``test_migration_recipe_source_slug_unique.py``.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+_VERSIONS = Path(__file__).resolve().parent.parent / "migrations" / "versions"
+
+
+def _load(filename, name):
+    spec = importlib.util.spec_from_file_location(name, _VERSIONS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _author_saver_migration():
+    return _load("d680a4b61194_add_user_id_author_and_user_id_saved_to_.py", "mig_d680a4b61194")
+
+
+def _source_recipe_id_migration():
+    return _load("a3c9e1f4b7d2_add_source_recipe_id_and_rekey_identity.py", "mig_a3c9e1f4b7d2")
+
+
+def _bare_recipe_engine(tmp_path):
+    """The recipe table as it stands when each backfill runs (post column-add,
+    pre index re-key), without the model's indexes so dirty states can be
+    staged freely."""
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'mig221.db'}")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE recipe ("
+                "id TEXT PRIMARY KEY, user_id INTEGER, guest_session_id TEXT, "
+                "name TEXT NOT NULL, slug TEXT, is_public INTEGER DEFAULT 0, "
+                "source_slug TEXT, source_recipe_id TEXT, "
+                "user_id_author INTEGER, user_id_saved_to INTEGER, "
+                "data TEXT NOT NULL DEFAULT '{}', created_at TEXT)"
+            )
+        )
+    return engine
+
+
+def _insert(conn, rows):
+    """Rows are dicts; unset keys default to NULL/0."""
+    for row in rows:
+        params = {
+            "id": row["id"],
+            "user_id": row.get("user_id"),
+            "guest": row.get("guest_session_id"),
+            "slug": row.get("slug"),
+            "public": 1 if row.get("is_public") else 0,
+            "source_slug": row.get("source_slug"),
+            "source_recipe_id": row.get("source_recipe_id"),
+        }
+        conn.execute(
+            sa.text(
+                "INSERT INTO recipe (id, user_id, guest_session_id, name, slug, "
+                "is_public, source_slug, source_recipe_id, data, created_at) "
+                "VALUES (:id, :user_id, :guest, 'R', :slug, :public, "
+                ":source_slug, :source_recipe_id, '{}', '2026-01-01')"
+            ),
+            params,
+        )
+
+
+def _rows(conn, columns):
+    cols = ", ".join(("id",) + columns)
+    fetched = conn.execute(sa.text(f"SELECT {cols} FROM recipe")).fetchall()  # noqa: S608
+    return {row.id: tuple(row[1:]) for row in fetched}
+
+
+# ─── d680a4b61194: user_id_author / user_id_saved_to backfill ────────────────
+
+
+def test_author_saver_backfill_covers_all_three_row_shapes(tmp_path):
+    """Originals, resolved copies, and orphans — the three UPDATE passes."""
+    mig = _author_saver_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                # An original the author published.
+                {"id": "src", "user_id": 1, "slug": "chili", "is_public": True},
+                # A copy of it another user saved.
+                {"id": "copy", "user_id": 2, "source_slug": "chili"},
+                # An unpublished original (never had a page).
+                {"id": "draft", "user_id": 2},
+                # A copy whose source is gone.
+                {"id": "orphan", "user_id": 3, "source_slug": "deleted-recipe"},
+            ],
+        )
+        mig._backfill_author_saver(conn)
+        rows = _rows(conn, ("user_id_author", "user_id_saved_to"))
+
+    assert rows["src"] == (1, None), "original: author = owner, no saver"
+    assert rows["copy"] == (1, 2), "copy: author = SOURCE owner, saved_to = holder"
+    assert rows["draft"] == (2, None), "unpublished original: still its owner's work"
+    assert rows["orphan"] == (None, 3), "orphan: author unknown stays NULL, saver set"
+
+
+def test_author_saver_backfill_ignores_unpublished_sources(tmp_path):
+    """The resolution requires the source to be PUBLIC — a private row with a
+    matching slug must not be claimed as the author (mirrors the runtime
+    resolution, which only ever sees /r/<slug> pages)."""
+    mig = _author_saver_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                {"id": "private", "user_id": 1, "slug": "chili", "is_public": False},
+                {"id": "copy", "user_id": 2, "source_slug": "chili"},
+            ],
+        )
+        mig._backfill_author_saver(conn)
+        rows = _rows(conn, ("user_id_author", "user_id_saved_to"))
+
+    assert rows["copy"] == (None, 2), "a non-public slug match is treated as an orphan"
+
+
+# ─── a3c9e1f4b7d2: source_recipe_id backfill + index re-key ──────────────────
+
+
+def _build_v2_indexes(conn, mig):
+    """The statements the migration issues after the backfill — expression
+    taken from the migration module itself so this test cannot drift from
+    what production runs."""
+    for name, scope in mig._INDEXES:
+        conn.execute(
+            sa.text(
+                f"CREATE UNIQUE INDEX {name} ON recipe "
+                f"({scope}, {mig._IDENTITY}) "
+                f"WHERE {scope} IS NOT NULL"
+            )
+        )
+
+
+def test_source_recipe_id_backfill_resolves_public_sources_only(tmp_path):
+    mig = _source_recipe_id_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                {"id": "src", "user_id": 1, "slug": "chili", "is_public": True},
+                {"id": "copy", "user_id": 2, "source_slug": "chili"},
+                {"id": "guest-copy", "guest_session_id": "sess-a", "source_slug": "chili"},
+                {"id": "orphan", "user_id": 3, "source_slug": "deleted-recipe"},
+                {"id": "private", "user_id": 1, "slug": "secret", "is_public": False},
+                {"id": "copy-of-private", "user_id": 2, "source_slug": "secret"},
+                {"id": "original", "user_id": 2},
+            ],
+        )
+        mig._backfill_source_recipe_id(conn)
+        rows = _rows(conn, ("source_recipe_id", "source_slug"))
+
+    assert rows["copy"] == ("src", "chili"), "resolved: key moves to the source id"
+    assert rows["guest-copy"] == ("src", "chili"), "guest copies resolve identically"
+    assert rows["orphan"] == (None, "deleted-recipe"), "unresolvable: slug pointer kept"
+    assert rows["copy-of-private"] == (None, "secret"), "non-public source does not resolve"
+    assert rows["original"] == (None, None), "originals are untouched"
+
+
+def test_rekeyed_index_refuses_the_id_keyed_duplicates(tmp_path):
+    """Seen to fail for the reason it exists — under the NEW key.
+
+    The two collisions the re-key must refuse: a second resolved copy of the
+    same source, and the source row's own holder saving it again (the Codex
+    #273 identity case, now id-keyed instead of slug-keyed).
+    """
+    mig = _source_recipe_id_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _build_v2_indexes(conn, mig)
+        _insert(
+            conn,
+            [
+                {"id": "src", "user_id": 1, "slug": "chili", "is_public": True},
+                {"id": "copy", "user_id": 2, "source_slug": "chili", "source_recipe_id": "src"},
+            ],
+        )
+
+    # A second resolved copy under the same owner.
+    with pytest.raises(sa.exc.IntegrityError):
+        with engine.begin() as conn:
+            _insert(
+                conn,
+                [{"id": "copy2", "user_id": 2, "source_slug": "chili", "source_recipe_id": "src"}],
+            )
+
+    # The author saving their own published page: copy keys on source id,
+    # the source row keys on its own id — same key, same owner, refused.
+    with pytest.raises(sa.exc.IntegrityError):
+        with engine.begin() as conn:
+            _insert(
+                conn,
+                [{"id": "self", "user_id": 1, "source_slug": "chili", "source_recipe_id": "src"}],
+            )
+
+    with engine.begin() as conn:
+        # A different owner saving the same recipe is the product working.
+        _insert(
+            conn,
+            [{"id": "other", "user_id": 3, "source_slug": "chili", "source_recipe_id": "src"}],
+        )
+        # Authored originals stay unconstrained (their own ids never collide).
+        _insert(conn, [{"id": "a", "user_id": 2}, {"id": "b", "user_id": 2}])
+        assert conn.execute(sa.text("SELECT count(*) FROM recipe")).scalar() == 5
+
+
+def test_rekeyed_index_keeps_the_slug_fallback_for_unresolved_copies(tmp_path):
+    """KAN-213's original dedup survives for copies whose source never resolved."""
+    mig = _source_recipe_id_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _build_v2_indexes(conn, mig)
+        _insert(conn, [{"id": "c1", "user_id": 1, "source_slug": "gone"}])
+
+    with pytest.raises(sa.exc.IntegrityError):
+        with engine.begin() as conn:
+            _insert(conn, [{"id": "c2", "user_id": 1, "source_slug": "gone"}])
+
+
+def test_data_satisfying_the_old_key_builds_the_new_indexes(tmp_path):
+    """The migration ships NO de-dup pre-pass, on the argument that every group
+    the new key forms is a subset of a group the old key formed — so data the
+    c8f3b71d20a4 indexes accepted cannot violate the re-keyed ones. This stages
+    the shapes that satisfy the OLD constraint and proves backfill + index
+    build succeed on them.
+    """
+    mig = _source_recipe_id_migration()
+    engine = _bare_recipe_engine(tmp_path)
+    with engine.begin() as conn:
+        _insert(
+            conn,
+            [
+                # Author's published original; two other owners each hold a copy.
+                {"id": "src", "user_id": 1, "slug": "chili", "is_public": True},
+                {"id": "u2-copy", "user_id": 2, "source_slug": "chili"},
+                {"id": "u3-copy", "user_id": 3, "source_slug": "chili"},
+                # A guest copy of the same page.
+                {"id": "g-copy", "guest_session_id": "sess-a", "source_slug": "chili"},
+                # Orphaned copies of the same dead slug, one per owner.
+                {"id": "u2-orphan", "user_id": 2, "source_slug": "gone"},
+                {"id": "u3-orphan", "user_id": 3, "source_slug": "gone"},
+                # Plain authored rows.
+                {"id": "u2-draft", "user_id": 2},
+                {"id": "u2-page", "user_id": 2, "slug": "tacos", "is_public": True},
+            ],
+        )
+        mig._backfill_source_recipe_id(conn)
+        _build_v2_indexes(conn, mig)
+
+        resolved = _rows(conn, ("source_recipe_id",))
+
+    assert resolved["u2-copy"] == ("src",)
+    assert resolved["u3-copy"] == ("src",)
+    assert resolved["g-copy"] == ("src",)
+    assert resolved["u2-orphan"] == (None,)

--- a/tests/test_saved_copy_publish_guard.py
+++ b/tests/test_saved_copy_publish_guard.py
@@ -205,3 +205,129 @@ def test_api_saved_copy_publish_returns_403(app, saver, published_recipe):
     assert resp.status_code == 403
     data = resp.get_json()
     assert data["error"] == db_recipe_repository.SAVED_COPY_PUBLISH_ERROR
+
+
+# ─── KAN-221: the guard keys on PERSISTED provenance, which is not ──────
+# ─── client-clearable (Copilot B1 on PR #279) ───────────────────────────
+
+
+def _client_for(app, user):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+    return client
+
+
+def _save_copy_via_api(app, user, source_slug, name="Chili"):
+    """Create a saved copy the way the SPA does — through the API, never the
+    ORM (KAN-213 lesson: an ORM-built row can 'prove' a state the product
+    cannot reach)."""
+    client = _client_for(app, user)
+    resp = client.post(
+        "/api/recipes",
+        json={"name": name, "sourceSlug": source_slug, "origin": "saved"},
+    )
+    assert resp.status_code == 201, resp.get_json()
+    return client, resp.get_json()
+
+
+def test_put_null_source_slug_cannot_bypass_the_guard_or_wipe_provenance(
+    app, saver, published_recipe
+):
+    """THE bypass this re-key exists to close.
+
+    While the guard keyed on the payload, ``PUT {"is_public": true,
+    "sourceSlug": null}`` wiped the provenance and published the copy in one
+    call. It must now 403, and BOTH provenance columns must survive intact.
+    """
+    client, created = _save_copy_via_api(app, saver, published_recipe.slug)
+
+    resp = client.put(
+        f"/api/recipes/{created['id']}",
+        json={"is_public": True, "sourceSlug": None},
+    )
+
+    assert resp.status_code == 403, (
+        f"expected 403, got {resp.status_code} — a null sourceSlug in the "
+        "payload must not blind a guard keyed on the persisted columns"
+    )
+    row = db.session.get(Recipe, created["id"])
+    assert row.source_slug == published_recipe.slug, "source_slug was wiped by the refused PUT"
+    assert row.source_recipe_id == published_recipe.id, "source_recipe_id was wiped"
+    assert row.is_public is False
+    assert row.data.get("sourceSlug") == published_recipe.slug, "blob must stay honest too"
+
+
+def test_put_null_source_slug_alone_cannot_clear_provenance(app, saver, published_recipe):
+    """Even without publishing, a client PUT can never null persisted provenance.
+
+    Otherwise the bypass just becomes two calls: clear first, publish second.
+    """
+    client, created = _save_copy_via_api(app, saver, published_recipe.slug)
+
+    resp = client.put(
+        f"/api/recipes/{created['id']}",
+        json={"name": "Renamed", "sourceSlug": None},
+    )
+
+    assert resp.status_code == 200
+    row = db.session.get(Recipe, created["id"])
+    assert row.source_slug == published_recipe.slug
+    assert row.source_recipe_id == published_recipe.id
+
+    # And the two-call publish attempt still fails.
+    resp = client.put(f"/api/recipes/{created['id']}", json={"is_public": True})
+    assert resp.status_code == 403
+
+
+def test_saved_copy_resolves_source_recipe_id_at_create(app, saver, published_recipe):
+    """The stable provenance key is resolved server-side when the copy is saved."""
+    _, created = _save_copy_via_api(app, saver, published_recipe.slug)
+
+    row = db.session.get(Recipe, created["id"])
+    assert row.source_recipe_id == published_recipe.id
+    assert row.source_slug == published_recipe.slug
+
+
+def test_source_deleted_copy_stays_blocked(app, author, saver, published_recipe):
+    """Locked rule: deleting the source does not free its copies for publishing."""
+    client, created = _save_copy_via_api(app, saver, published_recipe.slug)
+
+    assert db_recipe_repository.delete_recipe(published_recipe.id, user_id=author.id)
+
+    resp = client.put(f"/api/recipes/{created['id']}", json={"is_public": True})
+    assert resp.status_code == 403, "a copy whose source is gone must stay unpublishable"
+    row = db.session.get(Recipe, created["id"])
+    assert row.is_public is False
+    assert row.source_slug == published_recipe.slug, "the pointer text survives the delete"
+
+
+def test_pre_guard_published_copy_cannot_republish_after_unpublish(app, saver, published_recipe):
+    """Rows published BEFORE the guard existed are covered too.
+
+    The guard keys on persisted provenance, so a legacy is_public=True saved
+    copy that gets unpublished can never come back — no author exception, no
+    payload trick. Built via the ORM deliberately: the API can no longer
+    create this row, which is the point of testing it.
+    """
+    legacy = Recipe(
+        id="legacy-published-copy",
+        user_id=saver.id,
+        name="Chili",
+        slug="chili-2",
+        source_slug=published_recipe.slug,
+        source_recipe_id=published_recipe.id,
+        is_public=True,
+        data={"name": "Chili", "sourceSlug": published_recipe.slug, "is_public": True},
+    )
+    db.session.add(legacy)
+    db.session.commit()
+
+    client = _client_for(app, saver)
+    assert client.put(f"/api/recipes/{legacy.id}", json={"is_public": False}).status_code == 200
+
+    resp = client.put(f"/api/recipes/{legacy.id}", json={"is_public": True})
+    assert resp.status_code == 403
+    row = db.session.get(Recipe, legacy.id)
+    assert row.is_public is False
+    assert row.source_recipe_id == published_recipe.id

--- a/tests/test_saved_copy_publish_guard.py
+++ b/tests/test_saved_copy_publish_guard.py
@@ -331,3 +331,62 @@ def test_pre_guard_published_copy_cannot_republish_after_unpublish(app, saver, p
     row = db.session.get(Recipe, legacy.id)
     assert row.is_public is False
     assert row.source_recipe_id == published_recipe.id
+
+
+# ─── KAN-221: locked guest→user merge rules (Copilot B2 on PR #279) ─────
+
+
+def _guest_client(app, session_id="guest-merge-session"):
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        # The app keys the guest scope on session["session_id"]
+        # (utils/session_utils.get_or_create_session_id).
+        sess["session_id"] = session_id
+    return client
+
+
+def test_merge_guest_saved_copy_sets_author_from_source_and_saver_to_new_user(
+    app, author, saver, published_recipe
+):
+    """Locked rule: guest-SAVED copy -> author = source owner, saved_to = new user."""
+    from blueprints.auth_api_bp import _merge_guest_session_into_user
+
+    guest = _guest_client(app)
+    resp = guest.post(
+        "/api/recipes",
+        json={"name": "Chili", "sourceSlug": published_recipe.slug, "origin": "saved"},
+    )
+    assert resp.status_code == 201
+    recipe_id = resp.get_json()["id"]
+    row = db.session.get(Recipe, recipe_id)
+    assert row.user_id_saved_to is None, "precondition: guests have no user id to save to"
+
+    _merge_guest_session_into_user(saver, "guest-merge-session")
+
+    row = db.session.get(Recipe, recipe_id)
+    assert row.user_id == saver.id
+    assert row.user_id_author == author.id, "author must be the SOURCE row's owner"
+    assert row.user_id_saved_to == saver.id, "saver must be the user logging in"
+    assert row.source_recipe_id == published_recipe.id
+
+
+def test_merge_guest_generated_original_sets_author_and_saver_to_new_user(app, saver):
+    """Locked rule: guest-GENERATED original -> author = saved_to = new user."""
+    from blueprints.auth_api_bp import _merge_guest_session_into_user
+
+    guest = _guest_client(app)
+    resp = guest.post(
+        "/api/recipes",
+        json={"name": "Guest Soup", "origin": "generated"},
+    )
+    assert resp.status_code == 201
+    recipe_id = resp.get_json()["id"]
+    row = db.session.get(Recipe, recipe_id)
+    assert row.user_id_author is None, "precondition: guest originals have no author id"
+
+    _merge_guest_session_into_user(saver, "guest-merge-session")
+
+    row = db.session.get(Recipe, recipe_id)
+    assert row.user_id == saver.id
+    assert row.user_id_author == saver.id, "the guest IS the author — the new user claims it"
+    assert row.user_id_saved_to == saver.id

--- a/tests/test_saved_copy_publish_guard.py
+++ b/tests/test_saved_copy_publish_guard.py
@@ -1,0 +1,207 @@
+"""RCP-74: Saved copies cannot be published.
+
+A recipe saved from a public page (source_slug IS NOT NULL) must not be
+publishable by the saver. The guard lives in _gate_is_public() and returns
+403 at the API level.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app
+from extensions import db
+from models.recipe import Recipe
+from models.user import User
+from repositories import db_recipe_repository
+
+
+@pytest.fixture
+def app():
+    app = create_app(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+    )
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def author(app):
+    u = User(email="author@example.com", name="Author")
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+@pytest.fixture
+def saver(app):
+    u = User(email="saver@example.com", name="Saver")
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+@pytest.fixture
+def published_recipe(app, author):
+    """A published recipe that can be the source for saved copies."""
+    recipe = db_recipe_repository.create_recipe(
+        {"id": "orig-1", "name": "Chili", "is_public": True},
+        user_id=author.id,
+    )
+    assert recipe is not None
+    assert recipe.is_public is True
+    return recipe
+
+
+# ─── Repository guard: saved copy cannot publish ────────────────────────
+
+
+def test_saved_copy_create_publish_raises(app, saver, published_recipe):
+    """Creating a saved copy with is_public=True raises SavedCopyPublishError."""
+    with pytest.raises(db_recipe_repository.SavedCopyPublishError):
+        db_recipe_repository.create_recipe(
+            {
+                "id": "copy-1",
+                "name": "Chili",
+                "sourceSlug": published_recipe.slug,
+                "is_public": True,
+                "origin": "saved",
+            },
+            user_id=saver.id,
+        )
+
+
+def test_saved_copy_create_unpublished_ok(app, saver, published_recipe):
+    """Creating a saved copy with is_public=False succeeds normally."""
+    recipe = db_recipe_repository.create_recipe(
+        {
+            "id": "copy-2",
+            "name": "Chili",
+            "sourceSlug": published_recipe.slug,
+            "is_public": False,
+            "origin": "saved",
+        },
+        user_id=saver.id,
+    )
+    assert recipe is not None
+    assert recipe.is_public is False
+    assert recipe.source_slug == published_recipe.slug
+
+
+def test_saved_copy_update_publish_raises(app, saver, published_recipe):
+    """Updating a saved copy to is_public=True raises SavedCopyPublishError."""
+    recipe = db_recipe_repository.create_recipe(
+        {
+            "id": "copy-3",
+            "name": "Chili",
+            "sourceSlug": published_recipe.slug,
+            "is_public": False,
+            "origin": "saved",
+        },
+        user_id=saver.id,
+    )
+    assert recipe is not None
+
+    with pytest.raises(db_recipe_repository.SavedCopyPublishError):
+        db_recipe_repository.update_recipe(
+            "copy-3",
+            {"is_public": True},
+            user_id=saver.id,
+        )
+
+
+def test_original_publish_still_works(app, author):
+    """An original recipe (no source_slug) can still be published normally."""
+    recipe = db_recipe_repository.create_recipe(
+        {"id": "orig-2", "name": "Tacos", "is_public": True},
+        user_id=author.id,
+    )
+    assert recipe is not None
+    assert recipe.is_public is True
+
+
+# ─── KAN-221: author/saver columns ──────────────────────────────────────
+
+
+def test_original_sets_author(app, author):
+    """An original recipe sets user_id_author = user_id, user_id_saved_to = None."""
+    recipe = db_recipe_repository.create_recipe(
+        {"id": "orig-3", "name": "Soup"},
+        user_id=author.id,
+    )
+    assert recipe is not None
+    assert recipe.user_id_author == author.id
+    assert recipe.user_id_saved_to is None
+
+
+def test_saved_copy_sets_author_and_saver(app, author, saver, published_recipe):
+    """A saved copy sets user_id_author to source author, user_id_saved_to to saver."""
+    recipe = db_recipe_repository.create_recipe(
+        {
+            "id": "copy-4",
+            "name": "Chili",
+            "sourceSlug": published_recipe.slug,
+            "is_public": False,
+            "origin": "saved",
+        },
+        user_id=saver.id,
+    )
+    assert recipe is not None
+    assert recipe.user_id_author == author.id
+    assert recipe.user_id_saved_to == saver.id
+
+
+def test_saved_copy_orphan_author_is_none(app, saver):
+    """A saved copy from a deleted source has user_id_author = None."""
+    recipe = db_recipe_repository.create_recipe(
+        {
+            "id": "copy-5",
+            "name": "Mystery",
+            "sourceSlug": "deleted-recipe",
+            "is_public": False,
+            "origin": "saved",
+        },
+        user_id=saver.id,
+    )
+    assert recipe is not None
+    assert recipe.user_id_author is None
+    assert recipe.user_id_saved_to == saver.id
+
+
+# ─── API layer: 403 ─────────────────────────────────────────────────────
+
+
+def test_api_saved_copy_publish_returns_403(app, saver, published_recipe):
+    """The API returns 403 when trying to publish a saved copy."""
+    # First create the saved copy (unpublished)
+    recipe = db_recipe_repository.create_recipe(
+        {
+            "id": "copy-6",
+            "name": "Chili",
+            "sourceSlug": published_recipe.slug,
+            "is_public": False,
+            "origin": "saved",
+        },
+        user_id=saver.id,
+    )
+    assert recipe is not None
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user_id"] = saver.id
+
+    resp = client.put(
+        f"/api/recipes/{recipe.id}",
+        json={"is_public": True},
+    )
+    assert resp.status_code == 403
+    data = resp.get_json()
+    assert data["error"] == db_recipe_repository.SAVED_COPY_PUBLISH_ERROR

--- a/tests/test_saved_copy_publish_guard.py
+++ b/tests/test_saved_copy_publish_guard.py
@@ -371,7 +371,12 @@ def test_merge_guest_saved_copy_sets_author_from_source_and_saver_to_new_user(
 
 
 def test_merge_guest_generated_original_sets_author_and_saver_to_new_user(app, saver):
-    """Locked rule: guest-GENERATED original -> author = saved_to = new user."""
+    """Locked rule: guest-GENERATED original -> author = new user, saved_to = NULL.
+
+    Originals have no saver — the user IS the author, not someone who saved
+    another user's work. Matches the authenticated-create path (saved_to_id=None
+    for originals) and the migration backfill.
+    """
     from blueprints.auth_api_bp import _merge_guest_session_into_user
 
     guest = _guest_client(app)
@@ -389,4 +394,4 @@ def test_merge_guest_generated_original_sets_author_and_saver_to_new_user(app, s
     row = db.session.get(Recipe, recipe_id)
     assert row.user_id == saver.id
     assert row.user_id_author == saver.id, "the guest IS the author — the new user claims it"
-    assert row.user_id_saved_to == saver.id
+    assert row.user_id_saved_to is None, "originals have no saver — matches authenticated create"

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -9,12 +9,15 @@ cross-context race by construction: two tabs, or a tab and a phone, both read
 "you don't have this yet" before either writes.
 
 These tests pin the fix at the only layer that can refuse the second write —
-two partial unique indexes:
+two partial unique indexes (re-keyed by KAN-221 / migration a3c9e1f4b7d2 from
+COALESCE(source_slug, slug) onto the stable source-recipe id):
 
-    uq_recipe_user_recipe_identity   UNIQUE (user_id, COALESCE(source_slug, slug))
-        WHERE COALESCE(source_slug, slug) IS NOT NULL AND user_id IS NOT NULL
-    uq_recipe_guest_recipe_identity  UNIQUE (guest_session_id, COALESCE(source_slug, slug))
-        WHERE COALESCE(source_slug, slug) IS NOT NULL AND guest_session_id IS NOT NULL
+    uq_recipe_user_recipe_identity
+        UNIQUE (user_id, COALESCE(source_recipe_id, source_slug, id))
+        WHERE user_id IS NOT NULL
+    uq_recipe_guest_recipe_identity
+        UNIQUE (guest_session_id, COALESCE(source_recipe_id, source_slug, id))
+        WHERE guest_session_id IS NOT NULL
 
 Both ship together or neither (Sprint 6 R3): ``user_id`` is nullable and guests
 key on ``guest_session_id``, which is the KAN-186 path.
@@ -216,71 +219,58 @@ def test_update_that_collides_also_returns_409_not_500(client, logged_in):
     assert Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).count() == 1
 
 
-def test_slug_race_and_duplicate_source_slug_together_still_end_in_409(
+def test_publish_of_saved_copy_is_refused_before_slug_resolution_can_race(
     client, logged_in, monkeypatch
 ):
-    """Settles a disagreement between two reviews on PR #273.
+    """RCP-74 made the PR #273 slug-race x duplicate interaction unreachable.
 
-    ``_duplicate_source_slug_owner`` is consulted only on the *non*-slug-race
-    branch of ``_commit_publish_retrying``. One review read that as: a write
-    that loses a slug race AND has a duplicate source_slug burns all
-    ``_SLUG_COMMIT_RETRIES`` and then re-raises the raw IntegrityError as a
-    500 — R1 reopened from a narrower angle. A later review read the same code
-    as self-correcting after one retry. They cannot both be right, and neither
-    wrote a test.
+    HISTORY: this test used to prove that a write which lost a slug race AND
+    carried a duplicate source_slug still ended in 409 rather than burning all
+    retries into a raw 500 (a disagreement between two #273 reviews; the answer
+    was "one extra retry, then 409"). That interleaving required *publishing* a
+    row that carries a sourceSlug — exactly what the RCP-74 guard now refuses
+    up front, so the scenario the old test name promised can no longer execute
+    (Copilot B4 on PR #279).
 
-    Tracing it: attempt 1 fails with another row owning the probed slug, so
-    ``lost_slug_race`` is True and the duplicate check is skipped. Attempt 2
-    resolves a *fresh* slug that nobody owns, so ``lost_slug_race`` is now
-    False — control reaches the duplicate check and raises
-    ``RecipeDuplicateError``. One extra retry, then 409.
+    The interaction is structurally gone, not just untested:
 
-    This asserts that, so the claim stops being a matter of reading.
+    - Publishing is the only path into ``_resolve_public_slug``, and
+      ``_gate_is_public`` raises before ``_commit_publish_retrying`` is ever
+      entered when the write carries provenance (persisted or staged). No
+      publish, no slug probe, no slug race.
+    - A publishable row (no provenance) cannot trip the duplicate index at
+      all under the KAN-221 key: it is indexed by its own unique id, so the
+      slug-race retry loop and the duplicate refusal no longer share a
+      reachable write.
 
-    RCP-74 UPDATE: saved copies (sourceSlug IS NOT NULL) can no longer be
-    published — _gate_is_public raises SavedCopyPublishError before slug
-    resolution. The slug race + duplicate interaction is still testable on
-    non-saved recipes that share a slug via the publish path.
+    What this test now pins is the boundary itself: the refusal fires BEFORE
+    slug resolution runs, the response is the deliberate 403 (not a 500 or a
+    retry storm), and neither the competing row nor its provenance is touched.
     """
     from repositories import db_recipe_repository
 
     _insert_competing_row(user_id=logged_in.id)  # owner already holds SOURCE_SLUG
 
     real_resolve = db_recipe_repository._resolve_public_slug
-    state = {"raced": False, "resolves": 0}
+    state = {"resolves": 0}
 
-    def racing_resolve(data, recipe_id, current_slug=None, skip=frozenset()):
-        slug = real_resolve(data, recipe_id, current_slug, skip=skip)
+    def counting_resolve(data, recipe_id, current_slug=None, skip=frozenset()):
         state["resolves"] += 1
-        if not state["raced"]:
-            state["raced"] = True
-            # Another writer claims the probed slug before our commit, so
-            # attempt 1 is a genuine slug race on top of the duplicate.
-            with db.engine.begin() as conn:
-                conn.execute(
-                    sa.text(
-                        "INSERT INTO recipe (id, name, status, slug, is_public, "
-                        "is_canonical, data, created_at, updated_at) VALUES "
-                        "(:id, 'Racer', 'ready', :slug, 0, 0, '{}', "
-                        "'2026-08-09 00:00:00', '2026-08-09 00:00:00')"
-                    ),
-                    {"id": str(uuid.uuid4()), "slug": slug},
-                )
-        return slug
+        return real_resolve(data, recipe_id, current_slug, skip=skip)
 
-    monkeypatch.setattr(db_recipe_repository, "_resolve_public_slug", racing_resolve)
+    monkeypatch.setattr(db_recipe_repository, "_resolve_public_slug", counting_resolve)
 
-    # RCP-74: saved copies cannot be published, so this now gets 403 from
-    # the SavedCopyPublishError guard before slug resolution fires.
     response = client.post("/api/recipes", json={**_payload(), "is_public": True})
 
     assert (
         response.status_code == 403
     ), f"expected 403 (saved copy cannot publish, RCP-74), got {response.status_code}"
-    assert not state[
-        "raced"
-    ], "slug race should not fire — the saved-copy publish guard rejects before slug resolution"
-    assert Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).count() == 1
+    assert state["resolves"] == 0, (
+        "slug resolution ran — the guard must refuse before "
+        "_commit_publish_retrying can enter the slug-race window"
+    )
+    rows = Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).all()
+    assert len(rows) == 1, "the refused write must not have persisted anything"
 
 
 def test_guest_saves_are_constrained_too(client, guest, monkeypatch):
@@ -502,15 +492,16 @@ def test_saving_your_own_published_recipe_again_is_refused(client, logged_in):
 
 
 @pytest.mark.xfail(
-    reason="KAN-221: known dual-identity gap. A row holding BOTH source_slug and "
-    "slug (a saved copy that was later published) is indexed only by its "
-    "source_slug, so saving that row's own public URL is accepted. A unique "
-    "index keys one value per row and cannot express 'alias sets must be "
-    "disjoint', so there is no index-shaped fix. The two alternatives both cost "
-    "more than the gap: clearing source_slug on publish would shrink the row's "
-    "alias set and break KAN-186's guest-merge dedup, and a recipe_identity "
-    "side table is exactly what KAN-221 deletes when it replaces mutable slugs "
-    "with a stable source-recipe id. Documented rather than patched.",
+    reason="Known dual-identity gap, still open after the KAN-221 re-key. A row "
+    "holding BOTH a source pointer and its own published page (a saved copy "
+    "that was later published) is indexed only by its source pointer "
+    "(COALESCE picks source_recipe_id/source_slug over the id arm), so saving "
+    "that row's own public URL is accepted. A unique index keys one value per "
+    "row and cannot express 'alias sets must be disjoint' — that needs a "
+    "side table, which is out of KAN-221's scope. Note the ROW ITSELF is now "
+    "largely historical: the RCP-74 guard refuses publishing saved copies, so "
+    "new copy-then-published rows can no longer be created through the API. "
+    "Documented rather than patched.",
     strict=True,
 )
 def test_saving_your_own_published_copy_is_not_yet_refused(client, logged_in):
@@ -518,8 +509,10 @@ def test_saving_your_own_published_copy_is_not_yet_refused(client, logged_in):
 
     Found by Copilot on PR #273 after the COALESCE fix closed the second one.
     Three rounds found three holes in one identity model, which is the finding:
-    ``source_slug`` is a mutable string standing in for a relationship, so every
-    index over it has an aliasing hole. KAN-221 replaces it.
+    a single-valued key cannot cover a row aliased by two identities. The
+    KAN-221 re-key moved the key to the stable source id (closing the slug-
+    mutation holes); this dual-alias corner is the one it leaves, and the
+    RCP-74 publish guard is what starves it of new rows.
     """
     copy_then_published = Recipe(
         id="copy-published",

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -236,6 +236,11 @@ def test_slug_race_and_duplicate_source_slug_together_still_end_in_409(
     ``RecipeDuplicateError``. One extra retry, then 409.
 
     This asserts that, so the claim stops being a matter of reading.
+
+    RCP-74 UPDATE: saved copies (sourceSlug IS NOT NULL) can no longer be
+    published — _gate_is_public raises SavedCopyPublishError before slug
+    resolution. The slug race + duplicate interaction is still testable on
+    non-saved recipes that share a slug via the publish path.
     """
     from repositories import db_recipe_repository
 
@@ -265,18 +270,16 @@ def test_slug_race_and_duplicate_source_slug_together_still_end_in_409(
 
     monkeypatch.setattr(db_recipe_repository, "_resolve_public_slug", racing_resolve)
 
+    # RCP-74: saved copies cannot be published, so this now gets 403 from
+    # the SavedCopyPublishError guard before slug resolution fires.
     response = client.post("/api/recipes", json={**_payload(), "is_public": True})
 
-    assert state["raced"], "the slug race never fired — test is not exercising both collisions"
-    assert response.status_code == 409, (
-        f"expected 409, got {response.status_code}. A 500 here would mean the "
-        "slug-retry branch swallows the duplicate refusal — R1 from a narrower angle."
-    )
-    # Two resolves = one race retry, not an exhausted retry budget.
-    assert state["resolves"] == 2, (
-        f"expected exactly one retry, saw {state['resolves']} slug resolutions — "
-        "the duplicate check is not short-circuiting on the second attempt"
-    )
+    assert (
+        response.status_code == 403
+    ), f"expected 403 (saved copy cannot publish, RCP-74), got {response.status_code}"
+    assert not state[
+        "raced"
+    ], "slug race should not fire — the saved-copy publish guard rejects before slug resolution"
     assert Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).count() == 1
 
 

--- a/tests/test_source_slug_unique.py
+++ b/tests/test_source_slug_unique.py
@@ -192,14 +192,14 @@ def test_duplicate_refusal_body_carries_a_code_and_no_exception_text(
         assert leak not in str(body), f"response leaked internals: {leak!r}"
 
 
-def test_update_that_collides_also_returns_409_not_500(client, logged_in):
-    """The PUT route must refuse the same way the POST route does.
+def test_update_cannot_repoint_source_slug_to_collide(client, logged_in):
+    """Provenance is immutable once set — a PUT carrying a different sourceSlug
+    has the value pinned to the persisted column, so the collision scenario that
+    required repointing (old test: 409 on PUT) is structurally unreachable.
 
-    Covers the sibling path of R1: the repository re-raises
-    RecipeDuplicateError from update_recipe, so without a handler on the PUT
-    route the refusal falls into the generic 500. Unlike the create case this
-    needs no race — editing one recipe to carry another's sourceSlug trips the
-    index directly.
+    Before the pin, ``PUT {"sourceSlug": "<other-recipe's-slug>"}`` changed the
+    provenance and tripped the per-owner identity index. Now the pin preserves
+    the original, the row keeps its own source, and the update succeeds.
     """
     first = client.post("/api/recipes", json=_payload()).get_json()
     second = client.post(
@@ -207,15 +207,15 @@ def test_update_that_collides_also_returns_409_not_500(client, logged_in):
     ).get_json()
     assert first["id"] != second["id"]
 
-    # Point the second recipe at the first's source — now a duplicate pair.
+    # Attempt to repoint the second recipe at the first's source.
     response = client.put(f"/api/recipes/{second['id']}", json=_payload(name="Vegan Pot Pie"))
 
-    assert response.status_code == 409, (
-        f"expected 409, got {response.status_code} — an update that trips the "
-        "index must be a deliberate refusal, not an internal error"
+    assert response.status_code == 200, (
+        f"expected 200 — provenance pin should absorb the repointing attempt, "
+        f"got {response.status_code}"
     )
-    assert "code" in response.get_json()
-    # The write must not have landed.
+    row = Recipe.query.get(second["id"])
+    assert row.source_slug == "pot-pie", "provenance pinned to the persisted value"
     assert Recipe.query.filter_by(user_id=logged_in.id, source_slug=SOURCE_SLUG).count() == 1
 
 


### PR DESCRIPTION
## Summary

- **RCP-74:** Saved copies (`source_slug IS NOT NULL`) can no longer be published. `_gate_is_public()` raises `SavedCopyPublishError` (403 at the API) when an authenticated user tries to set `is_public=True` on a saved copy. Guest writes still silently force `is_public=False`.
- **KAN-221:** New columns `user_id_author` and `user_id_saved_to` on the recipe table, splitting the ambiguous `user_id` into explicit author/saver identities. Migration `d680a4b61194` adds columns + backfills existing rows.
- Login-merge in `auth_api_bp` carries the new columns through on guest-to-user reassignment.

## Test plan

- [x] 8 new tests in `test_saved_copy_publish_guard.py` (repository guard + API 403 + author/saver column assertions)
- [x] Updated `test_source_slug_unique.py` to reflect RCP-74 guard (saved copy + `is_public=True` now returns 403 before slug resolution)
- [x] Full Backend test suite passes (387 passed, 1 xfailed)
- [x] `black --check .` + `flake8` + `mypy .` clean
- [x] Single Alembic head (`d680a4b61194`)

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QyH7kTTAVdSUrAHV33GLa






<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

