### PR TITLE
feat(valkey): single Valkey config factory [KAN-160]

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,6 +134,8 @@ def create_app(**config_overrides):
     # Valkey degrades to SimpleCache instead of failing startup; per-call
     # failures are absorbed by utils/cache_utils safe_get/safe_set.
     # Tests may pre-set CACHE_TYPE via config_overrides to skip this block.
+    # All Valkey env reads live in utils/valkey_config (KAN-160); config.py
+    # re-exports the import-time snapshot that tests monkeypatch.
     if "CACHE_TYPE" not in app.config:
         from config import REDIS_URL, VALKEY_AUTH_MODE, VALKEY_HOST, VALKEY_PORT
 
@@ -146,11 +148,15 @@ def create_app(**config_overrides):
             else:
                 import redis
 
+                from utils.valkey_config import resolve_valkey_config
+
                 try:
                     cache_client = redis.StrictRedis(
                         host=VALKEY_HOST,
                         port=VALKEY_PORT,
-                        password=os.environ.get("VALKEY_PASSWORD"),
+                        # Resolved here, not at import time — same timing as
+                        # the inline os.environ read this replaced.
+                        password=resolve_valkey_config().password,
                         decode_responses=False,
                     )
                     cache_client.ping()

--- a/config.py
+++ b/config.py
@@ -15,6 +15,8 @@ from typing import Dict, Any, Optional
 from jsonschema import Draft7Validator
 import logging
 
+from utils.valkey_config import resolve_valkey_config
+
 logger = logging.getLogger(__name__)
 
 # Load environment variables
@@ -41,15 +43,15 @@ WORKER_CLAIM_STALE_SECONDS = max(
     int(os.getenv("WORKER_CLAIM_STALE_SECONDS", "600")),
 )
 
-# Valkey/Redis response cache
-# VALKEY_HOST: Memorystore private IP (e.g. 10.128.0.11)
-# VALKEY_PORT: defaults to 6379
-# VALKEY_AUTH_MODE: 'iam' for GCP IAM auth (prod default), 'password' for static password, or unset
-# REDIS_URL: legacy — full redis:// URL for local dev; used only when VALKEY_HOST is unset
-VALKEY_HOST = os.getenv("VALKEY_HOST")
-VALKEY_PORT = int(os.getenv("VALKEY_PORT", "6379"))
-VALKEY_AUTH_MODE = os.getenv("VALKEY_AUTH_MODE", "iam")
-REDIS_URL = os.getenv("REDIS_URL")
+# Valkey/Redis response cache — every VALKEY_*/REDIS_URL env read lives in
+# utils/valkey_config (KAN-160); see its docstring for what each var means.
+# Resolved once at import time (same semantics as every other setting here);
+# these module-level names are the ones tests monkeypatch.
+_VALKEY = resolve_valkey_config()
+VALKEY_HOST = _VALKEY.host
+VALKEY_PORT = _VALKEY.port
+VALKEY_AUTH_MODE = _VALKEY.auth_mode
+REDIS_URL = _VALKEY.redis_url
 
 # Default Model Configuration
 DEFAULT_MODEL = "gemini-3.1-pro-preview"

