### PR TITLE
fix(ssr): resolve source recipe image for published saved copies [KAN-215]

### DIFF
--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -89,17 +89,24 @@ def _own_image_url(recipe: Recipe) -> str | None:
 def _resolve_source_for_image(recipe: Recipe) -> Recipe | None:
     """Look up the source recipe for image fallback.
 
-    Returns ``None`` when the recipe is not a saved copy or when the source
-    has been deleted.  Prefers the immutable ``source_recipe_id`` FK; falls
-    back to ``source_slug`` for legacy copies whose FK was never backfilled.
+    Returns ``None`` when the recipe is not a saved copy, when the source
+    has been deleted, or when the source is no longer public.  Both paths
+    require ``is_public`` — without that gate a private source's image URL
+    would leak into a public page's ``<meta og:image>`` and Pinterest pin.
+
+    Prefers the immutable ``source_recipe_id`` FK; falls back to
+    ``source_slug`` for legacy copies whose FK was never backfilled.
     """
     if recipe.source_recipe_id:
-        return db.session.get(Recipe, recipe.source_recipe_id)
+        source = db.session.get(Recipe, recipe.source_recipe_id)
+        if source is not None and source.is_public:
+            return source
+        return None
     if recipe.source_slug:
-        source: Recipe | None = Recipe.query.filter(
+        source_by_slug: Recipe | None = Recipe.query.filter(
             Recipe.slug == recipe.source_slug, Recipe.is_public.is_(True)
         ).first()
-        return source
+        return source_by_slug
     return None
 
 

--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -23,6 +23,7 @@ from xml.etree.ElementTree import Element, SubElement, tostring
 from flask import Blueprint, Response, abort, jsonify, render_template, request, url_for
 from sqlalchemy.orm import joinedload
 
+from extensions import db
 from models import Recipe
 
 logger = logging.getLogger(__name__)
@@ -72,22 +73,57 @@ def _minutes_to_iso_duration(value: Any) -> str | None:
     return f"PT{minutes}M"
 
 
-def _recipe_image_url(recipe: Recipe) -> str | None:
-    """URL of an image the site can actually serve, or ``None`` to omit it.
+def _own_image_url(recipe: Recipe) -> str | None:
+    """Image URL from the recipe's own data blob — no source fallback.
 
-    A recipe row can carry an ``ai_image_url`` whose bytes were never
-    persisted (the /api/recipes/<id>/image endpoint then 404s). Trusting that
-    field produced dead hero images and dead ``og:image`` URLs on live
-    recipe pages (cookbook #3164). Derive the page media from the signal the
-    image endpoint actually serves from (real GCS/base64 bytes), else an
-    external stock image — never from the unverified ``ai_image_url``.
-    The same gate feeds the Pinterest share button, so the pin media and the
-    page media can never disagree.
+    Derives the page media from the signal the image endpoint actually serves
+    from (real GCS/base64 bytes), else an external stock image — never from
+    the unverified ``ai_image_url`` (cookbook #3164).
     """
     data = recipe.data or {}
     if data.get("ai_image_gcs") or data.get("ai_image_data"):
         return _canonical_url("generation_api.serve_recipe_image", recipe_id=recipe.id)
     return _absolute_url(data.get("stock_image_url"))
+
+
+def _resolve_source_for_image(recipe: Recipe) -> Recipe | None:
+    """Look up the source recipe for image fallback.
+
+    Returns ``None`` when the recipe is not a saved copy or when the source
+    has been deleted.  Prefers the immutable ``source_recipe_id`` FK; falls
+    back to ``source_slug`` for legacy copies whose FK was never backfilled.
+    """
+    if recipe.source_recipe_id:
+        return db.session.get(Recipe, recipe.source_recipe_id)
+    if recipe.source_slug:
+        source: Recipe | None = Recipe.query.filter(
+            Recipe.slug == recipe.source_slug, Recipe.is_public.is_(True)
+        ).first()
+        return source
+    return None
+
+
+def _recipe_image_url(recipe: Recipe) -> str | None:
+    """URL of an image the site can actually serve, or ``None`` to omit it.
+
+    KAN-215: saved copies (recipes with ``source_recipe_id`` or
+    ``source_slug``) often lack their own image data because the SPA save
+    flow does not propagate ``ai_image_gcs`` / ``ai_image_data``.  When the
+    recipe's own data has no serveable image, fall back to the source
+    recipe's image — resolving its *current* state so the pointer is always
+    live (no stale GCS URI if the source regenerates).
+
+    The same gate feeds the Pinterest share button, so the pin media and the
+    page media can never disagree.
+    """
+    url = _own_image_url(recipe)
+    if url is not None:
+        return url
+    # Saved copy with no image of its own — resolve from source.
+    source = _resolve_source_for_image(recipe)
+    if source is not None:
+        return _own_image_url(source)
+    return None
 
 
 def _format_ingredient(ingredient: Mapping[str, Any]) -> str:

--- a/blueprints/public_bp.py
+++ b/blueprints/public_bp.py
@@ -319,7 +319,10 @@ def show_public_recipe(slug):
     data = recipe.data or {}
     canonical_url = _canonical_url("public.show_public_recipe", slug=recipe.slug)
     image_url = _recipe_image_url(recipe)
-    pinterest_image_url = _pinnable_image_url(recipe)
+    # _pinnable_image_url is a module-level alias for _recipe_image_url
+    # (see the alias definition above _pinterest_share_url); calling it again
+    # would re-issue the saved-copy source lookup for no gain.
+    pinterest_image_url = image_url
     description = data.get("description") or "A vegan recipe from TastesLikeGood."
     instructions = _recipe_instructions(data)
     tags = _recipe_tags(data)

--- a/repositories/db_recipe_repository.py
+++ b/repositories/db_recipe_repository.py
@@ -932,6 +932,17 @@ def create_recipe(
                 author_id = source.user_id if source else None
                 source_recipe_id = source.id if source else None
                 saved_to_id = user_id
+                # KAN-215: copy stock_image_url from the source so the copy
+                # has its own image pointer.  ai_image_gcs / ai_image_data are
+                # NOT copied — if the source regenerates, the old GCS object
+                # is deleted (_delete_replaced_gcs_image), which would break a
+                # shared pointer.  The read-time fallback in public_bp
+                # _recipe_image_url handles AI images by resolving the
+                # source's current state at render time.
+                if source is not None:
+                    source_data = source.data or {}
+                    if source_data.get("stock_image_url") and not data.get("stock_image_url"):
+                        data["stock_image_url"] = source_data["stock_image_url"]
             else:
                 # Original recipe: author = owner, no saver, no source.
                 author_id = user_id

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -685,3 +685,173 @@ def test_public_recipe_page_links_save_cta_to_spa_save_url(app, client):
     resp = client.get("/r/thai-peanut-noodles")
     body = resp.get_data(as_text=True)
     assert "/?save=thai-peanut-noodles#kitchen" in body
+
+
+# ---------------------------------------------------------------------------
+# KAN-215: saved-copy image fallback from source recipe
+# ---------------------------------------------------------------------------
+
+
+def test_saved_copy_inherits_source_ai_image_via_fallback(app, client):
+    """A published saved copy with no image of its own falls back to the
+    source recipe's AI image (via source_recipe_id) on /r/<slug>."""
+    with app.app_context():
+        source = _make_recipe(
+            "Original Curry",
+            "original-curry",
+            data={
+                "name": "Original Curry",
+                "description": "Has an AI image.",
+                "ai_image_gcs": "gs://bucket/curry/v1.png",
+            },
+        )
+        db.session.add(source)
+        db.session.flush()
+
+        copy = Recipe(
+            id=str(uuid.uuid4()),
+            name="Original Curry",
+            slug="my-original-curry-copy",
+            is_public=True,
+            source_slug="original-curry",
+            source_recipe_id=source.id,
+            data={"name": "Original Curry", "description": "Saved copy."},
+        )
+        db.session.add(copy)
+        db.session.commit()
+        source_id = source.id
+
+    resp = client.get("/r/my-original-curry-copy")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # The og:image and hero should use the source's image endpoint
+    expected_url = f"/api/recipes/{source_id}/image"
+    assert expected_url in body
+
+
+def test_saved_copy_inherits_source_stock_image_via_fallback(app, client):
+    """A published saved copy falls back to the source's stock_image_url."""
+    with app.app_context():
+        source = _make_recipe(
+            "Stock Photo Stew",
+            "stock-photo-stew",
+            data={
+                "name": "Stock Photo Stew",
+                "description": "Has a stock image.",
+                "stock_image_url": "https://img.example/stew.jpg",
+            },
+        )
+        db.session.add(source)
+        db.session.flush()
+
+        copy = Recipe(
+            id=str(uuid.uuid4()),
+            name="Stock Photo Stew",
+            slug="my-stock-stew-copy",
+            is_public=True,
+            source_slug="stock-photo-stew",
+            source_recipe_id=source.id,
+            data={"name": "Stock Photo Stew", "description": "Saved copy."},
+        )
+        db.session.add(copy)
+        db.session.commit()
+
+    resp = client.get("/r/my-stock-stew-copy")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "https://img.example/stew.jpg" in body
+
+
+def test_saved_copy_with_own_image_does_not_fall_back(app, client):
+    """A copy that already has its own image must use it, not the source's."""
+    with app.app_context():
+        source = _make_recipe(
+            "Source Dish",
+            "source-dish",
+            data={
+                "name": "Source Dish",
+                "description": "Source.",
+                "stock_image_url": "https://img.example/source.jpg",
+            },
+        )
+        db.session.add(source)
+        db.session.flush()
+
+        copy = Recipe(
+            id=str(uuid.uuid4()),
+            name="Source Dish",
+            slug="my-source-dish-copy",
+            is_public=True,
+            source_slug="source-dish",
+            source_recipe_id=source.id,
+            data={
+                "name": "Source Dish",
+                "description": "Copy with own image.",
+                "stock_image_url": "https://img.example/copy-own.jpg",
+            },
+        )
+        db.session.add(copy)
+        db.session.commit()
+
+    resp = client.get("/r/my-source-dish-copy")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "https://img.example/copy-own.jpg" in body
+    assert "https://img.example/source.jpg" not in body
+
+
+def test_saved_copy_falls_back_via_source_slug_when_no_fk(app, client):
+    """Legacy copies with source_slug but no source_recipe_id still resolve."""
+    with app.app_context():
+        source = _make_recipe(
+            "Legacy Source",
+            "legacy-source",
+            data={
+                "name": "Legacy Source",
+                "description": "Has image.",
+                "ai_image_gcs": "gs://bucket/legacy/v1.png",
+            },
+        )
+        db.session.add(source)
+        db.session.flush()
+
+        copy = Recipe(
+            id=str(uuid.uuid4()),
+            name="Legacy Source",
+            slug="legacy-copy",
+            is_public=True,
+            source_slug="legacy-source",
+            source_recipe_id=None,  # FK never backfilled
+            data={"name": "Legacy Source", "description": "Legacy copy."},
+        )
+        db.session.add(copy)
+        db.session.commit()
+        source_id = source.id
+
+    resp = client.get("/r/legacy-copy")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    expected_url = f"/api/recipes/{source_id}/image"
+    assert expected_url in body
+
+
+def test_saved_copy_no_fallback_when_source_deleted(app, client):
+    """When the source recipe is gone, the copy shows no image (not crash)."""
+    with app.app_context():
+        copy = Recipe(
+            id=str(uuid.uuid4()),
+            name="Orphaned Copy",
+            slug="orphaned-copy",
+            is_public=True,
+            source_slug="deleted-source",
+            source_recipe_id=None,  # source deleted, FK set NULL
+            data={"name": "Orphaned Copy", "description": "Source gone."},
+        )
+        db.session.add(copy)
+        db.session.commit()
+
+    resp = client.get("/r/orphaned-copy")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # No image shown, page still renders
+    assert "Orphaned Copy" in body

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -856,7 +856,7 @@ def test_saved_copy_no_fallback_when_source_deleted(app, client):
     # Page renders without crashing
     assert "Orphaned Copy" in body
     # No og:image emitted — the template omits it when image_url is None
-    assert 'og:image' not in body
+    assert "og:image" not in body
 
 
 def test_saved_copy_no_fallback_when_source_unpublished(app, client):

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -853,8 +853,10 @@ def test_saved_copy_no_fallback_when_source_deleted(app, client):
     resp = client.get("/r/orphaned-copy")
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
-    # No image shown, page still renders
+    # Page renders without crashing
     assert "Orphaned Copy" in body
+    # No og:image emitted — the template omits it when image_url is None
+    assert 'og:image' not in body
 
 
 def test_saved_copy_no_fallback_when_source_unpublished(app, client):

--- a/tests/test_public_ssr.py
+++ b/tests/test_public_ssr.py
@@ -855,3 +855,95 @@ def test_saved_copy_no_fallback_when_source_deleted(app, client):
     body = resp.get_data(as_text=True)
     # No image shown, page still renders
     assert "Orphaned Copy" in body
+
+
+def test_saved_copy_no_fallback_when_source_unpublished(app, client):
+    """A private source's image must NOT leak into a public copy's og:image.
+
+    If the source is unpublished after copies were made, _resolve_source_for_image
+    must return None — otherwise the copy's page emits a /api/recipes/<source>/image
+    URL that 404s for anonymous visitors (and leaks a stock_image_url for a
+    private recipe).
+    """
+    with app.app_context():
+        source = Recipe(
+            id=str(uuid.uuid4()),
+            name="Now-Private Source",
+            slug="now-private-source",
+            is_public=False,  # unpublished after the copy was saved
+            data={
+                "name": "Now-Private Source",
+                "description": "Was public, now private.",
+                "ai_image_gcs": "gs://bucket/private/img.png",
+                "stock_image_url": "https://img.example/private-stock.jpg",
+            },
+        )
+        db.session.add(source)
+        db.session.flush()
+
+        copy = Recipe(
+            id=str(uuid.uuid4()),
+            name="Now-Private Source",
+            slug="copy-of-now-private",
+            is_public=True,
+            source_slug="now-private-source",
+            source_recipe_id=source.id,  # FK resolves, but source is private
+            data={"name": "Now-Private Source", "description": "Copy."},
+        )
+        db.session.add(copy)
+        db.session.commit()
+        source_id = source.id
+
+    resp = client.get("/r/copy-of-now-private")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # The source's image endpoint must NOT appear
+    assert f"/api/recipes/{source_id}/image" not in body
+    # The source's stock_image_url must NOT leak either
+    assert "https://img.example/private-stock.jpg" not in body
+    # Page still renders the recipe content
+    assert "Now-Private Source" in body
+
+
+def test_save_flow_copies_stock_image_url_from_source(app):
+    """The repository's stage_new path copies stock_image_url from the source.
+
+    Exercises the save-time copy in db_recipe_repository.create_recipe rather
+    than just the read-time fallback. Per KAN-215: stock_image_url is safe to
+    copy (external URL, not deleted on regeneration) unlike ai_image_gcs.
+    """
+    from repositories import db_recipe_repository
+
+    with app.app_context():
+        # Create a public source with a stock image
+        source = Recipe(
+            id="src-stock-001",
+            name="Stock Source",
+            slug="stock-source",
+            is_public=True,
+            data={
+                "name": "Stock Source",
+                "description": "Has stock image.",
+                "stock_image_url": "https://img.example/stock-original.jpg",
+            },
+        )
+        db.session.add(source)
+        db.session.commit()
+
+        # Save a copy via the repository (the real save flow)
+        copy_data = {
+            "id": "copy-stock-001",
+            "name": "Stock Source",
+            "sourceSlug": "stock-source",
+        }
+        owner = User(email="saver@example.com", name="Saver")
+        db.session.add(owner)
+        db.session.commit()
+
+        recipe = db_recipe_repository.create_recipe(copy_data, user_id=owner.id)
+
+        assert recipe is not None
+        # The copy's data blob must now contain the source's stock_image_url
+        assert recipe.data.get("stock_image_url") == "https://img.example/stock-original.jpg"
+        # The source_recipe_id FK must be set
+        assert recipe.source_recipe_id == "src-stock-001"


### PR DESCRIPTION
## Summary

- Published saved copies at `/r/<slug>` showed a blank hero/og:image when the copy lacked its own `ai_image_gcs`/`ai_image_data`/`stock_image_url` in the data blob.
- **Read-time fallback**: `_recipe_image_url` now resolves the source recipe's image when the copy has none, using `source_recipe_id` (FK) with `source_slug` fallback for legacy copies.
- **Save-time copy**: `stage_new` now copies `stock_image_url` from the source into the copy's data blob at save time. AI image keys are NOT copied to avoid stale GCS pointers (the read-time fallback resolves those safely from the source's current state).

## Premise note

The Sprint 8 acceptance criteria (RCP-86) specify "backfill at publish time", but `_gate_is_public` unconditionally blocks publishing saved copies (RCP-74 / `SavedCopyPublishError`). A publish-time hook is unreachable code. The read-time fallback achieves the same observable outcome — no blank hero/og:image on any `/r/<slug>` page — for all published copies, including legacy ones that predate the guard. The publish guard is not touched.

## Test plan

- [x] `test_saved_copy_inherits_source_ai_image_via_fallback` — AI image resolved from source via `source_recipe_id`
- [x] `test_saved_copy_inherits_source_stock_image_via_fallback` — stock image resolved from source
- [x] `test_saved_copy_with_own_image_does_not_fall_back` — copy's own image takes precedence
- [x] `test_saved_copy_falls_back_via_source_slug_when_no_fk` — legacy copies without FK still resolve
- [x] `test_saved_copy_no_fallback_when_source_deleted` — graceful fallback when source is gone
- [x] Full Backend suite: 422 passed, 1 xfailed
- [x] Black, flake8, mypy clean
- [ ] Verify on staging: `/r/<slug>` for a saved copy shows the source's image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ls8g5a4bqcBgUzPMxSZ4ir












<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Out of Rovo Dev credits</strong>
You've used all your Rovo Dev credits, so Rovo Dev can't review your pull requests.
<!-- /Rovo Dev code review status -->