--- a/tests/test_valkey_config.py
+++ b/tests/test_valkey_config.py
@@ -1,0 +1,209 @@
+"""Tests for the single Valkey config factory (KAN-160).
+
+utils/valkey_config is the only module allowed to read VALKEY_*/REDIS_URL
+environment variables. These tests pin:
+
+- env consolidation: every variable resolves through the factory
+- VALKEY_PORT validation: bad values warn loudly (naming the value) and
+  fall back to the explicit default 6379 — the anti-silent-degradation
+  contract from the 2026-07-25 board finding
+- CA-cert passthrough for the Memorystore TLS trust chain
+- the cache-backend priority contract VALKEY_HOST > REDIS_URL >
+  in-process SimpleCache, exercised through create_app
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from app import create_app  # noqa: E402
+from utils.valkey_config import (  # noqa: E402
+    DEFAULT_VALKEY_PORT,
+    resolve_valkey_config,
+)
+
+_FAKE_PEM = (
+    "-----BEGIN CERTIFICATE-----\n" "MIIBfakememorystorecabytes==\n" "-----END CERTIFICATE-----\n"
+)
+
+_ALL_VARS = (
+    "VALKEY_HOST",
+    "VALKEY_PORT",
+    "VALKEY_AUTH_MODE",
+    "VALKEY_PASSWORD",
+    "VALKEY_CA_CERT",
+    "REDIS_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_valkey_env(monkeypatch):
+    """Start every test from an empty Valkey env, whatever the local .env has."""
+    for var in _ALL_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+# ── Env consolidation ─────────────────────────────────────────────────────────
+
+
+def test_resolve_reads_all_env_vars(monkeypatch):
+    monkeypatch.setenv("VALKEY_HOST", "10.128.0.11")
+    monkeypatch.setenv("VALKEY_PORT", "6380")
+    monkeypatch.setenv("VALKEY_AUTH_MODE", "password")
+    monkeypatch.setenv("VALKEY_PASSWORD", "hunter2")
+    monkeypatch.setenv("VALKEY_CA_CERT", _FAKE_PEM)
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+
+    cfg = resolve_valkey_config()
+
+    assert cfg.host == "10.128.0.11"
+    assert cfg.port == 6380
+    assert cfg.auth_mode == "password"
+    assert cfg.password == "hunter2"
+    assert cfg.ca_cert == _FAKE_PEM
+    assert cfg.redis_url == "redis://localhost:6379/0"
+
+
+def test_resolve_defaults_when_env_unset():
+    cfg = resolve_valkey_config()
+
+    assert cfg.host is None
+    assert cfg.port == DEFAULT_VALKEY_PORT
+    assert cfg.auth_mode == "iam"  # prod default, matches the pre-factory config.py
+    assert cfg.password is None
+    assert cfg.ca_cert is None
+    assert cfg.redis_url is None
+
+
+def test_ca_cert_passthrough(monkeypatch):
+    """The Memorystore CA PEM must survive resolution byte-for-byte."""
+    monkeypatch.setenv("VALKEY_CA_CERT", _FAKE_PEM)
+    assert resolve_valkey_config().ca_cert == _FAKE_PEM
+
+
+# ── VALKEY_PORT validation ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["not-a-port", "", "6379.5"])
+def test_port_non_numeric_warns_and_defaults(monkeypatch, caplog, bad):
+    """Pre-factory this was int() at import time — a crash. Now: loud default."""
+    monkeypatch.setenv("VALKEY_PORT", bad)
+
+    with caplog.at_level("WARNING", logger="utils.valkey_config"):
+        cfg = resolve_valkey_config()
+
+    assert cfg.port == DEFAULT_VALKEY_PORT
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any(repr(bad) in msg and str(DEFAULT_VALKEY_PORT) in msg for msg in warnings), (
+        "warning must name the bad value and the default: %s" % warnings
+    )
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", "65536", "700000"])
+def test_port_out_of_range_warns_and_defaults(monkeypatch, caplog, bad):
+    """Pre-factory an out-of-range port was accepted silently. Now: loud default."""
+    monkeypatch.setenv("VALKEY_PORT", bad)
+
+    with caplog.at_level("WARNING", logger="utils.valkey_config"):
+        cfg = resolve_valkey_config()
+
+    assert cfg.port == DEFAULT_VALKEY_PORT
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any(repr(bad) in msg and str(DEFAULT_VALKEY_PORT) in msg for msg in warnings)
+
+
+@pytest.mark.parametrize(("raw", "expected"), [("1", 1), ("6380", 6380), ("65535", 65535)])
+def test_port_valid_values_pass_through_without_warning(monkeypatch, caplog, raw, expected):
+    monkeypatch.setenv("VALKEY_PORT", raw)
+
+    with caplog.at_level("WARNING", logger="utils.valkey_config"):
+        cfg = resolve_valkey_config()
+
+    assert cfg.port == expected
+    assert not caplog.records
+
+
+# ── Priority contract: VALKEY_HOST > REDIS_URL > SimpleCache ─────────────────
+#
+# app.create_app branches on the config-module snapshot (which tests
+# monkeypatch, same pattern as tests/test_cache.py), so the priority is
+# exercised end to end through create_app.
+
+
+class _FakeRedisClient:
+    """Minimal client: just enough for create_app's ping() health check."""
+
+    def __init__(self, **kwargs):
+        self.pinged = False
+
+    def ping(self):
+        self.pinged = True
+        return True
+
+
+def _create_app():
+    return create_app(TESTING=True, SQLALCHEMY_DATABASE_URI="sqlite:///:memory:")
+
+
+def test_priority_valkey_host_wins_over_redis_url(monkeypatch):
+    """With both configured, VALKEY_HOST is used and REDIS_URL never consulted."""
+    fake = _FakeRedisClient()
+    from_url_calls = []
+    monkeypatch.setattr("config.VALKEY_HOST", "valkey.test")
+    monkeypatch.setattr("config.VALKEY_AUTH_MODE", "password")
+    monkeypatch.setattr("config.REDIS_URL", "redis://should-be-ignored:6379/0")
+    monkeypatch.setattr("redis.StrictRedis", lambda **kwargs: fake)
+    monkeypatch.setattr(
+        "redis.from_url",
+        lambda *args, **kwargs: from_url_calls.append(args) or _FakeRedisClient(),
+    )
+
+    app = _create_app()
+
+    assert app.config["CACHE_TYPE"] == "RedisCache"
+    assert fake.pinged
+    assert not from_url_calls
+
+
+def test_priority_redis_url_used_when_no_valkey_host(monkeypatch):
+    fake = _FakeRedisClient()
+    monkeypatch.setattr("config.VALKEY_HOST", None)
+    monkeypatch.setattr("config.REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setattr("redis.from_url", lambda url, **kwargs: fake)
+
+    app = _create_app()
+
+    assert app.config["CACHE_TYPE"] == "RedisCache"
+    assert fake.pinged
+
+
+def test_priority_neither_configured_falls_back_to_simplecache(monkeypatch):
+    monkeypatch.setattr("config.VALKEY_HOST", None)
+    monkeypatch.setattr("config.REDIS_URL", None)
+
+    app = _create_app()
+
+    assert app.config["CACHE_TYPE"] == "SimpleCache"
+
+
+def test_password_auth_reads_password_via_factory(monkeypatch):
+    """The old inline os.environ.get in app.py must now flow through the factory."""
+    captured = {}
+
+    def fake_strictredis(**kwargs):
+        captured.update(kwargs)
+        return _FakeRedisClient()
+
+    monkeypatch.setattr("config.VALKEY_HOST", "valkey.test")
+    monkeypatch.setattr("config.VALKEY_AUTH_MODE", "password")
+    monkeypatch.setattr("config.REDIS_URL", None)
+    monkeypatch.setenv("VALKEY_PASSWORD", "hunter2")
+    monkeypatch.setattr("redis.StrictRedis", fake_strictredis)
+
+    app = _create_app()
+
+    assert app.config["CACHE_TYPE"] == "RedisCache"
+    assert captured["password"] == "hunter2"

--- a/utils/valkey_auth.py
+++ b/utils/valkey_auth.py
@@ -9,11 +9,12 @@ Ref: https://cloud.google.com/memorystore/docs/valkey/manage-iam-auth
 """
 
 import logging
-import os
 import threading
 import time
 
 import redis
+
+from utils.valkey_config import resolve_valkey_config
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,9 @@ def _build_client(host: str, port: int) -> redis.StrictRedis:
     # in-process backend. ssl_ca_data=None means "use the system trust store"
     # (local/dev), so keep TLS verification on either way. Mirrors
     # server/valkey.ts (the Express side already does this correctly).
-    ca_cert = os.environ.get("VALKEY_CA_CERT")
+    # Read via the shared factory at client-build time (same timing as the
+    # inline os.environ read this replaced — KAN-160).
+    ca_cert = resolve_valkey_config().ca_cert
 
     # Force RESP2 protocol: redis-py 8.x defaults to RESP3 which sends
     # HELLO 3 AUTH default <token> — the injected "default" username is

--- a/utils/valkey_config.py
+++ b/utils/valkey_config.py
@@ -1,0 +1,89 @@
+"""Single source of truth for Valkey/Redis environment configuration.
+
+Every Valkey-related environment variable is read HERE and nowhere else
+(KAN-160). Before this factory existed, config.py, app.py, and
+utils/valkey_auth.py each hand-mirrored their own subset of the env vars,
+which is how the silent SimpleCache degradation (#222/#3176) and the
+migrate job's missing VALKEY_CA_CERT (KAN-136) slipped through. Any new
+surface that needs Valkey settings must call resolve_valkey_config()
+instead of touching os.environ.
+
+Variables consolidated:
+- VALKEY_HOST: Memorystore private IP (e.g. 10.128.0.11)
+- VALKEY_PORT: defaults to 6379; invalid values warn loudly and default
+- VALKEY_AUTH_MODE: 'iam' for GCP IAM auth (prod default), 'password'
+  for static password auth
+- VALKEY_PASSWORD: static password when VALKEY_AUTH_MODE='password'
+- VALKEY_CA_CERT: PEM for the Google-managed private CA (TLS trust)
+- REDIS_URL: legacy — full redis:// URL for local dev; used only when
+  VALKEY_HOST is unset
+
+Cache-backend priority contract (implemented by app.create_app, pinned by
+tests/test_valkey_config.py): VALKEY_HOST > REDIS_URL > in-process
+SimpleCache.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VALKEY_PORT = 6379
+
+
+@dataclass(frozen=True)
+class ValkeyConfig:
+    """Immutable snapshot of every Valkey/Redis setting."""
+
+    host: str | None
+    port: int
+    auth_mode: str
+    password: str | None
+    ca_cert: str | None
+    redis_url: str | None
+
+
+def _parse_port(raw: str | None) -> int:
+    """Validate VALKEY_PORT, warning loudly instead of degrading silently.
+
+    A non-numeric or out-of-range value names the bad value in the log and
+    falls back to the explicit default 6379 — never a quiet crash or a
+    quietly-wrong port.
+    """
+    if raw is None:
+        return DEFAULT_VALKEY_PORT
+    try:
+        port = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid VALKEY_PORT %r: not an integer — using default %d",
+            raw,
+            DEFAULT_VALKEY_PORT,
+        )
+        return DEFAULT_VALKEY_PORT
+    if not 1 <= port <= 65535:
+        logger.warning(
+            "Invalid VALKEY_PORT %r: outside 1-65535 — using default %d",
+            raw,
+            DEFAULT_VALKEY_PORT,
+        )
+        return DEFAULT_VALKEY_PORT
+    return port
+
+
+def resolve_valkey_config() -> ValkeyConfig:
+    """Read all Valkey-related env vars in one place and return a snapshot.
+
+    Reads the environment fresh on every call; callers own the resolution
+    timing (config.py snapshots at import time, valkey_auth resolves at
+    client-build time).
+    """
+    return ValkeyConfig(
+        host=os.getenv("VALKEY_HOST"),
+        port=_parse_port(os.getenv("VALKEY_PORT")),
+        auth_mode=os.getenv("VALKEY_AUTH_MODE", "iam"),
+        password=os.getenv("VALKEY_PASSWORD"),
+        ca_cert=os.getenv("VALKEY_CA_CERT"),
+        redis_url=os.getenv("REDIS_URL"),
+    )


### PR DESCRIPTION
## Summary

Consolidates every Valkey/Redis environment read into a single factory, `utils/valkey_config.py` (frozen `ValkeyConfig` dataclass + `resolve_valkey_config()`), so no surface hand-mirrors these env vars again — the recurring-defect contract from the 2026-07-25 board finding (silent SimpleCache degradation #222/#3176; migrate job missing `VALKEY_CA_CERT`, KAN-136). Satisfies **RCP-77 AC1 (Flask side)** per Adam's D4 decision, 2026-08-11.

### What consolidates where

| Old read | New source |
| --- | --- |
| `config.py` — `VALKEY_HOST`, `VALKEY_PORT`, `VALKEY_AUTH_MODE`, `REDIS_URL` via `os.getenv` | import-time snapshot of `resolve_valkey_config()`; same module-level names re-exported (they're what tests monkeypatch) |
| `app.py` cache setup — inline `os.environ.get("VALKEY_PASSWORD")` | `resolve_valkey_config().password` at the same call-time point |
| `utils/valkey_auth.py` — `os.environ.get("VALKEY_CA_CERT")` | `resolve_valkey_config().ca_cert` at client-build time |

### Behavior preserved

- Priority contract unchanged: `VALKEY_HOST` > `REDIS_URL` > in-process SimpleCache.
- Resolution timing unchanged everywhere: config.py still resolves at import time; the password and CA-cert reads still happen at the same call sites they did before.
- `create_app`'s cache-selection branching untouched.

### New: loud VALKEY_PORT validation

Non-numeric or out-of-range (1–65535) values now log a warning **naming the bad value** and fall back to an explicit default 6379. Previously a non-numeric value crashed at import (`int()`), and an out-of-range value was accepted silently — the silent-degradation class this ticket exists to kill.

### Tests

`tests/test_valkey_config.py`: env consolidation (all six vars), defaults, port validation (non-numeric, out-of-range, boundary values), CA-cert passthrough, and the priority contract exercised end-to-end through `create_app` (host wins over `REDIS_URL`, `REDIS_URL` fallback, SimpleCache fallback, password-through-factory). All env access isolated via monkeypatch. Full suite: 396 passed, 1 xfailed; black/flake8/mypy clean.

### Merge shape

This PR → promote Backend `dev` → `main` → cookbook pointer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SfMnmhH2uoVVi3v2o2Dhs
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

